### PR TITLE
Bumped version for rubygem version.

### DIFF
--- a/bitstyles.gemspec
+++ b/bitstyles.gemspec
@@ -13,15 +13,13 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/bitcrowd/bitstyles"
   spec.license       = "ISC"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|styleguide|scripts|build)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/lib/bitstyles/version.rb
+++ b/lib/bitstyles/version.rb
@@ -1,3 +1,3 @@
 module Bitstyles
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitstyles",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The Bitcrowd CSS library",
   "main": "bitstyles.scss",
   "scripts": {


### PR DESCRIPTION
The following changes are contained in this pull request:
- Bumps version to 0.9.1
- Removes development-only files from the gem version
- Allows pushing gem to rubygems (now repo not private)

Every time:

- [x] `npm run checks` script has been run without errors.
