### PR TITLE
291/flex-primary-breaks-with-lots-of-content

### DIFF
--- a/scss/bitstyles/layout/flex/_.scss
+++ b/scss/bitstyles/layout/flex/_.scss
@@ -2,6 +2,14 @@
   @include flex;
 }
 
+.#{$bitstyles-namespace}l-flex--wrap {
+  @include flex--wrap;
+}
+
 .#{$bitstyles-namespace}l-flex__primary {
   @include flex__primary;
+}
+
+.#{$bitstyles-namespace}l-flex__no-shrink {
+  @include flex__no-shrink;
 }

--- a/scss/bitstyles/layout/flex/flex.md
+++ b/scss/bitstyles/layout/flex/flex.md
@@ -2,4 +2,12 @@
 
 ## Basic flex layout
 
-Apply to an element to simply make its children share the available width e.g. a list of links in a menu. Make one of the children `.l-flex__primary` to make it take as much space as is available i.e. all the horizontal space left after its siblings take the minimum width they need.
+**Resize your viewport for these examples**
+
+Apply `.l-flex` to an element to make its children share the available width e.g. a list of links in a menu.
+
+Give it the `.l-flex--wrap` too, if the content is a list of elements with intrinsic or fixed size e.g. a list of buttons, icons, or images. The result will mean the elements are allowed to flow onto the next line when there’s not enough space for them to be adjacent (note this will not work with elements that take all available space, e.g. paragraphs of text).
+
+Make one of the children `.l-flex__primary` to make it take all available space left over. If there is no space left over, it becomes the same size as its siblings.
+
+Apply `.l-flex__no-shrink` to a flex-child to stop it being crushed when there is not enough space for it and its siblings. This is useful with elements which have intrinsic size (e.g. images, icons), or that need to remain fully-sized (e.g. buttons).

--- a/scss/bitstyles/layout/flex/flex.stories.js
+++ b/scss/bitstyles/layout/flex/flex.stories.js
@@ -17,3 +17,39 @@ export const flex = () => `
     <li>List item four</li>
   </ul>
 `;
+
+export const flexWithLongContent = () => `
+  <ul class="l-flex o-list-reset">
+    <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+    <li class="l-flex__primary u-background-color--secondary">Important content here - Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+    <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+    <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+  </ul>
+`;
+
+export const flexWrapWithLongContent = () => `
+  <ul class="l-flex l-flex--wrap o-list-reset">
+    <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+    <li class="l-flex__primary u-background-color--secondary">Important content here - Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+    <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+    <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+  </ul>
+`;
+
+export const flexWrapWithIntrinsicWidthContent = () => `
+  <ul class="l-flex l-flex--wrap o-list-reset">
+    <li><img src="https://placekitten.com/300/300" width="300" height="300" class="l-block" /></li>
+    <li class="l-flex__primary u-background-color--secondary">Important content here</li>
+    <li><img src="https://placekitten.com/300/300" width="300" height="300" class="l-block" /></li>
+    <li><img src="https://placekitten.com/300/300" width="300" height="300" class="l-block" /></li>
+  </ul>
+`;
+
+export const flexWithIntrinsicWidthContent = () => `
+  <ul class="l-flex o-list-reset">
+    <li><img src="https://placekitten.com/300/300" width="300" height="300" class="l-block" /></li>
+    <li class="l-flex__primary u-background-color--secondary">Important content here</li>
+    <li><img src="https://placekitten.com/300/300" width="300" height="300" class="l-block" /></li>
+    <li><img src="https://placekitten.com/300/300" width="300" height="300" class="l-block" /></li>
+  </ul>
+`;

--- a/scss/bitstyles/tools/_flex.scss
+++ b/scss/bitstyles/tools/_flex.scss
@@ -13,6 +13,14 @@
   align-items: stretch;
 }
 
