### PR TITLE
[#336] Add html height

### DIFF
--- a/scss/bitstyles/generic/_box-sizing.scss
+++ b/scss/bitstyles/generic/_box-sizing.scss
@@ -3,7 +3,12 @@
 
 /* stylelint-disable selector-max-type */
 html {
+  height: 100%;
   box-sizing: border-box;
+}
+
+body {
+  min-height: 100%;
 }
 
 *,


### PR DESCRIPTION
Adds a height to HTML, and a min-height to body, to ensure the body element and its background color always fill the screen

Fixes #336