### PR TITLE
Bump version & remove private flag

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
   ],
   "homepage": "https://github.com/bitcrowd/bitstyles",
   "moduleType": [],
-  "private": false,
   "ignore": [
     "**/.*",
     "node_modules",

--- a/lib/bitstyles/version.rb
+++ b/lib/bitstyles/version.rb
@@ -1,3 +1,3 @@
 module Bitstyles
-  VERSION = "0.7.5"
+  VERSION = "0.8.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "bitstyles",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "The Bitcrowd CSS library",
   "main": "bitstyles.scss",
-  "private": true,
   "scripts": {
     "build": "node-sass scss/bitstyles.scss -o build --output-style compact",
     "postbuild": "postcss -c postcss_build.json",


### PR DESCRIPTION
### Summary

The following changes are contained in this pull request:
- removes the bower `private` flag
- Updates the version ready for tagging & publishing
