### PR TITLE
check for settings files

### DIFF
--- a/stylesheets/bitstyles.scss
+++ b/stylesheets/bitstyles.scss
@@ -11,6 +11,7 @@
 
 // TOOLS
 // Site-wide mixins and functions.
+@import 'tools/build';
 @import 'tools/zindex';
 @import 'tools/rem-sizing';
 @import 'tools/absolute-cover';

--- a/stylesheets/objects/_button.scss
+++ b/stylesheets/objects/_button.scss
@@ -1,3 +1,8 @@
+$bitstyles-button-settings: false !default;
+@if ($bitstyles-button-settings == false) {
+  @include output-settings-warning(button);
+};
+
 .button {
   position: relative;
   display: inline-block;

--- a/stylesheets/objects/_icon.scss
+++ b/stylesheets/objects/_icon.scss
@@ -1,3 +1,8 @@
+$bitstyles-icon-settings: false !default;
+@if ($bitstyles-icon-settings == false) {
+  @include output-settings-warning(icon)
+};
+
 .icon {
   display: inline-block;
   width: $bitstyles-icon-size;

--- a/stylesheets/settings/_button.scss
+++ b/stylesheets/settings/_button.scss
@@ -1,3 +1,5 @@
+$bitstyles-button-settings: true;
+
 $bitstyles-button-padding-vertical: 0.6rem !default;
 $bitstyles-button-padding-horizontal: 1.5rem !default;
 

--- a/stylesheets/settings/_icon.scss
+++ b/stylesheets/settings/_icon.scss
@@ -1,1 +1,3 @@
+$bitstyles-icon-settings: true;
+
 $bitstyles-icon-size: 1rem !default;

--- a/stylesheets/tools/_build.scss
+++ b/stylesheets/tools/_build.scss
@@ -1,0 +1,3 @@
+@mixin output-settings-warning($settings-name) {
+  @warn 'Oops! Have you included a #{$settings-name} settings file?'
+}


### PR DESCRIPTION
Adds a flag to the setting files for objects (other settings files are too generic for this to make sense — this is a limited dependency check!), and a check in the respective object.

Fixes #26 
