### PR TITLE
[#110] Font-face mixin

### DIFF
--- a/stylesheets/bitstyles.scss
+++ b/stylesheets/bitstyles.scss
@@ -45,6 +45,7 @@
 @import 'tools/hidden';
 @import 'tools/visuallyhidden';
 @import 'tools/list-reset';
+@import 'tools/font-face';
 //
 // ******** Add project-specific tools here ********
 //

--- a/stylesheets/generic/_normalize.scss
+++ b/stylesheets/generic/_normalize.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable */
 /*! normalize.css v4.1.1 | MIT License | github.com/necolas/normalize.css */
 
 /**
@@ -417,3 +418,4 @@ textarea {
   -webkit-appearance: button; /* 1 */
   font: inherit; /* 2 */
 }
+/* stylelint-enable */

--- a/stylesheets/tools/_font-face.scss
+++ b/stylesheets/tools/_font-face.scss
@@ -1,0 +1,21 @@
+// Webfont
+//
+// Helper mixin to output a widely cross-browser-compatible `@font-face` declaration.
+//
+// ```@include webfont(Roboto, italic, 700, 'fonts/roboto-bold-italic');```
+//
+// Styleguide 2.14
+
+@mixin webfont($font-family, $font-style, $font-weight, $font-url) {
+  @font-face {
+    font-family: $font-family;
+    font-style: $font-style;
+    font-weight: $font-weight;
+    src: font-url('#{$font-url}.eot');
+    src:
+      font-url('#{$font-url}.eot?#iefix') format('embedded-opentype'),
+      font-url('#{$font-url}.woff2') format('woff2'),
+      font-url('#{$font-url}.woff') format('woff'),
+      font-url('#{$font-url}.ttf') format('truetype');
+  }
+}


### PR DESCRIPTION
Adds a mixin to output widely browser-compatible `@font-face` declaration (works all the way back to IE6, but not the earliest versions of iOS).

Fixes #110 
