### PR TITLE
Missing `!default`s

### DIFF
--- a/scss/bitstyles/settings/_checkbox.scss
+++ b/scss/bitstyles/settings/_checkbox.scss
@@ -1,34 +1,34 @@
 //
 // Base styles ////////////////////////////////////////
-$bitstyles-checkbox-border-radius: spacing('xx-small');
+$bitstyles-checkbox-border-radius: spacing('xx-small') !default;
 
 //
 // Base colors ////////////////////////////////////////
-$bitstyles-checkbox-color: palette('text', 'light');
-$bitstyles-checkbox-background-color: palette('background');
-$bitstyles-checkbox-border: 2px solid;
+$bitstyles-checkbox-color: palette('text', 'light') !default;
+$bitstyles-checkbox-background-color: palette('background') !default;
+$bitstyles-checkbox-border: 2px solid !default;
 
 //
 // Hover colors ////////////////////////////////////////
-$bitstyles-checkbox-color-hover: palette('primary');
-$bitstyles-checkbox-background-color-hover: palette('background');
-$bitstyles-checkbox-border-hover: 2px solid;
+$bitstyles-checkbox-color-hover: palette('primary') !default;
+$bitstyles-checkbox-background-color-hover: palette('background') !default;
+$bitstyles-checkbox-border-hover: 2px solid !default;
 
 //
 // Checked colors ////////////////////////////////////////
-$bitstyles-checkbox-color-checked: palette('background');
-$bitstyles-checkbox-background-color-checked: palette('primary');
-$bitstyles-checkbox-border-checked: 2px solid palette('primary');
-$bitstyles-checkbox-background-image-checked: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='#ffffff' d='m83.07 11.71-44.41 44.59-21.73-21.81-15.93 15.99 37.65 37.81 60.35-60.59z'/%3E%3C/svg%3E");
+$bitstyles-checkbox-color-checked: palette('background') !default;
+$bitstyles-checkbox-background-color-checked: palette('primary') !default;
+$bitstyles-checkbox-border-checked: 2px solid palette('primary') !default;
+$bitstyles-checkbox-background-image-checked: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='#ffffff' d='m83.07 11.71-44.41 44.59-21.73-21.81-15.93 15.99 37.65 37.81 60.35-60.59z'/%3E%3C/svg%3E") !default;
 
 //
 // Disabled colors ////////////////////////////////////////
-$bitstyles-checkbox-color-disabled: palette('text', 'light');
-$bitstyles-checkbox-background-color-disabled: palette('background', 'dark');
-$bitstyles-checkbox-border-disabled: 2px solid;
+$bitstyles-checkbox-color-disabled: palette('text', 'light') !default;
+$bitstyles-checkbox-background-color-disabled: palette('background', 'dark') !default;
+$bitstyles-checkbox-border-disabled: 2px solid !default;
 
 //
 // Disabled-checked colors ////////////////////////////////////////
-$bitstyles-checkbox-color-disabled-checked: palette('text', 'light');
-$bitstyles-checkbox-background-color-disabled-checked: palette('background', 'dark');
-$bitstyles-checkbox-border-disabled-checked: 2px solid palette('background', 'dark');
+$bitstyles-checkbox-color-disabled-checked: palette('text', 'light') !default;
+$bitstyles-checkbox-background-color-disabled-checked: palette('background', 'dark') !default;
+$bitstyles-checkbox-border-disabled-checked: 2px solid palette('background', 'dark') !default;

--- a/scss/bitstyles/settings/_figure.scss
+++ b/scss/bitstyles/settings/_figure.scss
@@ -1,2 +1,2 @@
-$bitstyles-figure-font-style: italic;
-$bitstyles-figure-color: palette('text', 'light');
+$bitstyles-figure-font-style: italic !default;
+$bitstyles-figure-color: palette('text', 'light') !default;

--- a/scss/bitstyles/settings/_radio.scss
+++ b/scss/bitstyles/settings/_radio.scss
@@ -1,33 +1,33 @@
 //
 // Base styles ////////////////////////////////////////
-$bitstyles-radio-border-radius: $bitstyles-border-radius-round;
+$bitstyles-radio-border-radius: $bitstyles-border-radius-round !default;
 
 //
 // Base colors ////////////////////////////////////////
-$bitstyles-radio-color: palette('text', 'light');
-$bitstyles-radio-background-color: palette('background');
-$bitstyles-radio-border: 2px solid;
+$bitstyles-radio-color: palette('text', 'light') !default;
+$bitstyles-radio-background-color: palette('background') !default;
+$bitstyles-radio-border: 2px solid !default;
 
 //
 // Hover colors ////////////////////////////////////////
-$bitstyles-radio-color-hover: palette('primary');
-$bitstyles-radio-background-color-hover: palette('background');
-$bitstyles-radio-border-hover: 2px solid;
+$bitstyles-radio-color-hover: palette('primary') !default;
+$bitstyles-radio-background-color-hover: palette('background') !default;
+$bitstyles-radio-border-hover: 2px solid !default;
 
 //
 // Checked colors ////////////////////////////////////////
-$bitstyles-radio-color-checked: palette('primary');
-$bitstyles-radio-background-color-checked: palette('background');
-$bitstyles-radio-border-checked: 2px solid palette('primary');
+$bitstyles-radio-color-checked: palette('primary') !default;
+$bitstyles-radio-background-color-checked: palette('background') !default;
+$bitstyles-radio-border-checked: 2px solid palette('primary') !default;
 
 //
 // Disabled colors ////////////////////////////////////////
-$bitstyles-radio-color-disabled: palette('text', 'light');
-$bitstyles-radio-background-color-disabled: palette('background', 'dark');
-$bitstyles-radio-border-disabled: 2px solid;
+$bitstyles-radio-color-disabled: palette('text', 'light') !default;
+$bitstyles-radio-background-color-disabled: palette('background', 'dark') !default;
+$bitstyles-radio-border-disabled: 2px solid !default;
 
 //
 // Disabled-checked colors ////////////////////////////////////////
-$bitstyles-radio-color-disabled-checked: palette('text', 'light');
-$bitstyles-radio-background-color-disabled-checked: palette('background', 'dark');
-$bitstyles-radio-border-disabled-checked: 2px solid;
+$bitstyles-radio-color-disabled-checked: palette('text', 'light') !default;
+$bitstyles-radio-background-color-disabled-checked: palette('background', 'dark') !default;
+$bitstyles-radio-border-disabled-checked: 2px solid !default;


### PR DESCRIPTION
Adds missing `!default` to all the Sass variables that were missing them, to allow overriding by library consumers

Fixes #335 