### PR TITLE
[#120] No tests exist for trump layer

### DIFF
--- a/backstop.json
+++ b/backstop.json
@@ -1416,6 +1416,510 @@
       "misMatchThreshold" : 0.1,
       "onBeforeScript": "",
       "onReadyScript": ""
+    },
+    {
+      "label": "Margin Trumps — base",
+      "url": "http://localhost:3000/section/3.1.1-1/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Margin Trumps — left",
+      "url": "http://localhost:3000/section/3.1.1-2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Margin Trumps — top",
+      "url": "http://localhost:3000/section/3.1.1-3/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Margin Trumps — right",
+      "url": "http://localhost:3000/section/3.1.1-4/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Margin Trumps — bottom",
+      "url": "http://localhost:3000/section/3.1.1-5/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Margin Trumps — All",
+      "url": "http://localhost:3000/section/3.1.2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-margin Trumps — Base",
+      "url": "http://localhost:3000/section/3.2.1-1/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-margin Trumps — Left",
+      "url": "http://localhost:3000/section/3.2.1-2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-margin Trumps — Top",
+      "url": "http://localhost:3000/section/3.2.1-3/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-margin Trumps — Right",
+      "url": "http://localhost:3000/section/3.2.1-4/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-margin Trumps — Bottom",
+      "url": "http://localhost:3000/section/3.2.1-5/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-margin Trumps — All",
+      "url": "http://localhost:3000/section/3.2.2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-padding Trumps — Base",
+      "url": "http://localhost:3000/section/3.3.1-1/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-padding Trumps — Left",
+      "url": "http://localhost:3000/section/3.3.1-2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-padding Trumps — Top",
+      "url": "http://localhost:3000/section/3.3.1-3/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-padding Trumps — Right",
+      "url": "http://localhost:3000/section/3.3.1-4/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-padding Trumps — Bottom",
+      "url": "http://localhost:3000/section/3.3.1-5/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "No-padding Trumps — All",
+      "url": "http://localhost:3000/section/3.3.2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Padding Trumps — Base",
+      "url": "http://localhost:3000/section/3.4.1-1/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Padding Trumps — Left",
+      "url": "http://localhost:3000/section/3.4.1-2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Padding Trumps — Top",
+      "url": "http://localhost:3000/section/3.4.1-3/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Padding Trumps — Right",
+      "url": "http://localhost:3000/section/3.4.1-4/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Padding Trumps — Bottom",
+      "url": "http://localhost:3000/section/3.4.1-5/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Padding Trumps — All",
+      "url": "http://localhost:3000/section/3.4.2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Text-align Trumps — Base",
+      "url": "http://localhost:3000/section/3.5-1/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Text-align Trumps — Left",
+      "url": "http://localhost:3000/section/3.5-2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Text-align Trumps — Right",
+      "url": "http://localhost:3000/section/3.5-3/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Text-align Trumps — Centre",
+      "url": "http://localhost:3000/section/3.5-4/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Text-align Trumps — Justify",
+      "url": "http://localhost:3000/section/3.5-5/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Text-style Trumps — Base",
+      "url": "http://localhost:3000/section/3.6-1/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Text-style Trumps — Italic",
+      "url": "http://localhost:3000/section/3.6-2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Text-style Trumps — Normal",
+      "url": "http://localhost:3000/section/3.6-3/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Font-weight Trumps — Base",
+      "url": "http://localhost:3000/section/3.7-1/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Font-weight Trumps — Light",
+      "url": "http://localhost:3000/section/3.7-2/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Font-weight Trumps — Normal",
+      "url": "http://localhost:3000/section/3.7-3/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
+    },
+    {
+      "label": "Font-weight Trumps — Bold",
+      "url": "http://localhost:3000/section/3.7-4/fullscreen",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        ".object-section"
+      ],
+      "readyEvent": "styleguideRendered",
+      "delay": 20,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "",
+      "onReadyScript": ""
     }
   ],
   "paths": {

--- a/bitstyles/bitstyles.scss
+++ b/bitstyles/bitstyles.scss
@@ -125,6 +125,11 @@
 //
 // High-specificity overrides and helper classes (e.g. .hidden {}). `!important` exists here.
 //
+// sg-wrapper:
+// <div class="object-section">
+//   <sg-wrapper-content/>
+// </div>
+//
 // Styleguide 3.0
 @import 'trumps/text-weight';
 @import 'trumps/text-align';

--- a/bitstyles/trumps/_margin.scss
+++ b/bitstyles/trumps/_margin.scss
@@ -7,7 +7,7 @@
 // Add ad-hoc margins to elements.
 //
 // markup:
-// <p class="{$modifiers}">Some content here</p>
+// <div class="{$modifiers}"><div class="background-grey">Some content here</div></div>
 //
 //                    - Base style
 // .t-margin--left    - Left margin added.
@@ -30,7 +30,7 @@
 // Add ad-hoc margins to elements.
 //
 // markup:
-// <div class="margin"><p>Some content here.</p></div>
+// <div class="t-margin"><div class="background-grey">Some content here</div></div>
 //
 // Styleguide 3.1.2
 

--- a/bitstyles/trumps/_no-margin.scss
+++ b/bitstyles/trumps/_no-margin.scss
@@ -7,7 +7,7 @@
 // Remove margins from elements on an ad-hoc basis.
 //
 // markup:
-// <p class="{$modifiers}">Some content here</p>
+// <div class="t-margin {$modifiers}"><div class="background-grey">Some content here</div></div>
 //
 //                       - Base style
 // .t-no-margin--left    - Removes left-margin
@@ -30,7 +30,7 @@
 // Add ad-hoc margins to elements.
 //
 // markup:
-// <div class="margin"><p>Some content here.</p></div>
+// <div class="t-margin t-no-margin"><div class="background-grey">Some content here</div></div>
 //
 // Styleguide 3.2.2
 

--- a/bitstyles/trumps/_no-padding.scss
+++ b/bitstyles/trumps/_no-padding.scss
@@ -7,7 +7,9 @@
 // Use to remove padding from elements on an ad-hoc basis
 //
 // markup:
-// <p class="{$modifiers}">Some content here</p>
+// <div class="background-grey">
+//   <div class="t-padding {$modifiers}">Some content here</div>
+// </div>
 //
 //                        - Base style
 // .t-no-padding--left    - Removes left padding.
@@ -30,7 +32,9 @@
 // Use to remove padding from elements on an ad-hoc basis
 //
 // Markup:
-// <div class="padding"><p>Some content here.</p></div>
+// <div class="background-grey">
+//   <div class="t-padding t-no-padding">Some content here</div>
+// </div>
 //
 // Styleguide 3.3.2
 

--- a/bitstyles/trumps/_padding.scss
+++ b/bitstyles/trumps/_padding.scss
@@ -7,7 +7,9 @@
 // Use to add ad-hoc padding to elements
 //
 // markup:
-// <div class="{$modifiers}"><p>Some content here</p></div>
+// <div class="background-grey">
+//   <div class="{$modifiers}">Some content here.</div>
+// </div>
 //
 //                     - Base styling
 // .t-padding--left    - Add left-padding.
@@ -30,7 +32,9 @@
 // Add ad-hoc padding to elements.
 //
 // Markup:
-// <div class="padding"><p>Some content here.</p></div>
+// <div class="background-grey">
+//   <div class="t-padding">Some content here.</div>
+// </div>
 //
 // Styleguide 3.4.2
 


### PR DESCRIPTION
Backstop now screengrabs all the trump classes.
Removed`<p>`s from all the sample markup as they have margins that confuse the presentation.
Added grey backgrounds to make it clear to human readers where the edge of the containing div is.

Fixes #120 
