### PR TITLE
[#146] Auto-updating styleguide

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -152,6 +152,12 @@ gulp.task('stats:graph', ['build'], function cssGraph() {
   });
 });
 
-gulp.task('watch', function watch() {
+gulp.task('watch:build', function watch() {
   gulp.watch('bitstyles/**/*.scss', ['lint', 'stats']);
 });
+
+gulp.task('watch:styleguide', ['styleguide'], function watch() {
+  gulp.watch('bitstyles/**/*.scss', ['lint', 'stats', 'styleguide']);
+});
+
+gulp.task('default', ['stats']);


### PR DESCRIPTION
**Contains #99**
Fixes #146 

This PR adds the `watch:styleguide` gulp task. Run `gulp watch:styleguide` and open the styleguide in your browser. Any changes made to the sass or to the KSS markup in the sass file will be built & the styleguide will dynamically update without refresh (should make styleguide-driven development possible).
