### PR TITLE
[#240] breakpoints variables aren’t namespaced

### DIFF
--- a/scss/bitstyles/objects/_hidden.scss
+++ b/scss/bitstyles/objects/_hidden.scss
@@ -4,7 +4,7 @@
 //
 // Fully hides an element & its children — does not affect document flow, does
 // not get read by google or screenreaders. Available at every breakpoint defined
-// in `$hidden-breakpoints`.
+// in `$bitstyles-hidden-breakpoints`.
 //
 // .o-hidden          - Hide this element always (generally so it can be revealed using JS)
 // .o-hidden@small    - Hide this content on smallscreens
@@ -25,7 +25,7 @@
   @include hidden;
 }
 
-@each $breakpoint in $hidden-breakpoints {
+@each $breakpoint in $bitstyles-hidden-breakpoints {
   @include media-query($breakpoint) {
     .#{$bitstyles-namespace}o-hidden\@#{$breakpoint} {
       @include hidden;

--- a/scss/bitstyles/objects/_visuallyhidden.scss
+++ b/scss/bitstyles/objects/_visuallyhidden.scss
@@ -5,7 +5,7 @@
 // Hide an element visually while leaving it readable & accessible by google & screenreaders.
 // Use to give more complete & understandable labels for UI e.g. display only 'next' on a button,
 // but use `.o-visuallyhidden` to hide a span containing a more descriptive label.
-// Available at every breakpoint set in `$visuallyhidden-breakpoints`.
+// Available at every breakpoint set in `$bitstyles-visuallyhidden-breakpoints`.
 //
 // markup:
 // <button class="o-button">
@@ -21,7 +21,7 @@
   @include visuallyhidden;
 }
 
-@each $breakpoint in $visuallyhidden-breakpoints {
+@each $breakpoint in $bitstyles-visuallyhidden-breakpoints {
   @include media-query($breakpoint) {
     .#{$bitstyles-namespace}o-visuallyhidden\@#{$breakpoint} {
       @include visuallyhidden;

--- a/scss/bitstyles/settings/_hidden.scss
+++ b/scss/bitstyles/settings/_hidden.scss
@@ -1,1 +1,1 @@
-$hidden-breakpoints: (small, large) !default;
+$bitstyles-hidden-breakpoints: (small, large) !default;

--- a/scss/bitstyles/settings/_visuallyhidden.scss
+++ b/scss/bitstyles/settings/_visuallyhidden.scss
@@ -1,1 +1,1 @@
-$visuallyhidden-breakpoints: () !default;
+$bitstyles-visuallyhidden-breakpoints: () !default;


### PR DESCRIPTION
Fixes #240 

The following changes are contained in this pull request:
- Renamed `$hidden-breakpoints` to `$bitstyles-hidden-breakpoints`
- Renamed `$visuallyhidden-breakpoints` to `$bitstyles-visuallyhidden-breakpoints`

### Linting and testing

- [x] `npm run checks` script has been run without errors
