### PR TITLE
Body webfonts are not loaded

### DIFF
--- a/bitstyles/bitstyles/base/_typography.scss
+++ b/bitstyles/bitstyles/base/_typography.scss
@@ -6,7 +6,7 @@ html {
   color: $bitstyles-color-text;
   background: $bitstyles-color-background;
 
-  .fonts-loaded & {
+  &.fonts-loaded {
     font-family: $bitstyles-font-family-body-loaded;
   }
 }

--- a/stats/css.json
+++ b/stats/css.json
@@ -1,6 +1,6 @@
 {
  "total-stylesheets": 1,
- "total-stylesheet-size": 156976,
+ "total-stylesheet-size": 156659,
  "total-media-queries": 5,
  "media-queries": [
   "screen and (min-width:45em)",


### PR DESCRIPTION
``` sass
html {
  .fonts-loaded & {
    ...
  }
}
```

The above can never be achieved, as `html` is the root element. This PR adds the `.fonts-loaded` class as a class selector to the `html` selector, instead of it being a parent to `html`.
