### PR TITLE
[#117] typographic units

### DIFF
--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -10,7 +10,7 @@ $bitstyles-typography-settings: false !default;
 
 html {
   font-family: $bitstyles-font-family-body;
-  font-size: $bitstyles-font-size-base-small;
+  font-size: px-to-em($bitstyles-font-size-base-small);
   line-height: 1.5;
 
   .fonts-loaded & {
@@ -42,56 +42,56 @@ h6 {
 }
 
 h1 {
-  font-size: $bitstyles-font-size-h1-small;
+  @include font-size($bitstyles-font-size-h1-small);
 }
 
 h2 {
-  font-size: $bitstyles-font-size-h2-small;
+  @include font-size($bitstyles-font-size-h2-small);
 }
 
 h3 {
-  font-size: $bitstyles-font-size-h3-small;
+  @include font-size($bitstyles-font-size-h3-small);
 }
 
 h4 {
-  font-size: $bitstyles-font-size-h4-small;
+  @include font-size($bitstyles-font-size-h4-small);
 }
 
 h5 {
-  font-size: $bitstyles-font-size-h5-small;
+  @include font-size($bitstyles-font-size-h5-small);
 }
 
 h6 {
-  font-size: $bitstyles-font-size-h6-small;
+  @include font-size($bitstyles-font-size-h6-small);
 }
 
 @include media-query($bitstyles-typography-breakpoint) {
   html {
-    font-size: $bitstyles-font-size-base;
+    font-size: px-to-em($bitstyles-font-size-base);
   }
 
   h1 {
-    font-size: $bitstyles-font-size-h1;
+    @include font-size($bitstyles-font-size-h1, $bitstyles-font-size-base);
   }
 
   h2 {
-    font-size: $bitstyles-font-size-h2;
+    @include font-size($bitstyles-font-size-h2, $bitstyles-font-size-base);
   }
 
   h3 {
-    font-size: $bitstyles-font-size-h3;
+    @include font-size($bitstyles-font-size-h3, $bitstyles-font-size-base);
   }
 
   h4 {
-    font-size: $bitstyles-font-size-h4;
+    @include font-size($bitstyles-font-size-h4, $bitstyles-font-size-base);
   }
 
   h5 {
-    font-size: $bitstyles-font-size-h5;
+    @include font-size($bitstyles-font-size-h5, $bitstyles-font-size-base);
   }
 
   h6 {
-    font-size: $bitstyles-font-size-h6;
+    @include font-size($bitstyles-font-size-h6, $bitstyles-font-size-base);
   }
 }
 

--- a/stylesheets/bitstyles.scss
+++ b/stylesheets/bitstyles.scss
@@ -47,6 +47,7 @@
 @import 'tools/font-face';
 @import 'tools/grid-column-generator';
 @import 'tools/typography';
+@import 'tools/typography-conversions';
 //
 // ******** Add project-specific tools here ********
 //

--- a/stylesheets/objects/_typography.scss
+++ b/stylesheets/objects/_typography.scss
@@ -42,59 +42,59 @@ $bitstyles-typography-settings: false !default;
 }
 
 .#{$bitstyles-namespace}o-h0 {
-  font-size: $bitstyles-font-size-h0-small;
+  @include font-size($bitstyles-font-size-h0-small);
 }
 
 .#{$bitstyles-namespace}o-h1 {
-  font-size: $bitstyles-font-size-h1-small;
+  @include font-size($bitstyles-font-size-h1-small);
 }
 
 .#{$bitstyles-namespace}o-h2 {
-  font-size: $bitstyles-font-size-h2-small;
+  @include font-size($bitstyles-font-size-h2-small);
 }
 
 .#{$bitstyles-namespace}o-h3 {
-  font-size: $bitstyles-font-size-h3-small;
+  @include font-size($bitstyles-font-size-h3-small);
 }
 
 .#{$bitstyles-namespace}o-h4 {
