### PR TITLE
[#231] add parameters to the fixed ratio mixin

### DIFF
--- a/scss/bitstyles/objects/_fixed-ratio.scss
+++ b/scss/bitstyles/objects/_fixed-ratio.scss
@@ -2,9 +2,9 @@
 //
 // Fixed-ratio
 //
-// Enforces an aspect ratio on this element and its contents. Default ratio is
-// 16:9 — the element takes 100% width, then the height is set to the keep the
-// element at the specified ratio.
+// Enforces an aspect ratio on this element and its contents — the element takes
+// 100% width, then the height is set to the keep the element at the specified ratio.
+// Default ratio is defined in `$fixed-ratio-default-ratio`.
 //
 // markup:
 // <figure>
@@ -16,8 +16,13 @@
 //
 // Styleguide 4.9
 
+@import '../settings/fixed-ratio';
+
 .#{$bitstyles-namespace}o-fixed-ratio {
-  @include fixed-ratio(16, 9);
+  @include fixed-ratio(
+    map-get($fixed-ratio-default-ratio, 'width'),
+    map-get($fixed-ratio-default-ratio, 'height')
+  );
 }
 
 .#{$bitstyles-namespace}o-fixed-ratio__inner {

--- a/scss/bitstyles/objects/_fixed-ratio.scss
+++ b/scss/bitstyles/objects/_fixed-ratio.scss
@@ -2,8 +2,9 @@
 //
 // Fixed-ratio
 //
-// Enforces an aspect ratio on this element anbd its contents. Default ratio is
-// 16:9 — the element takes 100% width, then the height matches.
+// Enforces an aspect ratio on this element and its contents. Default ratio is
+// 16:9 — the element takes 100% width, then the height is set to the keep the
+// element at the specified ratio.
 //
 // markup:
 // <figure>
@@ -16,7 +17,7 @@
 // Styleguide 4.9
 
 .#{$bitstyles-namespace}o-fixed-ratio {
-  @include fixed-ratio;
+  @include fixed-ratio(16, 9);
 }
 
 .#{$bitstyles-namespace}o-fixed-ratio__inner {

--- a/scss/bitstyles/settings/_fixed-ratio.scss
+++ b/scss/bitstyles/settings/_fixed-ratio.scss
@@ -1,0 +1,3 @@
+$fixed-ratio-default-ratio: (
+  'width': 16,
+  'height': 9) !default;

--- a/scss/bitstyles/tools/_fixed-ratio.scss
+++ b/scss/bitstyles/tools/_fixed-ratio.scss
@@ -1,10 +1,31 @@
 // Fixed Ratio
 //
-// An element that has intrinsic shape — width will be 100%, height will be limited to keep 16:9 aspect ratio.
+// An element that has intrinsic shape — width will be 100%, height will be limited
+// to keep your aspect ratio. Pass in width & height parameters to set your aspect
+// ratio.
+//
+// Use the `fixed-ratio--variant` mixin to create modifier classes with ratios
+// different to your base class.
+//
+// e.g.
+//
+// ```scss
+// .o-fixed-ratio {
+//   @include fixed-ratio(16, 9);
+// }
+//
+// .o-fixed-ratio--16-10 {
+//   @include fixed-ratio--variant(16, 10);
+// }
+//
+// .o-fixed-ratio--square {
+//   @include fixed-ratio--variant(10, 10);
+// }
+// ```
 //
 // Styleguide 1.6
 
-@mixin fixed-ratio {
+@mixin fixed-ratio($width, $height) {
   position: relative;
   display: block;
   width: 100%;
@@ -12,9 +33,19 @@
 
   &::before {
     display: block;
-    padding-top: 56.25%;
+    padding-top: percentage-aspect-ratio($width, $height);
     content: '';
   }
+}
+
+@mixin fixed-ratio--variant($width, $height) {
+  &::before {
+    padding-top: percentage-aspect-ratio($width, $height);
+  }
+}
+
+@function percentage-aspect-ratio($width, $height) {
+  @return percentage($height / $width);
 }
 
 @mixin fixed-ratio__inner {


### PR DESCRIPTION
Fixes #231 

The following changes are contained in this pull request:
- Made the `fixed-ratio` mixin a little more general, now accepts width & height parameters to set its ratio.
- Added a new mixin to generate variations without re-specifying all the base declarations.
- Factored out the calculation of ratio into a function.

### Changes to objects & trumps

- [x] Styleguide documentation has been updated.
- [x] `npm run stats` script run and updated `stats/css.json` commited

### Linting and testing

- [x] `npm run checks` script has been run without errors