### PR TITLE
Removes the sourcemaps from built version CSS.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,6 @@ const syntaxScss = require('postcss-scss');
 const sass = require('gulp-sass');
 const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
-const sourcemaps = require('gulp-sourcemaps');
 const fs = require('fs');
 const graph = require('gulp-specificity-graph');
 const Parkerstats = require('parker');
@@ -26,7 +25,6 @@ const opener = require('opener');
 
 gulp.task('build', function compileCss() {
   return gulp.src('bitstyles/bitstyles.scss')
-    .pipe(sourcemaps.init())
     .pipe(sass({
       includePaths: [
         './node_modules/'
@@ -37,7 +35,6 @@ gulp.task('build', function compileCss() {
       cssnano({ safe: true }),
       postcssReporter
     ]))
-    .pipe(sourcemaps.write())
     .pipe(gulp.dest('build/'));
 });
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "gulp-eslint": "^2.0.0",
     "gulp-postcss": "^6.1.0",
     "gulp-sass": "^2.3.1",
-    "gulp-sourcemaps": "^2.0.0-alpha",
     "gulp-specificity-graph": "0.0.1",
     "opener": "^1.4.1",
     "parker": "0.0.10",

--- a/stats/css.json
+++ b/stats/css.json
@@ -1,6 +1,6 @@
 {
  "total-stylesheets": 1,
- "total-stylesheet-size": 196703,
+ "total-stylesheet-size": 14747,
  "total-media-queries": 5,
  "media-queries": [
   "screen and (min-width:45em)",


### PR DESCRIPTION
# Removes the sourcemaps from built version CSS.
Fixes #185.

# Changes

The following changes are proposed in this pull request:
- Remove sourcemaps from the built version of the CSS — that should be what’s shippable to the browser, right now it’s >90% source map comment
- Also removed the source maps npm package as we don’t use it anywhere else

# Checklist

Has **linting** and **testing** been conducted?

- [x] `gulp test:run` script has been run and visual tests pass
- [x] `gulp lint:scss` script has been run without errors
- [x] `gulp lint:js` script has been run without errors
