### PR TITLE
Add a Github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,23 @@
 # Summary
 Fixes # .
 
-Changes proposed in this pull request:
+# Changes
+
+The following changes are proposed in this pull request:
 - x
 - y
 - z
 
 # Checklist
+
 Have any **object** or **trumps** components been updated? (delete this if not)
+
 - [ ] Styleguide documentation has been updated.
 - [ ] `backstop.json` file has been updated
-- [ ] `gulp test:build` script has been sucessfully run
+- [ ] `gulp test:build` script has been sucessfully run and new/changed images committed
 
 Has **linting** and **testing** been conducted?
+
 - [ ] `gulp test:run` script has been run and visual tests pass
 - [ ] `gulp lint:scss` script has been run without errors
 - [ ] `gulp lint:js` script has been run without errors


### PR DESCRIPTION
Fixes #160.
- Adds a Github PR template.
- Adds a simple checklist of items that should be confirmed before a PR is approvable.
- Adds a "Fixes" field (as there should always be an associated issue).
- Adds a list of changes for a PR.
