### PR TITLE
[#241] add css:stats to the checks task

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:components": "backstop test --configPath=test/backstop_tests/components.json",
     "test:trumps": "backstop test --configPath=test/backstop_tests/trumps.json",
 
-    "checks": "npm run lint && npm run test",
+    "checks": "npm run lint && npm run css:stats && npm run test",
     "prestyleguide": "npm run build && cat build/bitstyles.css styleguide/assets/stylesheets/styleguide-extras.css > build/bitstyles_styleguide.css",
     "styleguide": "scripts/styleguide.sh",
     "watch": "npm run build && npm run build -- --watch --recursive",


### PR DESCRIPTION
Fixes #241 

The following changes are contained in this pull request:
- Added `npm run css:stats` to the `checks` task.

### Linting and testing

- [x] `npm run checks` script has been run without errors