### PR TITLE
Removes the max-width & -height properties from `.o-icon` — a fix app…

### DIFF
--- a/bitstyles/bitstyles/objects/_icon.scss
+++ b/bitstyles/bitstyles/objects/_icon.scss
@@ -25,8 +25,6 @@
   display: inline-block;
   width: 1em;
   height: 1em;
-  max-width: 100%;
-  max-height: 100%;
   font-size: 1em;
   vertical-align: middle;
   outline: none;


### PR DESCRIPTION
# Removes the max-width & -height properties from `.o-icon`

# Changes

The following changes are proposed in this pull request:
- Removes the max-width & -height properties from `.o-icon`

This was a fix for over-large icons, but it’s a fix applied in the wrong place; the parent element should constrain dimensions using font-size. It caused breakages in some browsers when the icon is the only child of an `inline-block` parent as that parent has zero inherent width, hence so did the icon and was invisible.

# Checklist

Have any **object** or **trumps** components been updated? (delete this if not)

- [ ] Styleguide documentation has been updated.
- [ ] `backstop.json` file has been updated
- [x] `gulp test:build` script has been sucessfully run and new/changed images committed

Has **linting** and **testing** been conducted?

- [x] `gulp test:run` script has been run and visual tests pass
- [x] `gulp lint:scss` script has been run without errors
- [x] `gulp lint:js` script has been run without errors
