### PR TITLE
[#351] Shorter size names

### DIFF
--- a/scss/bitstyles/base/typography/_.scss
+++ b/scss/bitstyles/base/typography/_.scss
@@ -19,7 +19,7 @@ h6 {
 @include generate-font-sizes('', (html, h1, h2, h3, h4, h5, h6));
 
 p {
-  margin: 0 0 spacing('base');
+  margin: 0 0 spacing('m');
 }
 
 address {

--- a/scss/bitstyles/generic/_normalize.scss
+++ b/scss/bitstyles/generic/_normalize.scss
@@ -173,7 +173,7 @@ button:-moz-focusring,
  */
 
 fieldset {
-  padding: spacing('base');
+  padding: spacing('m');
 }
 
 /**

--- a/scss/bitstyles/layout/grid/grid.md
+++ b/scss/bitstyles/layout/grid/grid.md
@@ -22,8 +22,8 @@ This means e.g. they cannot change from being 3-column on larger screens, to one
 
 ### The grid system can also be used responsively — setting different widths for an element based on the viewport size
 
-To do this, append the name of a breakpoint to the width class to have it activate only at that breakpoint e.g. `.l-width--12-of-12.l-width--6-of-12@medium` to create an element that’s fullwidth for all screens, then becomes half width for `medium`-screens and larger.
+To do this, append the name of a breakpoint to the width class to have it activate only at that breakpoint e.g. `.l-width--12-of-12.l-width--6-of-12@m` to create an element that’s fullwidth for all viewports, then becomes half width for `m`-sized viewports and larger.
 
 Multiple l-width--item/breakpoints combinations can be used to define a grid item’s width at several breakpoints (for all the breakpoints defined in the `$bitstyles-widths-breakpoints` Sass list).
 
-This is commonly used to set a default mobile-first width of `.l-width--12-of-12` and a larger-screen width of e.g. `.l-width--4-of-12@medium` for a three-column layout that becomes a single-column stack on small screens.
+This is commonly used to set a default mobile-first width of `.l-width--12-of-12` and a larger-screen width of e.g. `.l-width--4-of-12@m` for a three-column layout that becomes a single-column stack on small viewports.

--- a/scss/bitstyles/layout/grid/grid.stories.js
+++ b/scss/bitstyles/layout/grid/grid.stories.js
@@ -97,20 +97,20 @@ export const grid = () => `
 
 export const gridResponsive = () => `
   <ul class="l-grid">
-    <li class="l-grid__item l-width--6-of-12 l-width--4-of-12@medium">
-      <div class="u-background-color--secondary">6-of-12 / 4-of-12@medium</div>
+    <li class="l-grid__item l-width--6-of-12 l-width--4-of-12@m">
+      <div class="u-background-color--secondary">6-of-12 / 4-of-12@m</div>
     </li><!--
-    --><li class="l-grid__item l-width--6-of-12 l-width--4-of-12@medium">
-      <div>6-of-12 / 4-of-12@medium</div>
+    --><li class="l-grid__item l-width--6-of-12 l-width--4-of-12@m">
+      <div>6-of-12 / 4-of-12@m</div>
     </li><!--
-    --><li class="l-grid__item l-width--6-of-12 l-width--4-of-12@medium">
-      <div class="u-background-color--secondary">6-of-12 / 4-of-12@medium</div>
+    --><li class="l-grid__item l-width--6-of-12 l-width--4-of-12@m">
+      <div class="u-background-color--secondary">6-of-12 / 4-of-12@m</div>
     </li><!--
-    --><li class="l-grid__item l-width--12-of-12 l-width--6-of-12@medium">
-      <div class="u-background-color--secondary">12-of-12 / 6-of-12@medium</div>
+    --><li class="l-grid__item l-width--12-of-12 l-width--6-of-12@m">
+      <div class="u-background-color--secondary">12-of-12 / 6-of-12@m</div>
     </li><!--
-    --><li class="l-grid__item l-width--12-of-12 l-width--6-of-12@medium">
-      <div>12-of-12 / 6-of-12@medium</div>
+    --><li class="l-grid__item l-width--12-of-12 l-width--6-of-12@m">
+      <div>12-of-12 / 6-of-12@m</div>
     </li>
   </ul>
 `;

--- a/scss/bitstyles/layout/width/width.md
+++ b/scss/bitstyles/layout/width/width.md
@@ -9,9 +9,9 @@ Set the `$bitstyles-widths` variable to define how many columns you need. To cre
 - `.l-width--1-of-10` … `.l-width--10-of-10`
 - `.l-width--1-of-12` … `.l-width--12-of-12`.
 
-If you define the `$bitstyles-widths-breakpoints` Sass list to contain the names of one or more breakpoints (it defaults to just `medium`), widths will also be created that apply only at those breakpoints:
+If you define the `$bitstyles-widths-breakpoints` Sass list to contain the names of one or more breakpoints (it defaults to just `m`), widths will also be created that apply only at those breakpoints:
 
-`.l-width--1-of-12@medium`…
+`.l-width--1-of-12@m`…
 
 This allows you to create an element that is displayed at different sizes based on viewport size. See the section on responsive grid systems for an example of the most common uses for this.
 

--- a/scss/bitstyles/objects/icon/icon.md
+++ b/scss/bitstyles/objects/icon/icon.md
@@ -8,9 +8,9 @@ Set icon sizes by overiding the `$bitstyles-icon-sizes` list (see `settings/_ico
 
 ```scss
 $bitstyles-icon-sizes: (
-  'small' 2rem,
-  'medium' 4rem,
-  'large' 8rem
+  's' 2rem,
+  'm' 4rem,
+  'l' 8rem
 );
 ```
 

--- a/scss/bitstyles/objects/icon/icon.stories.js
+++ b/scss/bitstyles/objects/icon/icon.stories.js
@@ -15,14 +15,20 @@ export const icon = () => `
   </svg>
 `;
 
-export const iconLarge = () => `
-  <svg class="o-icon o-icon--large" viewBox="0 0 100 100" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+export const iconSmall = () => `
+  <svg class="o-icon o-icon--s" viewBox="0 0 100 100" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
     <path d="m55.94 1.03v43h43v12h-43v43h-12v-43h-43v-12h43v-43z" fill-rule="evenodd"/>
   </svg>
 `;
 
 export const iconMedium = () => `
-  <svg class="o-icon o-icon--medium" viewBox="0 0 100 100" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+  <svg class="o-icon o-icon--m" viewBox="0 0 100 100" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+    <path d="m55.94 1.03v43h43v12h-43v43h-12v-43h-43v-12h43v-43z" fill-rule="evenodd"/>
+  </svg>
+`;
+
+export const iconLarge = () => `
+  <svg class="o-icon o-icon--l" viewBox="0 0 100 100" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
     <path d="m55.94 1.03v43h43v12h-43v43h-12v-43h-43v-12h43v-43z" fill-rule="evenodd"/>
   </svg>
 `;

--- a/scss/bitstyles/settings/_button--icon.scss
+++ b/scss/bitstyles/settings/_button--icon.scss
@@ -1,4 +1,4 @@
-$bitstyles-button-icon-padding: 1rem !default;
+$bitstyles-button-icon-padding: spacing('m') !default;
 $bitstyles-button-icon-color: $bitstyles-color-white !default;
 $bitstyles-button-icon-background-color: $bitstyles-color-black !default;
 $bitstyles-button-icon-border: 0 !default;

--- a/scss/bitstyles/settings/_button.scss
+++ b/scss/bitstyles/settings/_button.scss
@@ -1,13 +1,13 @@
 //
 // Base styles ////////////////////////////////////////
 
-$bitstyles-button-padding-vertical: spacing('small') !default;
-$bitstyles-button-padding-horizontal: spacing('base') !default;
-$bitstyles-button-border-radius: spacing('xx-small') !default;
+$bitstyles-button-padding-vertical: spacing('s') !default;
+$bitstyles-button-padding-horizontal: spacing('m') !default;
+$bitstyles-button-border-radius: spacing('xxs') !default;
 $bitstyles-button-transition:
   color $bitstyles-transition-duration $bitstyles-transition-easing,
   background-color $bitstyles-transition-duration $bitstyles-transition-easing !default;
-$bitstyles-button-icon-spacing: spacing('small') !default;
+$bitstyles-button-icon-spacing: spacing('s') !default;
 
 //
 // Base colors ////////////////////////////////////////

--- a/scss/bitstyles/settings/_checkbox.scss
+++ b/scss/bitstyles/settings/_checkbox.scss
@@ -1,6 +1,6 @@
 //
 // Base styles ////////////////////////////////////////
-$bitstyles-checkbox-border-radius: spacing('xx-small') !default;
+$bitstyles-checkbox-border-radius: spacing('xxs') !default;
 
 //
 // Base colors ////////////////////////////////////////

--- a/scss/bitstyles/settings/_content.scss
+++ b/scss/bitstyles/settings/_content.scss
@@ -1,4 +1,4 @@
 $bitstyles-content-max-width: 45rem !default;
 $bitstyles-content-horizontal-padding: spacing('m') !default;
 $bitstyles-content-horizontal-padding-large: spacing('l') !default;
-$bitstyles-content-large-breakpoint: 'large' !default; // The breakpoint at which we implement the above horizontal-padding value.
+$bitstyles-content-large-breakpoint: 'l' !default; // The breakpoint at which we implement the above horizontal-padding value.

--- a/scss/bitstyles/settings/_content.scss
+++ b/scss/bitstyles/settings/_content.scss
@@ -1,4 +1,4 @@
 $bitstyles-content-max-width: 45rem !default;
-$bitstyles-content-horizontal-padding: spacing('base') !default;
-$bitstyles-content-horizontal-padding-large: spacing('large') !default;
+$bitstyles-content-horizontal-padding: spacing('m') !default;
+$bitstyles-content-horizontal-padding-large: spacing('l') !default;
 $bitstyles-content-large-breakpoint: 'large' !default; // The breakpoint at which we implement the above horizontal-padding value.

--- a/scss/bitstyles/settings/_global.breakpoints.scss
+++ b/scss/bitstyles/settings/_global.breakpoints.scss
@@ -3,10 +3,10 @@ $bitstyles-breakpoint-small-medium-boundary:     45em !default;
 $bitstyles-breakpoint-medium-large-boundary:     64em !default;
 
 $bitstyles-breakpoints: (
-  'small-only':          'screen and (max-width: #{$bitstyles-breakpoint-small-medium-boundary - $bitstyles-breakpoint-boundary-width})',
-  'medium':              'screen and (min-width: #{$bitstyles-breakpoint-small-medium-boundary})',
-  'large':               'screen and (min-width: #{$bitstyles-breakpoint-medium-large-boundary})',
-  'hidpi':               '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)',
-  'landscape':           'all and (orientation:landscape)',
-  'portrait':            'all and (orientation:portrait)'
+  's':                  'screen and (max-width: #{$bitstyles-breakpoint-small-medium-boundary - $bitstyles-breakpoint-boundary-width})',
+  'm':                  'screen and (min-width: #{$bitstyles-breakpoint-small-medium-boundary})',
+  'l':                  'screen and (min-width: #{$bitstyles-breakpoint-medium-large-boundary})',
+  'hidpi':              '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)',
+  'landscape':          'all and (orientation:landscape)',
+  'portrait':           'all and (orientation:portrait)'
 ) !default;

--- a/scss/bitstyles/settings/_global.layout.scss
+++ b/scss/bitstyles/settings/_global.layout.scss
@@ -1,13 +1,13 @@
 $bitstyles-global-z: topbar !default;
 $bitstyles-border-radius-round: 9999rem !default;
 
-$bitstyles-spacing: 1rem !default;
+$bitstyles-spacing-base: 1rem !default;
 $bitstyles-spacing-sizes: (
-  'base': $bitstyles-spacing,
-  'xx-small': $bitstyles-spacing / 8,
-  'x-small': $bitstyles-spacing / 4,
-  'small': $bitstyles-spacing / 2,
-  'large': $bitstyles-spacing * 2,
-  'x-large': $bitstyles-spacing * 4,
-  'xx-large': $bitstyles-spacing * 8
+  'xxs': $bitstyles-spacing-base / 8,
+  'xs': $bitstyles-spacing-base / 4,
+  's': $bitstyles-spacing-base / 2,
+  'm': $bitstyles-spacing-base,
+  'l': $bitstyles-spacing-base * 2,
+  'xl': $bitstyles-spacing-base * 4,
+  'xxl': $bitstyles-spacing-base * 8
 ) !default;

--- a/scss/bitstyles/settings/_global.typography.scss
+++ b/scss/bitstyles/settings/_global.typography.scss
@@ -21,7 +21,7 @@ $bitstyles-font-sizes: (
     'h5': $bitstyles-font-size-base-small,
     'h6': $bitstyles-font-size-base-small
   ),
-  'medium': (
+  'm': (
     'html': $bitstyles-font-size-base,
     'h0': 86px,
     'h1': 40px,

--- a/scss/bitstyles/settings/_grid.scss
+++ b/scss/bitstyles/settings/_grid.scss
@@ -1,1 +1,1 @@
-$bitstyles-grid-gutter: $bitstyles-spacing !default;
+$bitstyles-grid-gutter: spacing('m') !default;

--- a/scss/bitstyles/settings/_hidden.scss
+++ b/scss/bitstyles/settings/_hidden.scss
@@ -1,1 +1,1 @@
-$bitstyles-hidden-breakpoints: (small-only, large) !default;
+$bitstyles-hidden-breakpoints: ('s', 'l') !default;

--- a/scss/bitstyles/settings/_icon.scss
+++ b/scss/bitstyles/settings/_icon.scss
@@ -1,5 +1,5 @@
 $bitstyles-icon-sizes: (
-  'small':     spacing('m'),
-  'medium':    spacing('m') * 2,
-  'large':     spacing('m') * 3
+  's':     spacing('m'),
+  'm':    spacing('m') * 2,
+  'l':     spacing('m') * 3
 ) !default;

--- a/scss/bitstyles/settings/_icon.scss
+++ b/scss/bitstyles/settings/_icon.scss
@@ -1,5 +1,5 @@
 $bitstyles-icon-sizes: (
-  'small':     1rem,
-  'medium':    2rem,
-  'large':     3rem
+  'small':     spacing('m'),
+  'medium':    spacing('m') * 2,
+  'large':     spacing('m') * 3
 ) !default;

--- a/scss/bitstyles/settings/_input.scss
+++ b/scss/bitstyles/settings/_input.scss
@@ -1,10 +1,10 @@
 //
 // Base styles ////////////////////////////////////////
 
-$bitstyles-input-padding: spacing('small') !default;
+$bitstyles-input-padding: spacing('s') !default;
 $bitstyles-input-border-radius: 0 !default;
 $bitstyles-input-placeholder-color: $bitstyles-color-gray-50 !default;
-$bitstyles-input-checkbox-size: spacing('base') !default;
+$bitstyles-input-checkbox-size: spacing('m') !default;
 
 //
 // Base colors ////////////////////////////////////////

--- a/scss/bitstyles/settings/_modal.scss
+++ b/scss/bitstyles/settings/_modal.scss
@@ -1,4 +1,4 @@
-$bitstyles-modal-padding: spacing('base') !default;
+$bitstyles-modal-padding: spacing('m') !default;
 $bitstyles-modal-background-color: #d9d9d9 !default;
 $bitstyles-modal-overlay-color: rgba($bitstyles-color-black, 0.7) !default;
 $bitstyles-modal-transition-easing: ease-in-out !default;

--- a/scss/bitstyles/settings/_modal.scss
+++ b/scss/bitstyles/settings/_modal.scss
@@ -7,4 +7,4 @@ $bitstyles-modal-transition-duration-smallscreen: 0.25s !default;
 $bitstyles-modal-transition-delay: 0.05s !default;
 $bitstyles-modal-will-change: opacity, transform, visibility !default;
 $bitstyles-modal-border-radius: 0 !default;
-$bitstyles-modal-breakpoint: medium !default;
+$bitstyles-modal-breakpoint: 'm' !default;

--- a/scss/bitstyles/settings/_select.scss
+++ b/scss/bitstyles/settings/_select.scss
@@ -1,7 +1,7 @@
 //
 // Base styles ////////////////////////////////////////
-$bitstyles-select-padding-vertical: spacing('small') !default;
-$bitstyles-select-padding-horizontal: spacing('base') !default;
+$bitstyles-select-padding-vertical: spacing('s') !default;
+$bitstyles-select-padding-horizontal: spacing('m') !default;
 $bitstyles-select-border-radius: $bitstyles-border-radius-round !default;
 
 //

--- a/scss/bitstyles/settings/_topbar.scss
+++ b/scss/bitstyles/settings/_topbar.scss
@@ -1,4 +1,4 @@
-$bitstyles-topbar-vertical-padding: $bitstyles-spacing / 2 !default;
-$bitstyles-topbar-horizontal-padding: $bitstyles-spacing !default;
+$bitstyles-topbar-vertical-padding: spacing('s') !default;
+$bitstyles-topbar-horizontal-padding: spacing('m') !default;
 $bitstyles-topbar-color: inherit !default;
 $bitstyles-topbar-background-color: $bitstyles-color-white !default;

--- a/scss/bitstyles/settings/_width.scss
+++ b/scss/bitstyles/settings/_width.scss
@@ -8,5 +8,5 @@ $bitstyles-widths: (12) !default;
 // breakpoint.
 // If this is empty, no responsive breakpoints will be generated.
 $bitstyles-widths-breakpoints: (
-  'medium'
+  'm'
 ) !default;

--- a/scss/bitstyles/tools/_fieldset.scss
+++ b/scss/bitstyles/tools/_fieldset.scss
@@ -5,7 +5,7 @@
 }
 
 @mixin legend {
-  padding: 0 spacing('small');
+  padding: 0 spacing('s');
   color: $bitstyles-legend-color;
   background-color: $bitstyles-legend-background-color;
   border: $bitstyles-legend-border;

--- a/scss/bitstyles/tools/_media.scss
+++ b/scss/bitstyles/tools/_media.scss
@@ -17,5 +17,5 @@
 
 @mixin media__feature {
   float: left;
-  margin-right: spacing('base');
+  margin-right: spacing('m');
 }

--- a/scss/bitstyles/tools/_spacing.scss
+++ b/scss/bitstyles/tools/_spacing.scss
@@ -2,10 +2,10 @@
 //
 // **Returns requested size/length from the global `$bitstyles-spacing-sizes` map**.
 //
-// e.g. `padding: spacing('small');`
+// e.g. `padding: spacing('s');`
 //
-// Default naming of sizes: `base`, `small`, `large` (suggested: `x-small`,
-// `xx-small` etc. for further variants)
+// Default naming of sizes: `s`, `m`, `l` (suggested: `xs`,
+// `xxs` etc. for further variants)
 //
 // @param {String} $spacing-size  Name of the standardised size required, as defined in the map `$bitstyles-spacing-sizes`.
 //

--- a/scss/bitstyles/tools/_typography.scss
+++ b/scss/bitstyles/tools/_typography.scss
@@ -46,7 +46,7 @@
 //     'h5': $bitstyles-font-size-base-small,
 //     'h6': $bitstyles-font-size-base-small
 //   ),
-//   'medium-and-up': (
+//   'm': (
 //     'html': $bitstyles-font-size-base,
 //     'h0': 86px,
 //     'h1': 40px,

--- a/scss/bitstyles/tools/_typography.scss
+++ b/scss/bitstyles/tools/_typography.scss
@@ -4,7 +4,7 @@
 //
 
 @mixin generic-heading {
-  margin: 0 0 spacing('base');
+  margin: 0 0 spacing('m');
   font-family: $bitstyles-font-family-header;
   font-weight: $bitstyles-font-weight-bold;
   text-rendering: optimizeLegibility;

--- a/scss/bitstyles/utilities/hidden/hidden.stories.js
+++ b/scss/bitstyles/utilities/hidden/hidden.stories.js
@@ -17,12 +17,18 @@ export const hidden = () => `
 
 export const hiddenAtSmallOnly = () => `
   <p>Paragraph 1 content</p>
-  <p class="u-hidden@small-only">Paragraph 2 content</p>
+  <p class="u-hidden@s">Paragraph 2 content</p>
+  <p>Paragraph 3 content</p>
+`;
+
+export const hiddenAtMedium = () => `
+  <p>Paragraph 1 content</p>
+  <p class="u-hidden@s">Paragraph 2 content</p>
   <p>Paragraph 3 content</p>
 `;
 
 export const hiddenAtLarge = () => `
   <p>Paragraph 1 content</p>
-  <p class="u-hidden@large">Paragraph 2 content</p>
+  <p class="u-hidden@l">Paragraph 2 content</p>
   <p>Paragraph 3 content</p>
 `;

--- a/scss/bitstyles/utilities/margin/_.scss
+++ b/scss/bitstyles/utilities/margin/_.scss
@@ -1,9 +1,9 @@
 @each $position in (left, top, right, bottom) {
   .#{$bitstyles-namespace}u-margin--#{$position} {
-    margin-#{$position}: $bitstyles-spacing;
+    margin-#{$position}: spacing('m');
   }
 }
 
 .#{$bitstyles-namespace}u-margin {
-  margin: $bitstyles-spacing;
+  margin: spacing('m');
 }

--- a/scss/bitstyles/utilities/padding/_.scss
+++ b/scss/bitstyles/utilities/padding/_.scss
@@ -1,9 +1,9 @@
 @each $position in (left, top, right, bottom) {
   .#{$bitstyles-namespace}u-padding--#{$position} {
-    padding-#{$position}: $bitstyles-spacing;
+    padding-#{$position}: spacing('m');
   }
 }
 
 .#{$bitstyles-namespace}u-padding {
-  padding: $bitstyles-spacing;
+  padding: spacing('m');
 }

--- a/test/css-stats.json
+++ b/test/css-stats.json
@@ -8,7 +8,7 @@
     "comments": 1,
     "commentsLength": 72,
     "complexSelectors": 0,
-    "duplicatedSelectors": 4,
+    "duplicatedSelectors": 5,
     "duplicatedProperties": 2,
     "emptyRules": 0,
     "expressions": 0,
@@ -19,55 +19,56 @@
     "notMinified": 1,
     "multiClassesSelectors": 0,
     "parsingErrors": 0,
-    "oldPropertyPrefixes": 8,
+    "oldPropertyPrefixes": 9,
     "propertyResets": 0,
     "qualifiedSelectors": 0,
     "specificityIdAvg": 0,
     "specificityIdTotal": 0,
     "specificityClassAvg": 0.99,
-    "specificityClassTotal": 373,
+    "specificityClassTotal": 375,
     "specificityTagAvg": 0.36,
     "specificityTagTotal": 135,
-    "selectors": 375,
-    "selectorLengthAvg": 1.024,
-    "selectorsByAttribute": 118,
+    "selectors": 377,
+    "selectorLengthAvg": 1.023872679045093,
+    "selectorsByAttribute": 120,
     "selectorsByClass": 153,
     "selectorsById": 0,
     "selectorsByPseudo": 124,
     "selectorsByTag": 113,
-    "length": 19468,
-    "rules": 215,
-    "declarations": 504
+    "length": 19395,
+    "rules": 216,
+    "declarations": 515
   },
   "offenders": {
     "duplicatedProperties": [
       "abbr[title] {text-decoration: underline dotted} @ 2:277",
-      ".c-expander-body[aria-hidden=false] {max-height: 200vh} @ 2:17756"
+      ".c-expander-body[aria-hidden=false] {max-height: 200vh} @ 2:17696"
     ],
     "oldPropertyPrefixes": [
       "html { -webkit-text-size-adjust: 100% } // was required by UC Browser for Android 11.4, iOS Safari 11 and earlier @ 2:1876",
       "a { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 2:2529",
       "[type=button], [type=reset], [type=submit], button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:5742",
-      ".l-topbar { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:11999",
-      ".o-button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:13684",
-      ".o-link { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 2:15578",
-      ".c-modal__overlay { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:16084",
-      ".c-modal__content { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:16628"
+      "[type=checkbox], [type=radio] { -moz-appearance: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:6780",
+      ".l-topbar { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:11939",
+      ".o-button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:13624",
+      ".o-link { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 2:15518",
+      ".c-modal__overlay { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:16024",
+      ".c-modal__content { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:16568"
     ],
     "mediaQueries": [
       "@media screen and (min-width:45em) (7 rules) @ 2:2166",
       "@media screen and (min-width:64em) (1 rules) @ 2:10664",
       "@media screen and (min-width:45em) (12 rules) @ 2:11298",
-      "@media screen and (min-width:45em) (7 rules) @ 2:15210",
-      "@media screen and (min-width:45em) (2 rules) @ 2:16887",
-      "@media screen and (max-width:44.9375em) (1 rules) @ 2:19210",
-      "@media screen and (min-width:64em) (1 rules) @ 2:19296"
+      "@media screen and (min-width:45em) (7 rules) @ 2:15150",
+      "@media screen and (min-width:45em) (2 rules) @ 2:16827",
+      "@media screen and (max-width:44.9375em) (1 rules) @ 2:19150",
+      "@media screen and (min-width:64em) (1 rules) @ 2:19227"
     ],
     "importants": [
-      ".u-visuallyhidden {position: absolute!important} @ 2:18993",
-      ".u-hidden {display: none!important} @ 2:19187",
-      ".u-hidden\\@small-only {display: none!important} @ 2:19272",
-      ".u-hidden\\@large {display: none!important} @ 2:19348"
+      ".u-visuallyhidden {position: absolute!important} @ 2:18933",
+      ".u-hidden {display: none!important} @ 2:19127",
+      ".u-hidden\\@s {display: none!important} @ 2:19203",
+      ".u-hidden\\@l {display: none!important} @ 2:19275"
     ],
     "colors": [
       "#ffffff (14 times)",
@@ -90,7 +91,8 @@
       "html (3 times)",
       "[type=button], [type=reset], [type=submit], button (2 times)",
       "fieldset (2 times)",
-      "legend (2 times)"
+      "legend (2 times)",
+      "[type=checkbox], [type=radio] (2 times)"
     ]
   }
 }

--- a/test/css-stats.json
+++ b/test/css-stats.json
@@ -35,14 +35,14 @@
     "selectorsById": 0,
     "selectorsByPseudo": 124,
     "selectorsByTag": 113,
-    "length": 19395,
+    "length": 19382,
     "rules": 216,
     "declarations": 515
   },
   "offenders": {
     "duplicatedProperties": [
       "abbr[title] {text-decoration: underline dotted} @ 2:277",
-      ".c-expander-body[aria-hidden=false] {max-height: 200vh} @ 2:17696"
+      ".c-expander-body[aria-hidden=false] {max-height: 200vh} @ 2:17683"
     ],
     "oldPropertyPrefixes": [
       "html { -webkit-text-size-adjust: 100% } // was required by UC Browser for Android 11.4, iOS Safari 11 and earlier @ 2:1876",
@@ -50,25 +50,25 @@
       "[type=button], [type=reset], [type=submit], button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:5742",
       "[type=checkbox], [type=radio] { -moz-appearance: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:6780",
       ".l-topbar { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:11939",
-      ".o-button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:13624",
-      ".o-link { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 2:15518",
-      ".c-modal__overlay { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:16024",
-      ".c-modal__content { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:16568"
+      ".o-button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 2:13611",
+      ".o-link { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 2:15505",
+      ".c-modal__overlay { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:16011",
+      ".c-modal__content { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari 11 and earlier @ 2:16555"
     ],
     "mediaQueries": [
       "@media screen and (min-width:45em) (7 rules) @ 2:2166",
       "@media screen and (min-width:64em) (1 rules) @ 2:10664",
       "@media screen and (min-width:45em) (12 rules) @ 2:11298",
-      "@media screen and (min-width:45em) (7 rules) @ 2:15150",
-      "@media screen and (min-width:45em) (2 rules) @ 2:16827",
-      "@media screen and (max-width:44.9375em) (1 rules) @ 2:19150",
-      "@media screen and (min-width:64em) (1 rules) @ 2:19227"
+      "@media screen and (min-width:45em) (7 rules) @ 2:15137",
+      "@media screen and (min-width:45em) (2 rules) @ 2:16814",
+      "@media screen and (max-width:44.9375em) (1 rules) @ 2:19137",
+      "@media screen and (min-width:64em) (1 rules) @ 2:19214"
     ],
     "importants": [
-      ".u-visuallyhidden {position: absolute!important} @ 2:18933",
-      ".u-hidden {display: none!important} @ 2:19127",
-      ".u-hidden\\@s {display: none!important} @ 2:19203",
-      ".u-hidden\\@l {display: none!important} @ 2:19275"
+      ".u-visuallyhidden {position: absolute!important} @ 2:18920",
+      ".u-hidden {display: none!important} @ 2:19114",
+      ".u-hidden\\@s {display: none!important} @ 2:19190",
+      ".u-hidden\\@l {display: none!important} @ 2:19262"
     ],
     "colors": [
       "#ffffff (14 times)",


### PR DESCRIPTION
Fixes #351

- Changes naming scheme of `spacing` from `small`, `medium` etc, to `s`, `m`, `xl`
- Updates naming of sized-based media queries to the shortened `s`, `m`, `l`, instead of small medium & large