### PR TITLE
Bumps node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 node_js:
-  - "11.10.1"
+  - "12.13.0"
 install:
   - yarn
 script:


### PR DESCRIPTION
Travis was complaining that the version of node set in `.travis.yml` was too low for one of the npm packages. this bumps node to v12.13.0