### PR TITLE
Feature/177 linting fails on block scss

### DIFF
--- a/bitstyles/bitstyles/objects/_block.scss
+++ b/bitstyles/bitstyles/objects/_block.scss
@@ -9,6 +9,6 @@
 //
 // Styleguide 1.25
 
-.o-block {
+.#{$bitstyles-namespace}o-block {
   display: block;
 }

--- a/bitstyles/bitstyles/objects/_error.scss
+++ b/bitstyles/bitstyles/objects/_error.scss
@@ -9,6 +9,6 @@
 //
 // Styleguide 1.24
 
-.o-error {
+.#{$bitstyles-namespace}o-error {
   color: $bitstyles-color-error;
 }

--- a/bitstyles/bitstyles/objects/_input.scss
+++ b/bitstyles/bitstyles/objects/_input.scss
@@ -19,7 +19,7 @@
 //
 // Styleguide 1.22.1
 
-.o-input--textual {
+.#{$bitstyles-namespace}o-input--textual {
   min-width: $bitstyles-input-min-width;
   padding: $bitstyles-input-padding;
   background-color: $bitstyles-input-background;
@@ -46,7 +46,7 @@
 //
 // Styleguide 1.22.2
 
-.o-input--select {
+.#{$bitstyles-namespace}o-input--select {
   min-width: $bitstyles-input-min-width;
 }
 
@@ -63,7 +63,7 @@
 //
 // Styleguide 1.22.3
 
-.o-input--checkbox {
+.#{$bitstyles-namespace}o-input--checkbox {
   display: inline-block;
   width: $bitstyles-input-checkbox-width;
   vertical-align: middle;
@@ -86,7 +86,7 @@
 //
 // Styleguide 1.22.4
 
-.o-label + .o-input--checkbox {
+.#{$bitstyles-namespace}o-label + .#{$bitstyles-namespace}o-input--checkbox {
   text-align: right;
 }
 
@@ -100,6 +100,6 @@
 //
 // Styleguide 1.22.5
 
-.o-input--range {
+.#{$bitstyles-namespace}o-input--range {
   min-width: $bitstyles-input-min-width;
 }

--- a/bitstyles/bitstyles/objects/_input.scss
+++ b/bitstyles/bitstyles/objects/_input.scss
@@ -86,9 +86,12 @@
 //
 // Styleguide 1.22.4
 
+/* postcss-bem-linter: ignore */
 .#{$bitstyles-namespace}o-label + .#{$bitstyles-namespace}o-input--checkbox {
   text-align: right;
 }
+
+/* postcss-bem-linter: end */
 
 // Form inputs - Range
 //

--- a/bitstyles/bitstyles/objects/_label.scss
+++ b/bitstyles/bitstyles/objects/_label.scss
@@ -29,7 +29,7 @@
 //
 // Styleguide 1.23.1
 
-.o-label {
+.#{$bitstyles-namespace}o-label {
   @include font-size($bitstyles-font-size-base);
   font-weight: $bitstyles-font-weight-bold;
 }
@@ -47,7 +47,7 @@
 //
 // Styleguide 1.23.2
 
-.o-label--for-checkbox {
+.#{$bitstyles-namespace}o-label--for-checkbox {
   display: inline-block;
   width: calc(100% - (#{$bitstyles-input-checkbox-width} + #{$bitstyles-input-checkbox-width-gutter}));
   vertical-align: middle;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ gulp.task('lint:scss', function lintScss() {
   const ns = '#{\\$bitstyles-namespace}(l-|c-|o-|t-|is-|has-|js-)';
   const word = '[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*';
   const element = '(?:__' + word + ')?';
-  const modifier = '(?:_' + word + '){0,2}';
+  const modifier = '(?:--' + word + ')?';
   const attribute = '(?:\\[.+\\])?';
   const stylelint = require('stylelint');
   const bemlint = require('postcss-bem-linter')({

--- a/stats/css.json
+++ b/stats/css.json
@@ -1,6 +1,6 @@
 {
  "total-stylesheets": 1,
- "total-stylesheet-size": 195435,
+ "total-stylesheet-size": 195919,
  "total-media-queries": 5,
  "media-queries": [
   "screen and (min-width:45em)",


### PR DESCRIPTION
# Summary
Fixes #177. 

# Changes

The following changes are proposed in this pull request:
- Adds correct namespacing to those object moduels that were missing it. 
- Fixes the regex on postcss-bem-linter, so that BEM modifiers are now recognised

# Checklist

Has **linting** and **testing** been conducted?

- [ ] `gulp test:run` script has been run and visual tests pass
- [x] `gulp lint:scss` script has been run without errors
- [ ] `gulp lint:js` script has been run without errors
