### PR TITLE
[#145] $bitstyles-color-text is not used

### DIFF
--- a/bitstyles/base/_typography.scss
+++ b/bitstyles/base/_typography.scss
@@ -3,6 +3,8 @@ html {
   font-family: $bitstyles-font-family-body;
   font-size: px-to-em($bitstyles-font-size-base-small);
   line-height: 1.5;
+  color: $bitstyles-color-text;
+  background: $bitstyles-color-background;
 
   .fonts-loaded & {
     font-family: $bitstyles-font-family-body-loaded;

--- a/bitstyles/settings/_global.scss
+++ b/bitstyles/settings/_global.scss
@@ -52,7 +52,8 @@ $bitstyles-color-gray-80:         #333 !default;
 $bitstyles-color-gray-90:         #191919 !default;
 
 // Colours by usage
-$bitstyles-color-text:            #333 !default;
+$bitstyles-color-text:            $bitstyles-color-gray-80 !default;
+$bitstyles-color-background:      $bitstyles-color-white !default;
 $bitstyles-color-positive:        #0f0 !default;
 $bitstyles-color-negative:        #f00 !default;
 


### PR DESCRIPTION
Applies the colour to `html` & adds a variable to specify background colour.

Fixes #145 
