### PR TITLE
[#86] Media query mixin not in styleguide

### DIFF
--- a/stylesheets/tools/_media-query.scss
+++ b/stylesheets/tools/_media-query.scss
@@ -1,12 +1,17 @@
 // Media Query
 //
 // Helper function to ease usage of media-queries. Uses the breakpoints listed in $breakpoint sass variable.
+//
 // Usage:
+// 
+// `
 // @media-query(breakpoint-name) {
 //    .selector {
 //       …styles here…
 //    }
 // }
+// `
+//
 // Styleguide 2.11
 
 @mixin media-query($mq, $breakpoints: $bitstyles-breakpoints) {


### PR DESCRIPTION
Fixes #86.
- Was simply missing a space before "Styleguide".
- Added some backticks to format the example better. Would use a proper fence block but discovered an SC5 bug during this PR: https://github.com/SC5/sc5-styleguide/issues/970
