### PR TITLE
[#374] Add component: breadcrumbs

### DIFF
--- a/scss/bitstyles/components/breadcrumbs.stories.mdx
+++ b/scss/bitstyles/components/breadcrumbs.stories.mdx
@@ -1,0 +1,65 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Components/Breadcrumbs" />
+
+# Breadcrumbs
+
+A list of links charting the user’s place in the site structure.
+
+<Canvas isColumn>
+  <Story name="Breadcrumbs">
+    {`
+      <ul class="c-breadcrumbs u-h6 o-list-reset l-flex l-flex--wrap l-items-center">
+        <li class="u-margin-xs--right">
+          <a href="/">Main section</a>
+        </li>
+        <li class="u-margin-xs--right">
+          <svg class="o-icon o-icon--m u-fg--gray-30" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <path d="M32.83,97.22a6.07,6.07,0,1,1-8.59-8.58L58.59,54.29a6.07,6.07,0,0,0,0-8.58L24.24,11.36a6.07,6.07,0,1,1,8.59-8.58L75.76,45.71a6.07,6.07,0,0,1,0,8.58Z" fill-rule="evenodd"/>
+          </svg>
+        </li>
+        <li class="u-margin-xs--right">
+          <a href="/">Sub section</a>
+        </li>
+        <li class="u-margin-xs--right">
+          <svg class="o-icon o-icon--m u-fg--gray-30" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" aria-hidden="true">
+            <path d="M32.83,97.22a6.07,6.07,0,1,1-8.59-8.58L58.59,54.29a6.07,6.07,0,0,0,0-8.58L24.24,11.36a6.07,6.07,0,1,1,8.59-8.58L75.76,45.71a6.07,6.07,0,0,1,0,8.58Z" fill-rule="evenodd"/>
+          </svg>
+        </li>
+        <li class="u-margin-xs--right">
+          <a href="/">Sub page</a>
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="Breadcrumbs with icon">
+    {`
+      <ul class="c-breadcrumbs u-h6 o-list-reset l-flex l-flex--wrap l-items-center u-line-height-min">
+        <li class="u-margin-xs--right">
+          <a href="/">
+            <svg xmlns="http://www.w3.org/2000/svg" class="o-icon o-icon--l" viewBox="0 0 100 100">
+              <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
+            </svg>
+            <span class="u-sr-only">Home</span>
+          </a>
+        </li>
+        <li class="u-margin-xs--right">
+          <svg class="o-icon o-icon--m u-fg--gray-30" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <path d="M32.83,97.22a6.07,6.07,0,1,1-8.59-8.58L58.59,54.29a6.07,6.07,0,0,0,0-8.58L24.24,11.36a6.07,6.07,0,1,1,8.59-8.58L75.76,45.71a6.07,6.07,0,0,1,0,8.58Z" fill-rule="evenodd"/>
+          </svg>
+        </li>
+        <li class="u-margin-xs--right">
+          <a href="/">Sub section</a>
+        </li>
+        <li class="u-margin-xs--right">
+          <svg class="o-icon o-icon--m u-fg--gray-30" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" aria-hidden="true">
+            <path d="M32.83,97.22a6.07,6.07,0,1,1-8.59-8.58L58.59,54.29a6.07,6.07,0,0,0,0-8.58L24.24,11.36a6.07,6.07,0,1,1,8.59-8.58L75.76,45.71a6.07,6.07,0,0,1,0,8.58Z" fill-rule="evenodd"/>
+          </svg>
+        </li>
+        <li class="u-margin-xs--right">
+          <a href="/">Sub page</a>
+        </li>
+      </ul>
+    `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/components/breadcrumbs.stories.mdx
+++ b/scss/bitstyles/components/breadcrumbs.stories.mdx
@@ -4,62 +4,59 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Breadcrumbs
 
-A list of links charting the user’s place in the site structure.
+A list of links charting the user’s place in the site structure. The title of the current page should be in an `<h1>` on the page, so it isn’t needed here.
 
 <Canvas isColumn>
   <Story name="Breadcrumbs">
     {`
-      <ul class="c-breadcrumbs u-h6 o-list-reset l-flex l-flex--wrap l-items-center">
-        <li class="u-margin-xs--right">
+      <ol class="c-breadcrumbs u-h6 o-list-reset l-flex l-flex--wrap l-items-center">
+        <li class="u-margin-xs--right l-flex l-items-center">
           <a href="/">Main section</a>
         </li>
-        <li class="u-margin-xs--right">
-          <svg class="o-icon o-icon--m u-fg--gray-30" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <li class="u-margin-xs--right l-flex l-items-center">
+          <svg class="o-icon o-icon--m u-fg--gray-30 u-margin-xs--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <path d="M32.83,97.22a6.07,6.07,0,1,1-8.59-8.58L58.59,54.29a6.07,6.07,0,0,0,0-8.58L24.24,11.36a6.07,6.07,0,1,1,8.59-8.58L75.76,45.71a6.07,6.07,0,0,1,0,8.58Z" fill-rule="evenodd"/>
           </svg>
-        </li>
-        <li class="u-margin-xs--right">
           <a href="/">Sub section</a>
         </li>
-        <li class="u-margin-xs--right">
-          <svg class="o-icon o-icon--m u-fg--gray-30" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" aria-hidden="true">
+        <li class="u-margin-xs--right l-flex l-items-center">
+          <svg class="o-icon o-icon--m u-fg--gray-30 u-margin-xs--right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" aria-hidden="true">
             <path d="M32.83,97.22a6.07,6.07,0,1,1-8.59-8.58L58.59,54.29a6.07,6.07,0,0,0,0-8.58L24.24,11.36a6.07,6.07,0,1,1,8.59-8.58L75.76,45.71a6.07,6.07,0,0,1,0,8.58Z" fill-rule="evenodd"/>
           </svg>
-        </li>
-        <li class="u-margin-xs--right">
           <a href="/">Sub page</a>
         </li>
-      </ul>
+      </ol>
     `}
   </Story>
+</Canvas>
+
+Using the same structure, your root page might be represented with an icon, to make it really quick to spot.
+
+<Canvas>
   <Story name="Breadcrumbs with icon">
     {`
-      <ul class="c-breadcrumbs u-h6 o-list-reset l-flex l-flex--wrap l-items-center u-line-height-min">
-        <li class="u-margin-xs--right">
-          <a href="/">
+      <ol class="c-breadcrumbs u-h6 o-list-reset l-flex l-flex--wrap l-items-center u-line-height--min">
+        <li class="u-margin-xs--right l-flex l-items-center">
+          <a href="/" class="u-margin-xs--right l-flex l-items-center">
             <svg xmlns="http://www.w3.org/2000/svg" class="o-icon o-icon--l" viewBox="0 0 100 100">
               <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
             </svg>
             <span class="u-sr-only">Home</span>
           </a>
         </li>
-        <li class="u-margin-xs--right">
-          <svg class="o-icon o-icon--m u-fg--gray-30" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <li class="u-margin-xs--right l-flex l-items-center">
+          <svg class="o-icon u-fg--gray-30 u-margin-xs--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <path d="M32.83,97.22a6.07,6.07,0,1,1-8.59-8.58L58.59,54.29a6.07,6.07,0,0,0,0-8.58L24.24,11.36a6.07,6.07,0,1,1,8.59-8.58L75.76,45.71a6.07,6.07,0,0,1,0,8.58Z" fill-rule="evenodd"/>
           </svg>
-        </li>
-        <li class="u-margin-xs--right">
           <a href="/">Sub section</a>
         </li>
-        <li class="u-margin-xs--right">
-          <svg class="o-icon o-icon--m u-fg--gray-30" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" aria-hidden="true">
+        <li class="u-margin-xs--right l-flex l-items-center">
+          <svg class="o-icon o-icon--m u-fg--gray-30 u-margin-xs--right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" aria-hidden="true">
             <path d="M32.83,97.22a6.07,6.07,0,1,1-8.59-8.58L58.59,54.29a6.07,6.07,0,0,0,0-8.58L24.24,11.36a6.07,6.07,0,1,1,8.59-8.58L75.76,45.71a6.07,6.07,0,0,1,0,8.58Z" fill-rule="evenodd"/>
           </svg>
-        </li>
-        <li class="u-margin-xs--right">
           <a href="/">Sub page</a>
         </li>
-      </ul>
+      </ol>
     `}
   </Story>
 </Canvas>

--- a/scss/bitstyles/layout/box-alignment/_.scss
+++ b/scss/bitstyles/layout/box-alignment/_.scss
@@ -13,3 +13,4 @@
 .l-items-end {
   align-items: flex-end;
 }
+

--- a/scss/bitstyles/layout/box-alignment/_.scss
+++ b/scss/bitstyles/layout/box-alignment/_.scss
@@ -13,4 +13,3 @@
 .l-items-end {
   align-items: flex-end;
 }
-

--- a/scss/bitstyles/objects/icon/settings.scss
+++ b/scss/bitstyles/objects/icon/settings.scss
@@ -1,5 +1,5 @@
 $bitstyles-icon-sizes: (
   's':     spacing('xs'),
   'm':     spacing('m'),
-  'l':     spacing('xl')
+  'l':     spacing('l')
 ) !default;

--- a/scss/bitstyles/settings/_link.scss
+++ b/scss/bitstyles/settings/_link.scss
@@ -1,8 +1,8 @@
 $bitstyles-background-color-link: none !default;
-$bitstyles-color-link:            palette('brand-1') !default;
-$bitstyles-color-link-visited:    palette('brand-1', '80') !default;
+$bitstyles-color-link:            palette('brand-1', '80') !default;
+$bitstyles-color-link-visited:    palette('brand-1', '60') !default;
 $bitstyles-color-link-hover:      palette('brand-1', '100') !default;
 $bitstyles-background-color-link-hover: none !default;
 $bitstyles-link-transition: color $bitstyles-transition-duration $bitstyles-transition-easing !default;
-$bitstyles-text-decoration-link:       underline !default;
+$bitstyles-text-decoration-link:       none !default;
 $bitstyles-text-decoration-link-hover: underline !default;

--- a/scss/bitstyles/tools/_icon.scss
+++ b/scss/bitstyles/tools/_icon.scss
@@ -4,7 +4,12 @@
   height: 1em;
   font-size: 1em;
   vertical-align: middle;
+  flex-shrink: 0;
   outline: none;
-  transition: fill $bitstyles-transition-duration $bitstyles-transition-easing, stroke $bitstyles-transition-duration $bitstyles-transition-easing, background-color $bitstyles-transition-duration $bitstyles-transition-easing, transform $bitstyles-transition-duration $bitstyles-transition-easing;
+  transition:
+    fill $bitstyles-transition-duration $bitstyles-transition-easing,
+    stroke $bitstyles-transition-duration $bitstyles-transition-easing,
+    background-color $bitstyles-transition-duration $bitstyles-transition-easing,
+    transform $bitstyles-transition-duration $bitstyles-transition-easing;
   fill: currentColor;
 }

--- a/scss/bitstyles/utilities/fg/settings.scss
+++ b/scss/bitstyles/utilities/fg/settings.scss
@@ -3,4 +3,5 @@ $foreground-colors: (
   'brand-2': palette('brand-2', '100'),
   'warning': palette('warning', '100'),
   'gray-40': palette('gray', '40'),
+  'gray-30': palette('gray', '30'),
 ) !default;

--- a/test/css-stats.json
+++ b/test/css-stats.json
@@ -4,7 +4,7 @@
     "base64Length": 0,
     "redundantBodySelectors": 0,
     "redundantChildNodesSelectors": 0,
-    "colors": 37,
+    "colors": 39,
     "comments": 2,
     "commentsLength": 109,
     "complexSelectors": 0,
@@ -25,58 +25,58 @@
     "specificityIdAvg": 0,
     "specificityIdTotal": 0,
     "specificityClassAvg": 1.08,
-    "specificityClassTotal": 505,
+    "specificityClassTotal": 506,
     "specificityTagAvg": 0.27,
     "specificityTagTotal": 125,
-    "selectors": 469,
-    "selectorLengthAvg": 1.023454157782516,
+    "selectors": 470,
+    "selectorLengthAvg": 1.023404255319149,
     "selectorsByAttribute": 104,
-    "selectorsByClass": 275,
+    "selectorsByClass": 276,
     "selectorsById": 0,
     "selectorsByPseudo": 145,
     "selectorsByTag": 105,
-    "length": 26589,
-    "rules": 319,
-    "declarations": 780
+    "length": 26620,
+    "rules": 320,
+    "declarations": 782
   },
   "offenders": {
     "duplicatedProperties": [
       "abbr[title] {text-decoration: underline dotted} @ 1:373",
-      ".c-expander-body[aria-hidden=false] {max-height: 200vh} @ 1:22870"
+      ".c-expander-body[aria-hidden=false] {max-height: 200vh} @ 1:22872"
     ],
     "oldPropertyPrefixes": [
       "html { -webkit-text-size-adjust: 100% } // was required by UC Browser for Android 11.4, iOS Safari 11 and earlier @ 1:1973",
-      "a { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 1:2653",
-      "[type=checkbox], [type=radio] { -moz-appearance: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 1:5767",
-      ".l-topbar { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari NaN and earlier @ 1:10985",
-      ".o-button { -webkit-user-select: none } // was required by QQ Browser 1.2, UC Browser for Android 11.4, Android Browser 4.4, Chrome 53, iOS Safari 11, Opera 40, Safari NaN, Samsung Internet 6.2 and earlier @ 1:12935",
-      ".o-button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 1:12960",
-      ".o-link { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 1:19355",
-      ".c-modal__overlay { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari NaN and earlier @ 1:21192",
-      ".c-modal__content { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari NaN and earlier @ 1:21738",
-      ".u-sr-only { -webkit-clip-path: inset(50%) } // was required by QQ Browser 1.2, UC Browser for Android 11.4, Android Browser 4.4, Chrome 54, iOS Safari 11, Opera 41, Safari NaN, Samsung Internet 6.2 and earlier @ 1:26104"
+      "a { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 1:2648",
+      "[type=checkbox], [type=radio] { -moz-appearance: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 1:5762",
+      ".l-topbar { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari NaN and earlier @ 1:10980",
+      ".o-button { -webkit-user-select: none } // was required by QQ Browser 1.2, UC Browser for Android 11.4, Android Browser 4.4, Chrome 53, iOS Safari 11, Opera 40, Safari NaN, Samsung Internet 6.2 and earlier @ 1:12942",
+      ".o-button { -moz-user-select: none } // was required by Firefox for Android 57, Firefox 60 and earlier @ 1:12967",
+      ".o-link { -webkit-text-decoration-skip: ink } // was required by iOS Safari 11, Safari NaN and earlier @ 1:19357",
+      ".c-modal__overlay { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari NaN and earlier @ 1:21194",
+      ".c-modal__content { -webkit-backface-visibility: hidden } // was required by UC Browser for Android 11.4, Android Browser 4.4, Chrome 35, iOS Safari 11, Opera 22, Safari NaN and earlier @ 1:21740",
+      ".u-sr-only { -webkit-clip-path: inset(50%) } // was required by QQ Browser 1.2, UC Browser for Android 11.4, Android Browser 4.4, Chrome 54, iOS Safari 11, Opera 41, Safari NaN, Samsung Internet 6.2 and earlier @ 1:26135"
     ],
     "mediaQueries": [
       "@media screen and (min-width:30em) (7 rules) @ 1:2264",
-      "@media screen and (min-width:55em) (1 rules) @ 1:9627",
-      "@media screen and (min-width:30em) (12 rules) @ 1:10303",
-      "@media screen and (min-width:30em) (2 rules) @ 1:21997",
-      "@media screen and (min-width:30em) (7 rules) @ 1:23432",
-      "@media screen and (max-width:29.9375em) (1 rules) @ 1:26205",
-      "@media screen and (min-width:55em) (1 rules) @ 1:26272",
-      "@media screen and (max-width:29.9375em) (1 rules) @ 1:26357",
-      "@media screen and (min-width:30em) (1 rules) @ 1:26424",
-      "@media screen and (min-width:55em) (1 rules) @ 1:26486"
+      "@media screen and (min-width:55em) (1 rules) @ 1:9622",
+      "@media screen and (min-width:30em) (12 rules) @ 1:10298",
+      "@media screen and (min-width:30em) (2 rules) @ 1:21999",
+      "@media screen and (min-width:30em) (7 rules) @ 1:23434",
+      "@media screen and (max-width:29.9375em) (1 rules) @ 1:26236",
+      "@media screen and (min-width:55em) (1 rules) @ 1:26303",
+      "@media screen and (max-width:29.9375em) (1 rules) @ 1:26388",
+      "@media screen and (min-width:30em) (1 rules) @ 1:26455",
+      "@media screen and (min-width:55em) (1 rules) @ 1:26517"
     ],
     "multiClassesSelectors": [
-      ".o-button--icon.o-button--small @ 1:16472"
+      ".o-button--icon.o-button--small @ 1:16479"
     ],
     "importants": [
-      ".u-sr-only {position: absolute!important} @ 1:25998"
+      ".u-sr-only {position: absolute!important} @ 1:26029"
     ],
     "colors": [
       "#ffffff (29 times)",
-      "#000dff (13 times)",
+      "#000dff (11 times)",
       "#2e2f47 (11 times)",
       "#cfd0e9 (11 times)",
       "#ffaa00 (9 times)",
@@ -95,6 +95,7 @@
       "#e6e7ff (3 times)",
       "#ffbb33 (3 times)",
       "#fff7e6 (3 times)",
+      "#666eff (2 times)",
       "rgba(0,13,255,0.3) (2 times)",
       "#e82915 (2 times)",
       "rgba(232,41,21,0.3) (2 times)",
@@ -111,6 +112,7 @@
       "rgba(0,0,0,0.7) (1 times)",
       "#d9d9d9 (1 times)",
       "#8a8ba3 (1 times)",
+      "#a1a2bb (1 times)",
       "#171931 (1 times)"
     ],
     "duplicatedSelectors": [


### PR DESCRIPTION
Fixes #374 

Adds two breadcrumbs examples

Looks like:

Simple, with all text 

<img width="358" alt="Screenshot 2021-02-17 at 17 17 52" src="https://user-images.githubusercontent.com/2479422/108233478-1d67f880-7144-11eb-9a35-9cd36ac86590.png">

With an icon

<img width="358" alt="Screenshot 2021-02-17 at 17 17 57" src="https://user-images.githubusercontent.com/2479422/108233457-16d98100-7144-11eb-8461-3d6d862a61f5.png">
