### PR TITLE
[#233] npm run styleguide errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "autoprefixer": "^6.5.0",
     "cssnano": "^3.7.7",
     "eslint": "^3.7.1",
-    "eslint-config-bitcrowd": "0.0.3",
     "eslint-config-bitcrowd-base": "^8.0.0",
     "eslint-plugin-import": "^1.16.0",
     "node-sass": "^3.10.1",
@@ -74,7 +73,7 @@
     "postcss-reporter": "^1.4.1",
     "postcss-scss": "^0.3.1",
     "rimraf": "^2.5.4",
-    "sc5-styleguide": "^1.2.0",
+    "sc5-styleguide": "^1.4.1",
     "specificity-graph": "^0.1.7",
     "stylelint": "^7.5.0",
     "stylelint-config-bitcrowd": "^1.1.0"


### PR DESCRIPTION
Fixes #233

The following changes are contained in this pull request:
- Updates sc-5 styleguide dependency — version 1.3.3 had parsing issues, it’s now specified at minimum 1.4.1
- Removes the already-unused dependency on the deprecated `eslint-config-bitcrowd`.

- [x] `npm run checks` script has been run without errors
