### PR TITLE
HOTFIX/duplicate-styleguide-section-numbers

### DIFF
--- a/scss/bitstyles/tools/_overflow.scss
+++ b/scss/bitstyles/tools/_overflow.scss
@@ -7,7 +7,7 @@
 // needed, this mixin at least ensures no scrollbars are displayed unless there’s
 // something to scroll.
 //
-// Styleguide 1.22
+// Styleguide 1.23
 
 // (1) Fixes bug in safari that causes the scrollbars to appear behind some content within the overflow element.
 


### PR DESCRIPTION
The following changes are contained in this pull request:
- Renumbered the tools/overflow stylguide section

Every time:

- [x] `npm run checks` script has been run without errors.
