### PR TITLE
[#94] Implement Inuit Grids directly in project

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,6 @@
     "stylelint-config-standard": "^6.0.0"
   },
   "dependencies": {
-    "inuit-layout": "^0.2.2",
-    "inuit-responsive-widths": "^0.2.2",
-    "inuit-widths": "^0.4.2",
     "normalize.css": "^4.0.0"
   }
 }

--- a/stylesheets/objects/_grid.scss
+++ b/stylesheets/objects/_grid.scss
@@ -58,13 +58,36 @@ $bitstyles-grid-settings: false !default;
   @include output-settings-warning(grid);
 }
 
-@import '../node_modules/inuit-defaults/settings.defaults';
-@import '../node_modules/inuit-defaults/settings.defaults';
-@import '../node_modules/inuit-responsive-settings/settings.responsive';
-@import '../node_modules/inuit-tools-widths/tools.widths';
-@import '../node_modules/inuit-layout/objects.layout';
-@import '../node_modules/inuit-widths/trumps.widths';
-@import '../node_modules/inuit-responsive-widths/trumps.widths-responsive';
+/* stylelint-disable comment-whitespace-inside */
+
+/*!
+ * inuitcss, by @csswizardry
+ *
+ * github.com/inuitcss | inuitcss.com
+ *
+ * Copyright 2014 Harry Roberts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* stylelint-enable  */
+
+@import 'settings/inuit-defaults';
+@import 'settings/inuit-responsive';
+@import 'tools/inuit-widths';
+@import 'objects/inuit-layout';
+@import 'trumps/inuit-widths';
+@import 'trumps/inuit-widths-responsive';
 
 // Ignore the whole thing for now — there’s nothing here to look at directly.
 // styleguide:ignore:end

