### PR TITLE
Bump version 1.0

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,7 @@
 name: Deploy to GitHub Pages
 on:
-  push:
+  release:
+    types: [published]
     branches:
       - main
     paths: ["scss/**"]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "bugs": {
     "url": "https://github.com/bitcrowd/bitstyles/issues"
   },
-  "homepage": "https://github.com/bitcrowd/bitstyles#readme",
+  "homepage": "https://bitcrowd.github.io/bitstyles",
   "devDependencies": {
     "@babel/core": "^7.8.7",
     "@storybook/addon-actions": "^6.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitstyles",
-  "version": "1.0.0a",
+  "version": "1.0.0",
   "description": "The Bitcrowd CSS library",
   "main": "bitstyles.scss",
   "scripts": {


### PR DESCRIPTION
- Bumps version
- deploy to storybook now only happens on release published

On hold until the two remaining PRs are merged (will need rebase afterwards)