### PR TITLE
button variations

### DIFF
--- a/objects/_button--icon.scss
+++ b/objects/_button--icon.scss
@@ -1,0 +1,19 @@
+// A specialised button type — (visible) content is intended to be only an icon.
+// Icon alt attribute should give valid text to use as button label,
+// or provide a `.visuallyhidden` text element as sibling to the icon.
+// <button class="button button--icon"><svg class="icon"><use xlink:href="icons-svg#twitter"></use></svg></button>
+//
+// Styleguide Icon Button
+
+$bitstyles-button-icon-settings: false !default;
+@if ($bitstyles-button-icon-settings == false) {
+  @include output-settings-warning(button--icon);
+};
+
+.button--icon {
+  padding: $bitstyles-button-icon-padding;
+  color: $bitstyles-button-icon-color;
+  background-color: $bitstyles-button-icon-background-color;
+  border: $bitstyles-button-icon-border;
+  border-radius: $bitstyles-button-icon-border-radius;
+}

--- a/settings/_button--icon.scss
+++ b/settings/_button--icon.scss
@@ -1,0 +1,7 @@
+$bitstyles-button-icon-settings: true;
+
+$bitstyles-button-icon-padding: 1rem !default;
+$bitstyles-button-icon-color: $bitstyles-color-white !default;
+$bitstyles-button-icon-background-color: $bitstyles-color-black !default;
+$bitstyles-button-icon-border: 0 !default;
+$bitstyles-button-icon-border-radius: $bitstyles-border-radius-round !default;

--- a/stylesheets/bitstyles.scss
+++ b/stylesheets/bitstyles.scss
@@ -8,6 +8,7 @@
 @import 'settings/typography';
 @import 'settings/icon';
 @import 'settings/button';
+@import 'settings/button--icon';
 @import 'settings/grid';
 
 // TOOLS
@@ -40,8 +41,9 @@
 // Objects, abstractions, and design patterns (e.g. .media {}). Cosmetic-free.
 @import 'objects/icon';
 @import 'objects/button';
+// @import 'objects/button--icon';
 // @import 'objects/grid';
 
 // TRUMPS
 // High-specificity, very explicit selectors. Overrides and helper classes (e.g. .hidden {}).
-@import 'trumps/typography';
+// @import 'trumps/typography';

--- a/stylesheets/settings/_global.scss
+++ b/stylesheets/settings/_global.scss
@@ -1,3 +1,5 @@
 // Namespacing
 // Defining a namespace will prepend it to every selector and variable name
 $bitstyles-namespace: null !default;
+
+$bitstyles-border-radius-round: 9999rem;


### PR DESCRIPTION
Adds button--icon, with settings. Note the setting-check warning will actually cause an error until #30 is merged.
Also comments out any imports in the manifest that result in css output — these now need to be un-commented to enable them, so the order & contents can be defined on a pre-project basis.

Fixes #13 
