### PR TITLE
[#151] .l-content needs width 100%

### DIFF
--- a/bitstyles/bitstyles/generic/_box-sizing.scss
+++ b/bitstyles/bitstyles/generic/_box-sizing.scss
@@ -5,7 +5,7 @@
 
 /* stylelint-disable selector-no-type */
 html {
-  box-sizing: $bitstyles-box-sizing;
+  box-sizing: border-box;
 }
 
 *,

--- a/bitstyles/bitstyles/layout/_content.scss
+++ b/bitstyles/bitstyles/layout/_content.scss
@@ -15,14 +15,8 @@
 @import '../settings/content';
 
 .#{$bitstyles-namespace}l-content {
-  @if ($bitstyles-box-sizing == border-box) {
-    width: 100%;
-  } @else {
-    // styleguide:ignore:start
-    width: calc(100% - #{$bitstyles-content-horizontal-padding * 2});
-    // styleguide:ignore:end
-  }
   display: block;
+  width: 100%;
   max-width: $bitstyles-content-max-width;
   padding-right: $bitstyles-content-horizontal-padding;
   padding-left: $bitstyles-content-horizontal-padding;

--- a/bitstyles/bitstyles/settings/_global.scss
+++ b/bitstyles/bitstyles/settings/_global.scss
@@ -9,8 +9,6 @@ $bitstyles-spacing-horizontal: $bitstyles-spacing !default;
 
 /********* Layout */
 
-$bitstyles-box-sizing: border-box !default;
-
 $bitstyles-breakpoint-boundary-width:            0.0625em !default;
 $bitstyles-breakpoint-small-medium-boundary:     45em !default;
 $bitstyles-breakpoint-medium-large-boundary:     64em !default;


### PR DESCRIPTION
Fixes #151 

Sets width to 100% on .l-content to ensure consistent sizing (see #151 — there are case(s) where a block element will not have width).

Slightly complicated by the need to check for box-the global sizing setting.

Styleguide:ignore comments are because annoyingly the styleguide generator chokes on the calc when it includes sass interpolation `#{$blah * 2}`.

**Which raises the question**: as we use the box-sizing inherit method, we can change the box-sizing on objects as we need. Do we need the variable? Removing it would make this more concise.
