### PR TITLE
[#98] stylelint extra linting rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -9,6 +9,10 @@
     "max-nesting-depth": 2,
     "declaration-no-important": true,
     "selector-no-id": true,
+    "declaration-block-no-duplicate-properties": true,
+    "no-unknown-animations": true,
+    "selector-no-type": true,
+    "no-descending-specificity": true,
     "declaration-block-properties-order": [
       "position",
       "top",

--- a/stylesheets/base/_images.scss
+++ b/stylesheets/base/_images.scss
@@ -5,7 +5,9 @@
 //
 // Styleguide 4.11
 
+/* stylelint-disable selector-no-type */
 img {
   height: auto;
   max-width: 100%;
 }
+/* stylelint-enable selector-no-type */

--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -6,6 +6,8 @@ $bitstyles-typography-settings: false !default;
 }
 // styleguide:ignore:end
 
+/* stylelint-disable selector-no-type */
+
 html {
   font-family: $bitstyles-font-family-body;
   font-size: $bitstyles-font-size-base-small;
@@ -385,3 +387,5 @@ dt {
 // </table>
 //
 // Styleguide 4.10
+
+/* stylelint-enable selector-no-type */

--- a/stylesheets/generic/_box-sizing.scss
+++ b/stylesheets/generic/_box-sizing.scss
@@ -3,6 +3,7 @@
 //
 // No styleguide reference.
 
+/* stylelint-disable selector-no-type */
 html {
   box-sizing: $bitstyles-box-sizing;
 }
@@ -12,3 +13,4 @@ html {
 *::after {
   box-sizing: inherit;
 }
+/* stylelint-enable selector-no-type */


### PR DESCRIPTION
More linting. Checks for:
- duplicate declarations `a {color: #fff; color: #fff}`
- unknown animations: every `animation-name` should refer to known animation definition
- selector-no-type: no tagnames
- no-descending-specificity: overrides should come after the thing they’re overriding: `.container a {} a {}` fails, `a {} .container a{}` is fine (should never do that of course! this checks a bunch more cases)

Fixes #98 
