### PR TITLE
Cleanup icon styles — adds missing, removes unnecessary/overly-visual.

### DIFF
--- a/objects/_icon.scss
+++ b/objects/_icon.scss
@@ -2,14 +2,9 @@
   display: inline-block;
   fill: currentColor;
   height: $bitstyles-icon-size;
+  max-height: 100%;
+  max-width: 100%;
   outline: none;
-  transition: fill $bitstyles-transition-duration $bitstyles-transition-easing, stroke $bitstyles-transition-duration $bitstyles-transition-easing, background-color $bitstyles-transition-duration $bitstyles-transition-easing, transform $bitstyles-transition-duration $bitstyles-transition-easing;
   vertical-align: middle;
   width: $bitstyles-icon-size;
-
-  // inherit hover colours of a containing button
-  .btn &:hover,
-  .btn &:focus {
-    fill: currentColor;
-  }
 }


### PR DESCRIPTION
Hover styles re-specifiying fill: currentColor are unnecessary as they’re specified in the base class. Removal also avoids the messy mixing of buttons & icons styles.
Also removes the transition, as most projects only need the icons to transition with an enclosing button — in which case the colours already transition using the property inherited from the button.

Fixes #9 
