### PR TITLE
Warnings: number-zero-length-no-unit deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postcss-reporter": "^1.3.3",
     "postcss-scss": "^0.1.7",
     "sc5-styleguide": "^0.3.45",
-    "stylelint": "^6.5.1",
-    "stylelint-config-standard": "^6.0.0"
+    "stylelint": "^7.0.1",
+    "stylelint-config-standard": "^11.0.0"
   }
 }

--- a/stylesheets/objects/_expander.scss
+++ b/stylesheets/objects/_expander.scss
@@ -21,7 +21,7 @@
 
   &.is-active {
     .icon {
-      transform: rotate(0deg); /* stylelint-disable-line number-zero-length-no-unit */
+      transform: rotate(0deg); /* stylelint-disable-line length-zero-no-unit */
     }
   }
 }


### PR DESCRIPTION
Fixes warnings that were emerging from an older `stylelint-config-package`.

Fixes #113.
