### PR TITLE
Updated button classname to un-abbreviated version

### DIFF
--- a/objects/_button.scss
+++ b/objects/_button.scss
@@ -1,4 +1,4 @@
-.btn {
+.button {
   -webkit-appearance: none;
   background: $bitstyles-button-background-color;
   border: $bitstyles-button-border;
@@ -24,7 +24,7 @@
   }
 }
 
-.btn__label {
+.button__label {
   display: inline;
   position: relative;
   vertical-align: middle;


### PR DESCRIPTION
Fixes #6 

note: This branch has no `.btn__label` — merging this branch with that will mean we have to update that to `.button__label` to match nomenclature.