-  font-size: $bitstyles-font-size-h4-small;
+  @include font-size($bitstyles-font-size-h4-small);
 }
 
 .#{$bitstyles-namespace}o-h5 {
-  font-size: $bitstyles-font-size-h5-small;
+  @include font-size($bitstyles-font-size-h5-small);
 }
 
 .#{$bitstyles-namespace}o-h6 {
-  font-size: $bitstyles-font-size-h6-small;
+  @include font-size($bitstyles-font-size-h6-small);
 }
 
 @include media-query($bitstyles-typography-breakpoint) {
   .#{$bitstyles-namespace}o-h0 {
-    font-size: $bitstyles-font-size-h0;
+    @include font-size($bitstyles-font-size-h0, $bitstyles-font-size-base);
   }
 
   .#{$bitstyles-namespace}o-h1 {
-    font-size: $bitstyles-font-size-h1;
+    @include font-size($bitstyles-font-size-h1, $bitstyles-font-size-base);
   }
 
   .#{$bitstyles-namespace}o-h2 {
-    font-size: $bitstyles-font-size-h2;
+    @include font-size($bitstyles-font-size-h2, $bitstyles-font-size-base);
   }
 
   .#{$bitstyles-namespace}o-h3 {
-    font-size: $bitstyles-font-size-h3;
+    @include font-size($bitstyles-font-size-h3, $bitstyles-font-size-base);
   }
 
   .#{$bitstyles-namespace}o-h4 {
-    font-size: $bitstyles-font-size-h4;
+    @include font-size($bitstyles-font-size-h4, $bitstyles-font-size-base);
   }
 
   .#{$bitstyles-namespace}o-h5 {
-    font-size: $bitstyles-font-size-h5;
+    @include font-size($bitstyles-font-size-h5, $bitstyles-font-size-base);
   }
 
   .#{$bitstyles-namespace}o-h6 {
-    font-size: $bitstyles-font-size-h6;
+    @include font-size($bitstyles-font-size-h6, $bitstyles-font-size-base);
   }
 }

--- a/stylesheets/settings/_layout.scss
+++ b/stylesheets/settings/_layout.scss
@@ -1,7 +1,7 @@
 // Box sizing across the site
 $bitstyles-box-sizing: border-box !default;
 
-$breakpoint-boundary-width:            0.625em !default;
+$breakpoint-boundary-width:            0.0625em !default;
 $breakpoint-small-medium-boundary:     45em !default;
 $breakpoint-medium-large-boundary:     64em !default;
 

--- a/stylesheets/tools/_typography-conversions.scss
+++ b/stylesheets/tools/_typography-conversions.scss
@@ -1,0 +1,18 @@
+// Px to Rem sizing
+//
+// Converts pixels to rems — use to define font-sizes etc.
+//
+// Styleguide 2.12.1
+
+@function px-to-rem($pixel-size, $root-size: $bitstyles-font-size-base-small) {
+  @return ($pixel-size / $root-size) * 1rem;
+}
+
+// em sizing
+//
+// Converts pixels to ems — use to define font-sizes etc.
+//
+// Styleguide 2.12.2
+@function px-to-em($pixels, $browser-context: $bitstyles-font-size-base-small) {
+  @return ($pixels / $browser-context) + 0em; // stylelint-disable-line length-zero-no-unit
+}

--- a/stylesheets/tools/_typography.scss
+++ b/stylesheets/tools/_typography.scss
@@ -8,3 +8,10 @@
     font-family: $bitstyles-font-family-header-loaded;
   }
 }
+
+@mixin font-size($pixel-size, $browser-context: $bitstyles-font-size-base-small) {
+  /* stylelint-disable declaration-block-no-duplicate-properties */
+  font-size: $pixel-size;
+  font-size: px-to-rem($pixel-size, $browser-context);
+  /* stylelint-enable declaration-block-no-duplicate-properties */
+}


### PR DESCRIPTION
Fixes #117 

Using ems & rems, px fallback. Functions & mixin to support.
Also fixes incorrectly-placed decimal place in `$breakpoint-boundary`.