+@mixin flex--wrap {
+  flex-wrap: wrap;
+}
+
 @mixin flex__primary {
-  flex: 1 0 auto;
+  flex-grow: 1;
+}
+
+@mixin flex__no-shrink {
+  flex-shrink: 0;
 }

--- a/test/css-stats.json
+++ b/test/css-stats.json
@@ -25,19 +25,19 @@
     "specificityIdAvg": 0,
     "specificityIdTotal": 0,
     "specificityClassAvg": 0.78,
-    "specificityClassTotal": 209,
-    "specificityTagAvg": 0.42,
+    "specificityClassTotal": 211,
+    "specificityTagAvg": 0.41,
     "specificityTagTotal": 112,
-    "selectors": 268,
-    "selectorLengthAvg": 1.037313432835821,
+    "selectors": 270,
+    "selectorLengthAvg": 1.037037037037037,
     "selectorsByAttribute": 25,
-    "selectorsByClass": 162,
+    "selectorsByClass": 164,
     "selectorsById": 0,
     "selectorsByPseudo": 44,
     "selectorsByTag": 90,
-    "length": 12435,
-    "rules": 201,
-    "declarations": 437
+    "length": 12462,
+    "rules": 203,
+    "declarations": 438
   },
   "offenders": {
     "oldPropertyPrefixes": [
@@ -45,28 +45,28 @@
       "html { -webkit-text-size-adjust: 100% } // was required by UC Browser for Android 11.4, iOS Safari 11 and earlier @ 2:108",
       "a { -webkit-text-decoration-skip: objects } // was required by iOS Safari 11, Safari NaN and earlier @ 2:438",
       "a { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 2:2798",
-      ".o-button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:6205",
-      ".o-link { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 2:8972"
+      ".o-button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:6232",
+      ".o-link { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 2:8999"
     ],
     "duplicatedProperties": [
       "abbr[title] {text-decoration: underline dotted} @ 2:606",
       "b, strong {font-weight: bolder} @ 2:668",
-      ".c-expander-body[aria-hidden=false] {max-height: 200vh} @ 2:11157"
+      ".c-expander-body[aria-hidden=false] {max-height: 200vh} @ 2:11184"
     ],
     "mediaQueries": [
       "@media screen and (min-width:45em) (5 rules) @ 2:2537",
       "@media screen and (min-width:64em) (1 rules) @ 2:3219",
       "@media screen and (min-width:45em) (12 rules) @ 2:3853",
-      "@media screen and (max-width:44.9375em) (1 rules) @ 2:6901",
-      "@media screen and (min-width:64em) (1 rules) @ 2:6987",
-      "@media screen and (min-width:45em) (5 rules) @ 2:7984",
-      "@media screen and (min-width:45em) (2 rules) @ 2:10288"
+      "@media screen and (max-width:44.9375em) (1 rules) @ 2:6928",
+      "@media screen and (min-width:64em) (1 rules) @ 2:7014",
+      "@media screen and (min-width:45em) (5 rules) @ 2:8011",
+      "@media screen and (min-width:45em) (2 rules) @ 2:10315"
     ],
     "importants": [
-      ".o-hidden {display: none!important} @ 2:6878",
-      ".o-hidden\\@small-only {display: none!important} @ 2:6963",
-      ".o-hidden\\@large {display: none!important} @ 2:7039",
-      ".o-visuallyhidden {position: absolute!important} @ 2:7180"
+      ".o-hidden {display: none!important} @ 2:6905",
+      ".o-hidden\\@small-only {display: none!important} @ 2:6990",
+      ".o-hidden\\@large {display: none!important} @ 2:7066",
+      ".o-visuallyhidden {position: absolute!important} @ 2:7207"
     ],
     "colors": [
       "#7f7f7f (8 times)",


### PR DESCRIPTION
Fixes #291 

- flex__primary now only sets flex-grow — the element will no longer cause the flex parent to overflow when it’s content is of unrestrained width
- Adds the __no-shrink child class, and the --wrap modifier
- Improves the examples, and the documentation