### PR TITLE
[#340] add colors for input invalid

### DIFF
--- a/scss/bitstyles/base/forms/forms.stories.js
+++ b/scss/bitstyles/base/forms/forms.stories.js
@@ -47,6 +47,13 @@ export const inputTextWithLabelDisabled = () => `
   </label>
 `;
 
+export const inputTextWithLabelInvalid = () => `
+  <label for="input_1">
+    <span>This is labeling text for an invalid input (once you enter invalid data)</span>
+    <input type="number" id="input_1" placeholder="Enter some text into this number input" />
+  </label>
+`;
+
 export const inputCheckboxWithLabel = () => `
   <label for="input_1" class="l-flex l-flex--align-center">
     <input type="checkbox" id="input_1" />

--- a/scss/bitstyles/settings/_global.color-palette.scss
+++ b/scss/bitstyles/settings/_global.color-palette.scss
@@ -3,7 +3,7 @@ $bitstyles-color-secondary: $bitstyles-color-gray-20 !default;
 $bitstyles-color-text: $bitstyles-color-gray-80 !default;
 $bitstyles-color-background: $bitstyles-color-white !default;
 $bitstyles-color-positive: #0f0 !default;
-$bitstyles-color-negative: #f00 !default;
+$bitstyles-color-negative: #fe881e !default;
 $bitstyles-color-tone-factor: 10% !default;
 
 // Colour palette. Each colour has variants (each needs at least the `base`), defined

--- a/scss/bitstyles/settings/_input.scss
+++ b/scss/bitstyles/settings/_input.scss
@@ -33,3 +33,9 @@ $bitstyles-input-background-active: $bitstyles-color-white !default;
 $bitstyles-input-background-disabled: palette('background', 'dark') !default;
 $bitstyles-input-color-disabled: palette('text') !default;
 $bitstyles-input-border-disabled: 2px solid palette('text', 'light') !default;
+
+//
+// Invalid colors ////////////////////////////////////////
+
+$input-border-color-invalid: palette('warning') !default;
+$input-background-color-invalid: $bitstyles-color-white !default;

--- a/scss/bitstyles/settings/_input.scss
+++ b/scss/bitstyles/settings/_input.scss
@@ -37,5 +37,6 @@ $bitstyles-input-border-disabled: 2px solid palette('text', 'light') !default;
 //
 // Invalid colors ////////////////////////////////////////
 
-$input-border-color-invalid: palette('warning') !default;
+$input-color-invalid: palette('error') !default;
 $input-background-color-invalid: $bitstyles-color-white !default;
+$input-border-color-invalid: palette('error') !default;

--- a/scss/bitstyles/tools/_input.scss
+++ b/scss/bitstyles/tools/_input.scss
@@ -48,6 +48,11 @@
     border: $bitstyles-input-border-active;
     outline: none;
   }
+
+  &:invalid {
+    background-color: $input-background-color-invalid;
+    border-color: $input-border-color-invalid;
+  }
 }
 
 @mixin input-placeholder {

--- a/scss/bitstyles/tools/_input.scss
+++ b/scss/bitstyles/tools/_input.scss
@@ -50,6 +50,7 @@
   }
 
   &:invalid {
+    color: $input-color-invalid;
     background-color: $input-background-color-invalid;
     border-color: $input-border-color-invalid;
   }


### PR DESCRIPTION
Fixes #340 

Adds styles for invalid inputs:

- Updates `error` color to be less angry, more humane
- Adds text-color, border-colour & background-color variables for invalid inputs
- Adds a story to illustrate an invalid input (needs user input, as the browser will not render it invalid)

<img width="1248" alt="Screenshot 2020-07-15 at 17 53 48" src="https://user-images.githubusercontent.com/2479422/87567087-24b5b800-c6c4-11ea-9758-030019dc47a1.png">