--- a/stylesheets/objects/_inuit-layout.scss
+++ b/stylesheets/objects/_inuit-layout.scss
@@ -1,0 +1,259 @@
+/*
+ * inuitcss, by @csswizardry
+ *
+ * github.com/inuitcss | inuitcss.com
+ *
+ * Copyright 2014 Harry Roberts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ------------------------------------*\
+    #LAYOUT
+\*------------------------------------ */
+
+/**
+ * The inuitcss layout system uses `box-sizing: border-box;` and
+ * `display: inline-block;` to create an extremely powerful, flexible
+ * alternative to the traditional grid system. Combine the layout items with
+ * the widths found in `trumps.widths`.
+ */
+
+// Predefine the variables below in order to alter and enable specific features.
+$inuit-layout-namespace:        $inuit-namespace !default;
+$inuit-layout-gutter:           $inuit-base-spacing-unit !default;
+$inuit-layout-gutter--tiny:       quarter($inuit-layout-gutter) !default;
+$inuit-layout-gutter--small:        halve($inuit-layout-gutter) !default;
+$inuit-layout-gutter--large:       double($inuit-layout-gutter) !default;
+$inuit-layout-gutter--huge:     quadruple($inuit-layout-gutter) !default;
+$inuit-enable-layout--tiny:     false !default;
+$inuit-enable-layout--small:    false !default;
+$inuit-enable-layout--large:    false !default;
+$inuit-enable-layout--huge:     false !default;
+$inuit-enable-layout--flush:    false !default;
+$inuit-enable-layout--rev:      false !default;
+$inuit-enable-layout--middle:   false !default;
+$inuit-enable-layout--bottom:   false !default;
+$inuit-enable-layout--right:    false !default;
+$inuit-enable-layout--center:   false !default;
+$inuit-enable-layout--auto:     false !default;
+
+// Here we set a variable assuming that `box-sizing: border-box;` is not set
+// globally. If it has been previously been defined, the following variable will
+// be overriden and will be set to `true`.
+$inuit-global-border-box: false !default;
+
+/**
+ * Begin a layout group.
+ */
+.#{$inuit-layout-namespace}layout,
+%#{$inuit-layout-namespace}layout {
+  padding: 0;
+  margin: 0;
+  margin-left: -$inuit-layout-gutter;
+  list-style: none;
+}
+
+/**
+ * 1. Cause columns to stack side-by-side.
+ * 2. Space columns apart.
+ * 3. Align columns to the tops of each other.
+ * 4. Full-width unless told to behave otherwise.
+ * 5. Required to combine fluid widths and fixed gutters.
+ */
+.#{$inuit-layout-namespace}layout__item,
+%#{$inuit-layout-namespace}layout__item {
+  display: inline-block; /* [1] */
+  width: 100%; /* [4] */
+  padding-left: $inuit-layout-gutter; /* [2] */
+  vertical-align: top; /* [3] */
+
+  @if $inuit-global-border-box == false {
+    box-sizing: border-box; /* [5] */
+  }
+}
+
+@if ($inuit-enable-layout--tiny == true) {
+  /**
+   * Layouts with tiny gutters.
+   */
+
+  .#{$inuit-layout-namespace}layout--tiny,
+  %#{$inuit-layout-namespace}layout--tiny {
+    margin-left: -($inuit-layout-gutter--tiny);
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      padding-left: $inuit-layout-gutter--tiny;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--small == true) {
+  /**
+   * Layouts with small gutters.
+   */
+
+  .#{$inuit-layout-namespace}layout--small,
+  %#{$inuit-layout-namespace}layout--small {
+    margin-left: -($inuit-layout-gutter--small);
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      padding-left: $inuit-layout-gutter--small;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--large == true) {
+  /**
+   * Layouts with large gutters.
+   */
+
+  .#{$inuit-layout-namespace}layout--large,
+  %#{$inuit-layout-namespace}layout--large {
+    margin-left: -($inuit-layout-gutter--large);
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      padding-left: $inuit-layout-gutter--large;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--huge == true) {
+  /**
+   * Layouts with huge gutters.
+   */
+
+  .#{$inuit-layout-namespace}layout--huge,
+  %#{$inuit-layout-namespace}layout--huge {
+    margin-left: -($inuit-layout-gutter--huge);
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      padding-left: $inuit-layout-gutter--huge;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--flush == true) {
+  /**
+   * Layouts with no gutters.
+   */
+
+  .#{$inuit-layout-namespace}layout--flush,
+  %#{$inuit-layout-namespace}layout--flush {
+    margin-left: 0;
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      padding-left: 0;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--rev == true) {
+  /**
+   * Reversed rendered order of layout items, e.g. items 1, 2, 3, 4 in your
+   * markup will display in order 4, 3, 2, 1 on your page.
+   */
+
+  .#{$inuit-layout-namespace}layout--rev,
+  %#{$inuit-layout-namespace}layout--rev {
+    text-align: left;
+    direction: rtl;
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      text-align: left;
+      direction: ltr;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--middle == true) {
+  /**
+   * Align layout items to the vertical centers of each other.
+   */
+
+  .#{$inuit-layout-namespace}layout--middle,
+  %#{$inuit-layout-namespace}layout--middle {
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      vertical-align: middle;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--bottom == true) {
+  /**
+   * Align layout items to the vertical bottoms of each other.
+   */
+
+  .#{$inuit-layout-namespace}layout--bottom,
+  %#{$inuit-layout-namespace}layout--bottom {
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      vertical-align: bottom;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--right == true) {
+  /**
+   * Make the layout items fill up from the right hand side.
+   */
+
+  .#{$inuit-layout-namespace}layout--right,
+  %#{$inuit-layout-namespace}layout--right {
+    text-align: right;
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      text-align: left;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--center == true) {
+  /**
+   * Make the layout items fill up from the center outward.
+   */
+
+  .#{$inuit-layout-namespace}layout--center,
+  %#{$inuit-layout-namespace}layout--center {
+    text-align: center;
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      text-align: left;
+    }
+  }
+}
+
+@if ($inuit-enable-layout--auto == true) {
+  /**
+   * Cause layout items to take up a non-explicit amount of width.
+   */
+  .#{$inuit-layout-namespace}layout--auto,
+  %#{$inuit-layout-namespace}layout--auto {
+
+    > .#{$inuit-layout-namespace}layout__item,
+    > %#{$inuit-layout-namespace}layout__item {
+      width: auto;
+    }
+  }
+}

