### PR TITLE
add missing objects

### DIFF
--- a/stylesheets/bitstyles.scss
+++ b/stylesheets/bitstyles.scss
@@ -9,6 +9,8 @@
 @import 'settings/icon';
 @import 'settings/button';
 @import 'settings/grid';
+@import 'settings/hidden';
+@import 'settings/visuallyhidden';
 
 // TOOLS
 // Site-wide mixins and functions.
@@ -41,6 +43,15 @@
 @import 'objects/icon';
 @import 'objects/button';
 // @import 'objects/grid';
+// @import 'objects/absolute-center';
+// @import 'objects/absolute-cover';
+// @import 'objects/break-long-words';
+// @import 'objects/clearfix';
+// @import 'objects/fixed-ratio';
+// @import 'objects/hidden';
+// @import 'objects/truncate-with-ellipsis';
+// @import 'objects/vertical-center';
+// @import 'objects/visuallyhidden';
 
 // TRUMPS
 // High-specificity, very explicit selectors. Overrides and helper classes (e.g. .hidden {}).

--- a/stylesheets/objects/_absolute-center.scss
+++ b/stylesheets/objects/_absolute-center.scss
@@ -1,0 +1,3 @@
+.absolute-center {
+  @include absolute-center;
+}

--- a/stylesheets/objects/_absolute-cover.scss
+++ b/stylesheets/objects/_absolute-cover.scss
@@ -1,0 +1,3 @@
+.absolute-cover {
+  @include absolute-cover;
+}

--- a/stylesheets/objects/_break-long-words.scss
+++ b/stylesheets/objects/_break-long-words.scss
@@ -1,0 +1,3 @@
+.break-long-words {
+  @include break-long-words;
+}

--- a/stylesheets/objects/_clearfix.scss
+++ b/stylesheets/objects/_clearfix.scss
@@ -1,0 +1,3 @@
+.clearfix {
+  @include clearfix;
+}

--- a/stylesheets/objects/_fixed-ratio.scss
+++ b/stylesheets/objects/_fixed-ratio.scss
@@ -1,0 +1,9 @@
+// scss-lint:disable NameFormat
+
+.fixed-ratio {
+  @include fixed-ratio;
+}
+
+.fixed-ratio__inner {
+  @include fixed-ratio__inner;
+}

--- a/stylesheets/objects/_hidden.scss
+++ b/stylesheets/objects/_hidden.scss
@@ -1,0 +1,16 @@
+$bitstyles-hidden-settings: false !default;
+@if ($bitstyles-hidden-settings == false) {
+  @include output-settings-warning(hidden);
+}
+
+.hidden {
+  @include hidden;
+}
+
+@each $breakpoint in $hidden-breakpoints {
+  @include media-query($breakpoint) {
+    .hidden\@#{$breakpoint} {
+      @include hidden;
+    }
+  }
+}

--- a/stylesheets/objects/_truncate-with-ellipsis.scss
+++ b/stylesheets/objects/_truncate-with-ellipsis.scss
@@ -1,0 +1,3 @@
+.truncate-with-ellipsis {
+  @include truncate-with-ellipsis;
+}

--- a/stylesheets/objects/_vertical-center.scss
+++ b/stylesheets/objects/_vertical-center.scss
@@ -1,0 +1,3 @@
+.vertical-center {
+  @include vertical-center;
+}

--- a/stylesheets/objects/_visuallyhidden.scss
+++ b/stylesheets/objects/_visuallyhidden.scss
@@ -1,0 +1,16 @@
+$bitstyles-visuallyhidden-settings: false !default;
+@if ($bitstyles-visuallyhidden-settings == false) {
+  @include output-settings-warning(visuallyhidden);
+}
+
+.visuallyhidden {
+  @include visuallyhidden;
+}
+
+@each $breakpoint in $visuallyhidden-breakpoints {
+  @include media-query($breakpoint) {
+    .visuallyhidden\@#{$breakpoint} {
+      @include visuallyhidden;
+    }
+  }
+}

--- a/stylesheets/settings/_hidden.scss
+++ b/stylesheets/settings/_hidden.scss
@@ -1,0 +1,3 @@
+$bitstyles-hidden-settings: true;
+
+$hidden-breakpoints: () !default;

--- a/stylesheets/settings/_visuallyhidden.scss
+++ b/stylesheets/settings/_visuallyhidden.scss
@@ -1,0 +1,3 @@
+$bitstyles-visuallyhidden-settings: true;
+
+$visuallyhidden-breakpoints: () !default;

--- a/stylesheets/tools/_media-query.scss
+++ b/stylesheets/tools/_media-query.scss
@@ -6,7 +6,7 @@
 //    }
 // }
 
-@mixin media-query($mq) {
+@mixin media-query($mq, $breakpoints: $bitstyles-breakpoints) {
   $breakpoint-found: false;
 
   @each $breakpoint in $breakpoints {


### PR DESCRIPTION
Items in `tools/mixins` are now aslo implemented as objects:
- `.hidden` & `.visuallyhidden` have responsive variations if the framework consumer specifies which breakpoints they need.
- Updated the media-query mixin to enable us to pass in lists of breakpoints (instead of being limited to one as currently — everything is output at every breakpoint even if we dont need it).

Note there are no comments yet — there’s a PR adding comments to the mixins, if that’s merged I’ll look into how best to handle comments on objects & their mixins, avoiding duplication, being accessible to KSS etc.

Fixes #32 
