### PR TITLE
Updated css stats

### DIFF
--- a/stats/css.json
+++ b/stats/css.json
@@ -1,6 +1,6 @@
 {
  "total-stylesheets": 1,
- "total-stylesheet-size": 196800,
+ "total-stylesheet-size": 195435,
  "total-media-queries": 5,
  "media-queries": [
   "screen and (min-width:45em)",
@@ -18,7 +18,7 @@
  "top-selector-specificity-selector": ".o-expander-toggle[aria-expanded=true] .o-icon",
  "total-id-selectors": 0,
  "total-identifiers": 383,
- "total-declarations": 513,
+ "total-declarations": 492,
  "total-unique-colours": 9,
  "unique-colours": [
   "#FFFF00",


### PR DESCRIPTION
# Updates CSS `stats.json`

# Changes

The following changes are proposed in this pull request:
- Css-stats fell behind on last PR

# Checklist

- [ ] Styleguide documentation has been updated.
- [ ] `backstop.json` file has been updated
- [ ] `gulp test:build` script has been sucessfully run and new/changed images committed

Has **linting** and **testing** been conducted?

- [x] `gulp test:run` script has been run and visual tests pass
- [ ] `gulp lint:scss` script has been run without errors
- [ ] `gulp lint:js` script has been run without errors