--- a/stylesheets/settings/_inuit-defaults.scss
+++ b/stylesheets/settings/_inuit-defaults.scss
@@ -1,0 +1,47 @@
+/*
+ * inuitcss, by @csswizardry
+ *
+ * github.com/inuitcss | inuitcss.com
+ *
+ * Copyright 2014 Harry Roberts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+///*------------------------------------*\
+//    #DEFAULTS
+//\*------------------------------------*/
+
+// These variables are inuitcss’ defaults; they should not be modified or
+// adjusted directly; you should predefine the variables in your own project.
+
+// High-level base settings.
+$inuit-base-font-size:          16px !default;
+$inuit-base-line-height:        24px !default;
+$inuit-base-text-color:         #333 !default;
+$inuit-base-background-color:   #fff !default;
+
+// Namespace.
+//
+// Would you like inuitcss’ classes to be prepended with a namespace? If so,
+// define it here.
+$inuit-namespace:               null !default;
+
+// These variables are framework variables, sourced from variables defined
+// above. Feel free to use these variables throughout your project, but do not
+// modify or reassign them.
+$inuit-base-spacing-unit:           $inuit-base-line-height;
+$inuit-base-spacing-unit--tiny:     round($inuit-base-spacing-unit / 4);
+$inuit-base-spacing-unit--small:    round($inuit-base-spacing-unit / 2);
+$inuit-base-spacing-unit--large:    round($inuit-base-spacing-unit * 2);
+$inuit-base-spacing-unit--huge:     round($inuit-base-spacing-unit * 4);

--- a/stylesheets/settings/_inuit-responsive.scss
+++ b/stylesheets/settings/_inuit-responsive.scss
@@ -1,0 +1,41 @@
+/*
+ * inuitcss, by @csswizardry
+ *
+ * github.com/inuitcss | inuitcss.com
+ *
+ * Copyright 2014 Harry Roberts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+///*------------------------------------*\
+//    #SETTINGS-RESPONSIVE
+//\*------------------------------------*/
+
+// Hold our breakpoint aliases and conditions in a list.
+//
+// These can be invoked later on via the `media-query()` mixin found in
+// `_tools.responsive`.
+
+$breakpoints: (
+    "palm"          "screen and (max-width: 44.9375em)",
+    "lap"           "screen and (min-width: 45em) and (max-width: 63.9375em)",
+    "lap-and-up"    "screen and (min-width: 45em)",
+    "portable"      "screen and (max-width: 63.9375em)",
+    "desk"          "screen and (min-width: 64em)",
+    "retina"        "(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)"
+) !default;
+
+// If we have included this file, set a variable to tell the rest of the
+// framework that we have some responsive settings.
+$inuit-responsive-settings: true;

--- a/stylesheets/tools/_inuit-widths.scss
+++ b/stylesheets/tools/_inuit-widths.scss
@@ -1,0 +1,70 @@
+/*
+ * inuitcss, by @csswizardry
+ *
+ * github.com/inuitcss | inuitcss.com
+ *
+ * Copyright 2014 Harry Roberts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+///*------------------------------------*\
+//    #WIDTHS
+//\*------------------------------------*/
+
+// A mixin to spit out our width classes. Pass in the columns we want the widths
+// to have, and an optional suffix for responsive widths. E.g. to create thirds
+// and quarters for a small breakpoint:
+//
+// @include inuit-widths(3 4, -sm);
+
+// Predefine the variables below in order to alter and enable specific features.
+$inuit-widths-namespace: $inuit-namespace !default;
+
+// Do we want to use classes like `<div class="u-1/4">` instead of
+// `<div class="u-1-of-4">`?
+$inuit-use-fractions: true !default;
+
+// Depending on what we chose for `$inuit-use-fractions`, create the relevant
+// delimiter.
+@if ($inuit-use-fractions == true) {
+  $inuit-widths-delimiter: \/ !global;
+}
+
+@else {
+  $inuit-widths-delimiter: -of- !global;
+}
+
+@mixin inuit-widths($inuit-widths-columns, $inuit-widths-breakpoint: null) {
+  // Loop through the number of columns for each denominator of our fractions.
+  @each $inuit-widths-denominator in $inuit-widths-columns {
+    // If we’re trying to make wholes, just spit a 100% width utility out
+    // one time only.
+    @if ($inuit-widths-denominator == 1) {
+      .#{$inuit-widths-namespace}u-1#{$inuit-widths-delimiter}1#{$inuit-widths-breakpoint} {
+        width: 100% !important; // stylelint-disable-line declaration-no-important
+      }
+    }
+
+    @else {
+      // Begin creating a numberator for our fraction up until we hit the
+      // denominator.
+      @for $inuit-widths-numerator from 1 to $inuit-widths-denominator {
+        // Build a class in the format `.u-3/4` or `.u-3-of-4`.
+        .#{$inuit-widths-namespace}u-#{$inuit-widths-numerator}#{$inuit-widths-delimiter}#{$inuit-widths-denominator}#{$inuit-widths-breakpoint} { // stylelint-disable-line max-nesting-depth
+          width: ($inuit-widths-numerator / $inuit-widths-denominator) * 100% !important; // stylelint-disable-line declaration-no-important
+        }
+      }
+    }
+  }
+}

