### PR TITLE
[#150] breakpoint vars aren’t 'bitstyles-' prefixed

### DIFF
--- a/bitstyles/bitstyles/layout/_grid-columns.scss
+++ b/bitstyles/bitstyles/layout/_grid-columns.scss
@@ -26,22 +26,21 @@
 @include grid-columns($bitstyles-widths-columns);
 
 @if variable-exists(bitstyles-grid-breakpoints) {
-  @each $breakpoint in $bitstyles-breakpoints {
-    @each $grid-breakpoint in $bitstyles-grid-breakpoints {
-      $breakpoint-alias: nth($breakpoint, 1);
+  @each $grid-breakpoint-alias in $bitstyles-grid-breakpoints {
+    $breakpoint-condition: map-get($bitstyles-breakpoints, $grid-breakpoint-alias);
 
-      /* stylelint-disable max-nesting-depth */
-      // If the breakpoint is in the breakpoint grid list...
-      @if ($breakpoint-alias == $grid-breakpoint) {
-        // ...then for each breakpoint...
-        @include media-query($breakpoint-alias) {
-          // ..generate grid columns, with the appropiate postfix.
-          @each $i in $bitstyles-widths-columns-responsive {
-            @include grid-columns($i, -#{$breakpoint-alias});
-          }
+    @if ($breakpoint-condition) {
+      @include media-query($grid-breakpoint-alias) {
+        /* stylelint-disable max-nesting-depth */
+        @each $i in $bitstyles-widths-columns-responsive {
+          @include grid-columns($i, -#{$grid-breakpoint-alias});
         }
+        /* stylelint-enable max-nesting-depth */
       }
-      /* stylelint-enable max-nesting-depth */
+    }
+
+    @else {
+      @error "Oops! Breakpoint ‘#{$grid-breakpoint-alias}’ does not exist.";
     }
   }
 }

--- a/bitstyles/bitstyles/settings/_global.scss
+++ b/bitstyles/bitstyles/settings/_global.scss
@@ -16,13 +16,12 @@ $bitstyles-breakpoint-small-medium-boundary:     45em !default;
 $bitstyles-breakpoint-medium-large-boundary:     64em !default;
 
 $bitstyles-breakpoints: (
-  'small'               'screen and (max-width: #{$bitstyles-breakpoint-small-medium-boundary - $bitstyles-breakpoint-boundary-width})',
-  'medium'              'screen and (min-width: #{$bitstyles-breakpoint-small-medium-boundary}) and (max-width: #{$bitstyles-breakpoint-medium-large-boundary - $bitstyles-
-    breakpoint-boundary-width})',
-  'medium-and-up'       'screen and (min-width: #{$bitstyles-breakpoint-small-medium-boundary})',
-  'small-and-medium'    'screen and (max-width: #{$bitstyles-breakpoint-medium-large-boundary - $bitstyles-breakpoint-boundary-width})',
-  'large'               'screen and (min-width: #{$bitstyles-breakpoint-medium-large-boundary})',
-  'hidpi'               '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)'
+  'small':               'screen and (max-width: #{$bitstyles-breakpoint-small-medium-boundary - $bitstyles-breakpoint-boundary-width})',
+  'medium':              'screen and (min-width: #{$bitstyles-breakpoint-small-medium-boundary}) and (max-width: #{$bitstyles-breakpoint-medium-large-boundary - $bitstyles-breakpoint-boundary-width})',
+  'medium-and-up':       'screen and (min-width: #{$bitstyles-breakpoint-small-medium-boundary})',
+  'small-and-medium':    'screen and (max-width: #{$bitstyles-breakpoint-medium-large-boundary - $bitstyles-breakpoint-boundary-width})',
+  'large':               'screen and (min-width: #{$bitstyles-breakpoint-medium-large-boundary})',
+  'hidpi':               '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)'
 ) !default;
 
 $bitstyles-global-z: topbar !default;

--- a/bitstyles/bitstyles/tools/_media-query.scss
+++ b/bitstyles/bitstyles/tools/_media-query.scss
@@ -3,7 +3,7 @@
 // Helper function to ease usage of media-queries. Uses the breakpoints listed in $breakpoint sass variable.
 //
 // Usage:
-// 
+//
 // `
 // @media-query(breakpoint-name) {
 //    .selector {
@@ -15,23 +15,16 @@
 // Styleguide 2.11
 
 @mixin media-query($mq, $breakpoints: $bitstyles-breakpoints) {
-  $breakpoint-found: false;
 
-  @each $breakpoint in $bitstyles-breakpoints {
-    $alias: nth($breakpoint, 1);
-    $condition: nth($breakpoint, 2);
+  $breakpoint-condition: map-get($breakpoints, $mq);
 
-    @if $mq == $alias and $condition {
-      $breakpoint-found: true;
-
-      @media #{$condition} {
-        @content;
-      }
+  @if ($breakpoint-condition) {
+    @media #{$breakpoint-condition} {
+      @content;
     }
   }
 
-  // If the user specifies a non-exitent alias, send them a warning.
-  @if $breakpoint-found == false {
-    @warn "Oops! Breakpoint ‘#{$mq}’ does not exist.";
+  @else {
+    @error "Oops! Breakpoint ‘#{$mq}’ does not exist.";
   }
 }


### PR DESCRIPTION
Fixes #150 
- Adds `$bitstyles-` prefix to the breakpoint variables.
- Updated breakpoints variable, media-query mixin & grid generator to use sass-maps
- Note the media query mixin now emits an error if the media-query you’re looking for isn’t there. I did this because amongst all the noise on console I’ve often missed the warnings (and different MQs exist in different projects)
