### PR TITLE
Grid system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .sass-cache
 node_modules
-.DS_Store
 .npm
 npm-debug.log*

--- a/objects/_grid.scss
+++ b/objects/_grid.scss
@@ -1,0 +1,20 @@
+// Responsive grid, using inuit.css’s inline-block-based grid system
+// .layout
+//    .layout__item.u-2\/12
+//
+// Styleguide Grid
+
+$bitstyles-grid-settings: false !default;
+@if ($bitstyles-grid-settings == false) {
+  @include output-settings-warning(grid);
+};
+
+@import '../node_modules/inuit-defaults/settings.defaults';
+@import '../node_modules/inuit-responsive-settings/settings.responsive';
+
+@import '../node_modules/inuit-tools-widths/tools.widths';
+
+@import '../node_modules/inuit-layout/objects.layout';
+
+@import '../node_modules/inuit-widths/trumps.widths';
+@import '../node_modules/inuit-responsive-widths/trumps.widths-responsive';

--- a/package.json
+++ b/package.json
@@ -25,5 +25,10 @@
     "gulp": "^3.9.1",
     "gulp-sass": "^2.2.0",
     "gulp-scss-lint": "^0.3.9"
+  },
+  "dependencies": {
+    "inuit-layout": "^0.2.2",
+    "inuit-responsive-widths": "^0.2.2",
+    "inuit-widths": "^0.4.2"
   }
 }

--- a/settings/_grid.scss
+++ b/settings/_grid.scss
@@ -1,0 +1,11 @@
+$bitstyles-grid-settings: true;
+
+$inuit-layout-namespace: $bitstyles-namespace !default;
+$inuit-layout-gutter: 0 !default;
+$inuit-enable-layout--bottom: false !default;
+
+// These column variables can be lists — (10, 12) will give multiple grid systems: every permutation of 10 columns
+// (1/10, 2/10, 3/10… 9/10, 10/10) and 12 columns (1/12, 2/12, 3/12… 11/12, 12/12).
+// We normally only need one grid system (i.e. one set of columns).
+$inuit-widths-columns: (12) !default;
+$inuit-widths-columns-responsive: (12) !default;

--- a/stylesheets/bitstyles.scss
+++ b/stylesheets/bitstyles.scss
@@ -8,6 +8,7 @@
 @import 'settings/typography';
 @import 'settings/icon';
 @import 'settings/button';
+@import 'settings/grid';
 
 // TOOLS
 // Site-wide mixins and functions.
@@ -39,6 +40,7 @@
 // Objects, abstractions, and design patterns (e.g. .media {}). Cosmetic-free.
 @import 'objects/icon';
 @import 'objects/button';
+@import 'objects/grid';
 
 // TRUMPS
 // High-specificity, very explicit selectors. Overrides and helper classes (e.g. .hidden {}).


### PR DESCRIPTION
Adds the inuit.css responsive grid system.

Reasoning:
Susy, tachyons etc. while they’re also lightweight, use a float system. They both also require multiple file imports (or wholesale buy-in to their framework), so no complexity is saved.
Flexbox seems to have performance issues when used for whole-page layout; also feels as much a hack as using floats for layout.

From the bitstyles-consumer POV, the grid is like every other object — include a settings file & include the object css. The mass of imports is hidden away in the object file. We’ve never used `.layout` or `.layout__item` without also using widths, so it makes sense to package them all together.

Fixes #27 
