### PR TITLE
[#394] Add select invalid styling

### DIFF
--- a/scss/bitstyles/base/forms/forms.stories.mdx
+++ b/scss/bitstyles/base/forms/forms.stories.mdx
@@ -126,31 +126,27 @@ This includes all standard `type="text"` inputs, plus all the text-based inputs 
 <Canvas isColumn>
   <Story name="Select and label">
     {`
-      <label for="input_d1">
-        This is labeling text
-        <select id="input_d1">
-          <option value="value1" selected>Value 1</option>
-          <option value="value2">Value 2</option>
-          <option value="value3">Value 3</option>
-        </select>
-      </label>
+      <label for="input_d1">Select</label>
+      <select id="input_d1">
+        <option value="value1" selected>Value 1</option>
+        <option value="value2">Value 2</option>
+        <option value="value3">Value 3</option>
+      </select>
     `}
   </Story>
   <Story name="Select and label (disabled)">
     {`
-      <label for="input_d2">
-        This is labeling text
-        <select id="input_d2" disabled>
-          <option value="value1" selected>Value 1</option>
-          <option value="value2">Value 2</option>
-          <option value="value3">Value 3</option>
-        </select>
-      </label>
+      <label for="input_d2">Disabled select</label>
+      <select id="input_d2" disabled>
+        <option value="value1" selected>Value 1</option>
+        <option value="value2">Value 2</option>
+        <option value="value3">Value 3</option>
+      </select>
     `}
   </Story>
   <Story name="Select and label (invalid)">
     {`
-      <label for="input_d2">Label</label>
+      <label for="input_d2">Invalid select</label>
       <select required>
         <option value="" disabled hidden selected>Please select</option>
         <option value="value2">Value 2</option>

--- a/scss/bitstyles/base/forms/forms.stories.mdx
+++ b/scss/bitstyles/base/forms/forms.stories.mdx
@@ -148,6 +148,16 @@ This includes all standard `type="text"` inputs, plus all the text-based inputs 
       </label>
     `}
   </Story>
+  <Story name="Select and label (invalid)">
+    {`
+      <label for="input_d2">Label</label>
+      <select required>
+        <option value="" disabled hidden selected>Please select</option>
+        <option value="value2">Value 2</option>
+        <option value="value3">Value 3</option>
+      </select>
+    `}
+  </Story>
 </Canvas>
 
 

--- a/scss/bitstyles/base/forms/inputs.stories.mdx
+++ b/scss/bitstyles/base/forms/inputs.stories.mdx
@@ -104,6 +104,15 @@ You may find [Base/Forms](/?path=/docs/base-forms--fieldset) more informative.
       </select>
     `}
   </Story>
+  <Story name="Select (invalid)">
+    {`
+      <select required>
+        <option value="" disabled hidden selected>Please select</option>
+        <option value="value2">Value 2</option>
+        <option value="value3">Value 3</option>
+      </select>
+    `}
+  </Story>
 </Canvas>
 
 ## Label

--- a/scss/bitstyles/base/forms/settings-input.scss
+++ b/scss/bitstyles/base/forms/settings-input.scss
@@ -33,7 +33,7 @@ $bitstyles-input-box-shadow-active: 0 0 spacing('xxs') rgba(palette('brand-1', '
 //
 // Disabled colors ////////////////////////////////////////
 
-$bitstyles-input-background-disabled: palette('black', '20') !default;
+$bitstyles-input-background-disabled: palette('black', '10') !default;
 $bitstyles-input-color-disabled: palette('text') !default;
 $bitstyles-input-border-disabled: 2px solid palette('black', '20') !default;
 $bitstyles-input-box-shadow-disabled: none;

--- a/scss/bitstyles/base/forms/settings-select.scss
+++ b/scss/bitstyles/base/forms/settings-select.scss
@@ -26,6 +26,13 @@ $bitstyles-select-background-color-active: transparent !default;
 $bitstyles-select-background-image-active: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-active}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
 
 //
+// Invalid styles ////////////////////////////////////////
+$bitstyles-select-color-invalid: palette('warning') !default;
+$bitstyles-select-border-invalid: 2px solid palette('warning') !default;
+$bitstyles-select-background-color-invalid: palette('white') !default;
+$bitstyles-select-background-image-invalid: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-invalid}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
+
+//
 // Disabled styles ////////////////////////////////////////
 $bitstyles-select-color-disabled: palette('black', '40') !default;
 $bitstyles-select-border-disabled: 2px solid !default;

--- a/scss/bitstyles/base/forms/settings-select.scss
+++ b/scss/bitstyles/base/forms/settings-select.scss
@@ -34,7 +34,7 @@ $bitstyles-select-background-image-invalid: url("data:image/svg+xml,%3Csvg width
 
 //
 // Disabled styles ////////////////////////////////////////
-$bitstyles-select-color-disabled: palette('black', '40') !default;
-$bitstyles-select-border-disabled: 2px solid !default;
-$bitstyles-select-background-color-disabled: transparent !default;
+$bitstyles-select-color-disabled: palette('text') !default;
+$bitstyles-select-border-disabled: 2px solid palette('black', '20') !default;
+$bitstyles-select-background-color-disabled: palette('black', '20') !default;
 $bitstyles-select-background-image-disabled: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-disabled}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;

--- a/scss/bitstyles/base/forms/settings-select.scss
+++ b/scss/bitstyles/base/forms/settings-select.scss
@@ -9,7 +9,7 @@ $bitstyles-select-border-radius: spacing('xs') !default;
 $bitstyles-select-color: palette('gray', '60') !default;
 $bitstyles-select-border: 2px solid palette('gray', '40') !default;
 $bitstyles-select-background-color: transparent !default;
-$bitstyles-select-background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '60')}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
 
 //
 // Hover styles ////////////////////////////////////////
@@ -23,18 +23,18 @@ $bitstyles-select-background-image-hover: url("data:image/svg+xml,%3Csvg width='
 $bitstyles-select-color-active: palette('gray', '80') !default;
 $bitstyles-select-border-active: 2px solid palette('gray', '80') !default;
 $bitstyles-select-background-color-active: transparent !default;
-$bitstyles-select-background-image-active: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-active}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-image-active: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '80')}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
 
 //
 // Invalid styles ////////////////////////////////////////
 $bitstyles-select-color-invalid: palette('warning') !default;
 $bitstyles-select-border-invalid: 2px solid palette('warning') !default;
 $bitstyles-select-background-color-invalid: palette('white') !default;
-$bitstyles-select-background-image-invalid: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-invalid}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-image-invalid: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('warning')}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
 
 //
 // Disabled styles ////////////////////////////////////////
 $bitstyles-select-color-disabled: palette('text') !default;
 $bitstyles-select-border-disabled: 2px solid palette('black', '20') !default;
-$bitstyles-select-background-color-disabled: palette('black', '20') !default;
-$bitstyles-select-background-image-disabled: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-disabled}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-color-disabled: palette('black', '10') !default;
+$bitstyles-select-background-image-disabled: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '50')}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;

--- a/scss/bitstyles/tools/_select.scss
+++ b/scss/bitstyles/tools/_select.scss
@@ -41,6 +41,13 @@
     outline: none;
   }
 
+  &:invalid {
+    color: $bitstyles-select-color-invalid;
+    background-color: $bitstyles-select-background-color-invalid;
+    background-image: $bitstyles-select-background-image-invalid;
+    border: $bitstyles-select-border-invalid;
+  }
+
   &[disabled] {
     color: $bitstyles-select-color-disabled;
     cursor: default;


### PR DESCRIPTION
Fixes #394 

- Adds `:invalid` styles to the base select component
- Adds stories that show how to achieve it

Looks like:

<img width="1008" alt="Screenshot 2021-03-09 at 15 46 34" src="https://user-images.githubusercontent.com/2479422/110488639-f1121d00-80ee-11eb-86d9-ad8cc0e73b05.png">
