### PR TITLE
Adds npm, bower, & rubygems badges to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Bitstyles
 
+[![Build Status](https://travis-ci.org/bitcrowd/bitstyles.svg?branch=master)](https://travis-ci.org/bitcrowd/bitstyles)
 [![npm version](https://badge.fury.io/js/bitstyles.svg)](https://badge.fury.io/js/bitstyles)
 [![bower version](https://badge.fury.io/bo/bitstyles.svg)](https://badge.fury.io/bo/bitstyles)
 [![Gem Version](https://badge.fury.io/rb/bitstyles.svg)](https://badge.fury.io/rb/bitstyles)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Bitstyles
 
+[![npm version](https://badge.fury.io/js/bitstyles.svg)](https://badge.fury.io/js/bitstyles)
+[![bower version](https://badge.fury.io/bo/bitstyles.svg)](https://badge.fury.io/bo/bitstyles)
+[![Gem Version](https://badge.fury.io/rb/bitstyles.svg)](https://badge.fury.io/rb/bitstyles)
+
 A developing collection of CSS styles and helpers, for use in Bitcrowd projects.
 
 ## Using Bitstyles in a project


### PR DESCRIPTION
### Summary

Incomplete fix for #221 — needs the travis badge.

The following changes are contained in this pull request:
- Adds npmjs badge to README
- Adds bower badge to README
- Adds rubygems badge to README

### Linting and testing
- [x] `npm run checks` script has been run without errors
