### PR TITLE
[#132] namespace and postcss bem linter

### DIFF
--- a/bitstyles/layout/_topbar.scss
+++ b/bitstyles/layout/_topbar.scss
@@ -1,4 +1,4 @@
-/** @define l-topbar */
+/** @define topbar */
 //
 // Topbar
 //

--- a/bitstyles/objects/_absolute-center.scss
+++ b/bitstyles/objects/_absolute-center.scss
@@ -1,4 +1,4 @@
-/** @define o-absolute-center */
+/** @define absolute-center */
 //
 // Absolute Center
 //

--- a/bitstyles/objects/_absolute-cover.scss
+++ b/bitstyles/objects/_absolute-cover.scss
@@ -1,4 +1,4 @@
-/** @define o-absolute-cover */
+/** @define absolute-cover */
 //
 // Absolute Cover
 //

--- a/bitstyles/objects/_bordered-header.scss
+++ b/bitstyles/objects/_bordered-header.scss
@@ -1,4 +1,4 @@
-/** @define o-bordered-header */
+/** @define bordered-header */
 //
 // Bordered Header
 //

--- a/bitstyles/objects/_button.scss
+++ b/bitstyles/objects/_button.scss
@@ -1,4 +1,4 @@
-/** @define o-button */
+/** @define button */
 //
 // Button
 //

--- a/bitstyles/objects/_clearfix.scss
+++ b/bitstyles/objects/_clearfix.scss
@@ -1,4 +1,4 @@
-/** @define o-clearfix */
+/** @define clearfix */
 //
 // Clearfix
 //

--- a/bitstyles/objects/_fixed-ratio.scss
+++ b/bitstyles/objects/_fixed-ratio.scss
@@ -1,4 +1,4 @@
-/** @define o-fixed-ratio */
+/** @define fixed-ratio */
 //
 // Fixed-ratio
 //

--- a/bitstyles/objects/_flex.scss
+++ b/bitstyles/objects/_flex.scss
@@ -1,4 +1,4 @@
-/** @define o-flex */
+/** @define flex */
 //
 // Flex
 //

--- a/bitstyles/objects/_list-reset.scss
+++ b/bitstyles/objects/_list-reset.scss
@@ -1,3 +1,4 @@
+/** @define list-reset */
 // List reset
 //
 // List reset removes the default margin, padding and bullets on a list, making

--- a/bitstyles/objects/_media.scss
+++ b/bitstyles/objects/_media.scss
@@ -1,3 +1,4 @@
+/** @define media */
 // Media
 //
 // Nicole Sullivan’s OOCSS media object.
@@ -10,12 +11,12 @@
 //
 // Styleguide 1.21
 
-.o-media {
+.#{$bitstyles-namespace}o-media {
   display: block;
   overflow: hidden;
 }
 
-.o-media__feature {
+.#{$bitstyles-namespace}o-media__feature {
   float: left;
   margin-right: $bitstyles-spacing;
 }

--- a/bitstyles/objects/_vertical-center.scss
+++ b/bitstyles/objects/_vertical-center.scss
@@ -1,4 +1,4 @@
-/** @define o-vertical-center */
+/** @define vertical-center */
 //
 // Vertical Centre
 //

--- a/bitstyles/objects/_visuallyhidden.scss
+++ b/bitstyles/objects/_visuallyhidden.scss
@@ -1,4 +1,4 @@
-/** @define o-visuallyhidden */
+/** @define visuallyhidden */
 //
 // Visuallyhidden
 //

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,12 +37,16 @@ gulp.task('build', function compileCss() {
 });
 
 gulp.task('lint:scss', function lintScss() {
+  const ns = '#{\\$bitstyles-namespace}(l-|c-|o-|t-|is-|has-|js-)';
+  const word = '[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*';
+  const element = '(?:__' + word + ')?';
+  const modifier = '(?:_' + word + '){0,2}';
+  const attribute = '(?:\\[.+\\])?';
   const stylelint = require('stylelint');
   const bemlint = require('postcss-bem-linter')({
-    preset: 'bem',
-    ignoreSelectors: [
-      '.is-active'
-    ]
+    componentName: /^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/,
+    // Double-escaping required!
+    componentSelectors: '^\\.' + ns + '{componentName}' + element + modifier + attribute + '$'
   });
 
   return gulp.src('bitstyles/**/*.scss')


### PR DESCRIPTION
- Switched from using the BEM preset config for postcss-bem-linter to manually specifying it as we need regexp to recognise `#{$bitstyles-namepsace}` in the selectors.
- Component name regex is correctly set.
- Removed the prefixes from objects’ `@define` statement as that’s part of the namespace not the object’s name

Fixes #132 
