### PR TITLE
[#271] icon sizes should be specified in a map for consistency

### DIFF
--- a/scss/bitstyles/objects/_icon.scss
+++ b/scss/bitstyles/objects/_icon.scss
@@ -35,12 +35,9 @@
   fill: currentColor;
 }
 
-@each $icon-size in $bitstyles-icon-sizes {
-  $alias: nth($icon-size, 1);
-  $size: nth($icon-size, 2);
-
+@each $icon-size-alias, $icon-size-size in $bitstyles-icon-sizes {
   /* postcss-bem-linter: ignore */
-  .#{$bitstyles-namespace}o-icon--#{$alias} {
-    font-size: $size;
+  .#{$bitstyles-namespace}o-icon--#{$icon-size-alias} {
+    font-size: $icon-size-size;
   }
 }

--- a/scss/bitstyles/settings/_icon.scss
+++ b/scss/bitstyles/settings/_icon.scss
@@ -1,5 +1,5 @@
 $bitstyles-icon-sizes: (
-  'small'     1rem,
-  'medium'    2rem,
-  'large'     3rem
+  'small':     1rem,
+  'medium':    2rem,
+  'large':     3rem
 ) !default;

--- a/scss/bitstyles/tools/_typography.scss
+++ b/scss/bitstyles/tools/_typography.scss
@@ -71,10 +71,7 @@
 // Styleguide 1.15.3
 
 @mixin generate-font-sizes($prefix: '', $subset: ()) {
-  @each $media-query in $bitstyles-font-sizes {
-    $media-query-name: nth($media-query, 1);
-    $font-sizes: nth($media-query, 2);
-
+  @each $media-query-name, $font-sizes in $bitstyles-font-sizes {
     // Don’t wrap base classes in a media-query
     @if $media-query-name == 'base' {
       @include output-font-sizes($font-sizes, $prefix, $subset);
@@ -95,10 +92,7 @@
     $base-size: map-get($font-sizes, 'html');
   }
 
-  @each $element in ($font-sizes) {
-    $element-name: nth($element, 1);
-    $font-size: nth($element, 2);
-
+  @each $element-name, $font-size in ($font-sizes) {
     @if (length($subset) == 0) or (index($subset, $element-name)) {
       #{$bitstyles-namespace}#{$prefix}#{$element-name} {
         /* stylelint-disable max-nesting-depth */


### PR DESCRIPTION
Fixes #271 

The following changes are contained in this pull request:
- `$bitstyles-icon-sizes` is now a correct Sass map.
- `@mixin generate-font-sizes` and `@mixin output-font-sizes` both updated to use the more concise Sass map `@each` iterator accessors (instead of one of the more verbose boilerplatey Sass accessor functions like `map-get` or `nth`).

Every time:

- [x] `npm run checks` script has been run without errors.