--- a/stylesheets/trumps/_inuit-widths-responsive.scss
+++ b/stylesheets/trumps/_inuit-widths-responsive.scss
@@ -1,0 +1,51 @@
+/*
+ * inuitcss, by @csswizardry
+ *
+ * github.com/inuitcss | inuitcss.com
+ *
+ * Copyright 2014 Harry Roberts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ------------------------------------*\
+    #WIDTHS-RESPONSIVE
+\*------------------------------------ */
+
+/**
+ * Responsive width classes based on your responsive settings.
+ */
+
+// By default we will create wholes, halves, thirds, quarters, and fifths.
+// Predefine this Map to override.
+$inuit-widths-columns-responsive: (
+    1,
+    2,
+    3,
+    4,
+    5,
+) !default;
+
+// Loop over our breakpoints defined in _settings.responsive.scss
+@each $breakpoint in $breakpoints {
+  // Get the name of the breakpoint.
+  $alias: nth($breakpoint, 1);
+
+  @include media-query($alias) {
+    // Loop through each of our column sizes and generate its responsive width
+    // classes.
+    @each $inuit-widths-column in $inuit-widths-columns-responsive {
+      @include inuit-widths($inuit-widths-column, -#{$alias});
+    }
+  }
+}

--- a/stylesheets/trumps/_inuit-widths.scss
+++ b/stylesheets/trumps/_inuit-widths.scss
@@ -1,0 +1,43 @@
+/*
+ * inuitcss, by @csswizardry
+ *
+ * github.com/inuitcss | inuitcss.com
+ *
+ * Copyright 2014 Harry Roberts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ------------------------------------*\
+    #WIDTHS
+\*------------------------------------ */
+
+/**
+ * A series of width helper classes that you can use to size things like grid
+ * systems. Classes can take a fraction-like format (e.g. `.u-2/3`) or a spoken-
+ * word format (e.g. `.u-2-of-3`). Use these in your markup:
+ *
+ * <div class="u-7/12">
+ */
+
+// By default we will create wholes, halves, thirds, quarters, and fifths.
+// Predefine this Map to override.
+$inuit-widths-columns: (
+    1,
+    2,
+    3,
+    4,
+    5,
+) !default;
+
+@include inuit-widths($inuit-widths-columns);


### PR DESCRIPTION
- Removes the inuit npm packages, replaces them with copied-in versions.
- License & copyright notice included only once in output css, but present in each sass partial

Fixes #94 

**Note**
I’ve left the import statements for the inuit files in the `objects/_grid.scss` as there are several of them, and it’s not clear that they are dependencies of the grid object. This breaks the ITCSS-ish ordering we use :(

We could combine these files and rename them to something that makes clear their relation to the grid object (would mean stating which changes we made, according to the license?) or if we later implement a more fail-safe system/convention of enabling objects including their settings (as discussed yesterday).

For now I left this aspect of the PR as-is, and made only the changes requested in the issue #94.
