### PR TITLE
Adds mixins for media, flex & block objects

### DIFF
--- a/bitstyles/bitstyles.scss
+++ b/bitstyles/bitstyles.scss
@@ -37,6 +37,9 @@
 @import 'bitstyles/tools/grid-column-generator';
 @import 'bitstyles/tools/typography';
 @import 'bitstyles/tools/typography-conversions';
+@import 'bitstyles/tools/block';
+@import 'bitstyles/tools/flex';
+@import 'bitstyles/tools/media';
 //
 // ******** Add project-specific tools here ********
 //

--- a/bitstyles/bitstyles/objects/_block.scss
+++ b/bitstyles/bitstyles/objects/_block.scss
@@ -10,5 +10,5 @@
 // Styleguide 1.25
 
 .#{$bitstyles-namespace}o-block {
-  display: block;
+  @include block;
 }

--- a/bitstyles/bitstyles/objects/_flex.scss
+++ b/bitstyles/bitstyles/objects/_flex.scss
@@ -16,10 +16,9 @@
 // Styleguide 1.10
 
 .#{$bitstyles-namespace}o-flex {
-  display: flex;
-  align-items: stretch;
+  @include flex;
 }
 
 .#{$bitstyles-namespace}o-flex__primary {
-  flex: 1 0 auto;
+  @include flex__primary;
 }

--- a/bitstyles/bitstyles/objects/_media.scss
+++ b/bitstyles/bitstyles/objects/_media.scss
@@ -12,11 +12,9 @@
 // Styleguide 1.21
 
 .#{$bitstyles-namespace}o-media {
-  display: block;
-  overflow: hidden;
+  @include media;
 }
 
 .#{$bitstyles-namespace}o-media__feature {
-  float: left;
-  margin-right: $bitstyles-spacing;
+  @include media__feature;
 }

--- a/bitstyles/bitstyles/tools/_block.scss
+++ b/bitstyles/bitstyles/tools/_block.scss
@@ -1,0 +1,9 @@
+// Block
+//
+// Display an element as a block.
+//
+// Styleguide 2.16
+
+@mixin block {
+  display: block;
+}

--- a/bitstyles/bitstyles/tools/_flex.scss
+++ b/bitstyles/bitstyles/tools/_flex.scss
@@ -1,0 +1,15 @@
+// Flex
+//
+// Simple flex layout.
+// Make one of the children `.o-flex__primary` to make it take as much space as is available.
+//
+// Styleguide 2.17
+
+@mixin flex {
+  display: flex;
+  align-items: stretch;
+}
+
+@mixin flex__primary {
+  flex: 1 0 auto;
+}

--- a/bitstyles/bitstyles/tools/_media.scss
+++ b/bitstyles/bitstyles/tools/_media.scss
@@ -1,0 +1,15 @@
+// Media
+//
+// Nicole Sullivan’s OOCSS media object.
+//
+// Styleguide 2.18
+
+@mixin media {
+  display: block;
+  overflow: hidden;
+}
+
+@mixin media__feature {
+  float: left;
+  margin-right: $bitstyles-spacing;
+}


### PR DESCRIPTION
# Adds mixins for media, flex & block objects
Fixes #187.

# Changes

The following changes are proposed in this pull request:
- New mixins created to define  `.o-media`, `.o-flex`, & `.o-block`. These can then be used to create breakpoint-dependent versions in client projects. 

# Checklist

Have any **object** or **trumps** components been updated? (delete this if not)

- [x] Styleguide documentation has been updated.
- [ ] `backstop.json` file has been updated
- [ ] `gulp test:build` script has been sucessfully run and new/changed images committed

Has **linting** and **testing** been conducted?

- [x] `gulp test:run` script has been run and visual tests pass
- [x] `gulp lint:scss` script has been run without errors
- [x] `gulp lint:js` script has been run without errors

