### PR TITLE
Fix build (wip)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 node_js:
   - "6.9"
 install:
-  - gem uninstall bundler
+  - gem uninstall bundler --executables
   - gem install bundler --version '1.12'
   - yarn
   - npm install -g phantomjs-prebuilt casperjs backstopjs

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,9 @@ cache:
     - test/backstop_data
 language: node_js
 sudo: false
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
 node_js:
-  - "6.9"
+  - '6.9'
 install:
-  - gem uninstall bundler --executables
   - gem install bundler --version '1.12'
   - yarn
   - npm install -g phantomjs-prebuilt casperjs backstopjs


### PR DESCRIPTION
I just wanted to update the dependencies. But I can not install the  dependencies on my machine. node-sass refuses to build. Therefore, escape to the CI. Which is red 😞. I managed to get a few more step going, but the global dependencies now include code that will not run on node 6.9. So we have to update everything at once, without test-suite support (because the source of red is unclear: is it a dependency, or is it broken behavior).

Maybe this first step helps the next person 🙂 