### PR TITLE
[#274] Tests should continue even after one of them failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "lint:js": "eslint .",
     "lint": "npm run lint:scss && npm run lint:js",
 
-    "test:build": "npm run test:build:base && npm run test:build:objects && npm run test:build:layout && npm run test:build:components && npm run test:build:trumps",
+    "test:build": "npm run test:build:base; npm run test:build:objects; npm run test:build:layout; npm run test:build:components; npm run test:build:trumps",
     "test:build:base": "backstop reference --configPath=test/backstop_tests/base.json",
     "test:build:objects": "backstop reference --configPath=test/backstop_tests/objects.json",
     "test:build:layout": "backstop reference --configPath=test/backstop_tests/layout.json",
     "test:build:components": "backstop reference --configPath=test/backstop_tests/components.json",
     "test:build:trumps": "backstop reference --configPath=test/backstop_tests/trumps.json",
 
-    "test": "npm run test:base && npm run test:layout && npm run test:objects && npm run test:components && npm run test:trumps",
+    "test": "npm run test:base; npm run test:layout; npm run test:objects; npm run test:components; npm run test:trumps",
     "test:base": "backstop test --configPath=test/backstop_tests/base.json",
     "test:objects": "backstop test --configPath=test/backstop_tests/objects.json",
     "test:layout": "backstop test --configPath=test/backstop_tests/layout.json",


### PR DESCRIPTION
Fixes #274 

The following changes are contained in this pull request:
- Tests now chained together using `;` instead of `&&`.

Every time:

- [x] `npm run checks` script has been run without errors.
