### PR TITLE
Adds reminder to generate CSS stats to PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@ Have any **object** or **trumps** components been updated? (delete this if not)
 - [ ] Styleguide documentation has been updated.
 - [ ] `backstop.json` file has been updated
 - [ ] `gulp test:build` script has been sucessfully run and new/changed images committed
+- [ ] `gulp stats` script run and updated `stats/css.json` commited
 
 Has **linting** and **testing** been conducted?
 


### PR DESCRIPTION
# Summary
Fixes #202 .

# Changes

The following changes are proposed in this pull request:
- Adds a reminder to rum CSS stats generate script to PR template

# Checklist

Have any **object** or **trumps** components been updated? (delete this if not)

- [ ] Styleguide documentation has been updated.
- [ ] `backstop.json` file has been updated
- [ ] `gulp test:build` script has been sucessfully run and new/changed images committed

Has **linting** and **testing** been conducted?

- [ ] `gulp test:run` script has been run and visual tests pass
- [ ] `gulp lint:scss` script has been run without errors
- [ ] `gulp lint:js` script has been run without errors

