### PR TITLE
[#407] Add component: header bars

### DIFF
--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -67,6 +67,7 @@
 @import 'bitstyles/utilities/line-height/';
 @import 'bitstyles/utilities/fg/';
 @import 'bitstyles/utilities/bg/';
+@import 'bitstyles/utilities/border/';
 @import 'bitstyles/utilities/absolute-center/';
 @import 'bitstyles/utilities/absolute-cover/';
 @import 'bitstyles/utilities/overflow/';

--- a/scss/bitstyles/atoms/button--tab/_.scss
+++ b/scss/bitstyles/atoms/button--tab/_.scss
@@ -14,8 +14,8 @@
   &:visited {
     color: $bitstyles-button-tab-color;
     background: $bitstyles-button-tab-background-color;
-    box-shadow: $bitstyles-button-tab-box-shadow;
     border: $bitstyles-button-tab-border;
+    box-shadow: $bitstyles-button-tab-box-shadow;
 
     &::after {
       position: absolute;
@@ -34,8 +34,8 @@
   &:focus {
     color: $bitstyles-button-tab-color-hover;
     text-decoration: none;
-    border: $bitstyles-button-tab-border-hover;
     background: $bitstyles-button-tab-background-color-hover;
+    border: $bitstyles-button-tab-border-hover;
     outline: none;
     box-shadow: $bitstyles-button-tab-box-shadow-hover;
 
@@ -46,8 +46,8 @@
 
   &:active {
     color: $bitstyles-button-tab-color-active;
-    border: $bitstyles-button-tab-border-active;
     background: $bitstyles-button-tab-background-color-active;
+    border: $bitstyles-button-tab-border-active;
     box-shadow: $bitstyles-button-tab-box-shadow-active;
 
     &::after {
@@ -68,8 +68,8 @@
   &:disabled {
     color: $bitstyles-button-tab-color-disabled;
     cursor: default;
-    border: $bitstyles-button-tab-border-disabled;
     background: $bitstyles-button-tab-background-color-disabled;
+    border: $bitstyles-button-tab-border-disabled;
     box-shadow: $bitstyles-button-tab-box-shadow-disabled;
 
     &::after {

--- a/scss/bitstyles/atoms/button--tab/_.scss
+++ b/scss/bitstyles/atoms/button--tab/_.scss
@@ -15,6 +15,7 @@
     color: $bitstyles-button-tab-color;
     background: $bitstyles-button-tab-background-color;
     box-shadow: $bitstyles-button-tab-box-shadow;
+    border: $bitstyles-button-tab-border;
 
     &::after {
       position: absolute;
@@ -22,7 +23,7 @@
       bottom: 0;
       left: $bitstyles-button-padding-horizontal;
       height: $bitstyles-button-tab-border-width;
-      background-color: $bitstyles-button-tab-border-color;
+      background-color: $bitstyles-button-tab-indicator-color;
       border-radius: $bitstyles-border-radius-round;
       content: '';
       transition: background-color $bitstyles-transition-duration $bitstyles-transition-easing;
@@ -33,22 +34,24 @@
   &:focus {
     color: $bitstyles-button-tab-color-hover;
     text-decoration: none;
+    border: $bitstyles-button-tab-border-hover;
     background: $bitstyles-button-tab-background-color-hover;
     outline: none;
     box-shadow: $bitstyles-button-tab-box-shadow-hover;
 
     &::after {
-      background-color: $bitstyles-button-tab-border-color-hover;
+      background-color: $bitstyles-button-tab-indicator-color-hover;
     }
   }
 
   &:active {
     color: $bitstyles-button-tab-color-active;
+    border: $bitstyles-button-tab-border-active;
     background: $bitstyles-button-tab-background-color-active;
     box-shadow: $bitstyles-button-tab-box-shadow-active;
 
     &::after {
-      background-color: $bitstyles-button-tab-border-color-active;
+      background-color: $bitstyles-button-tab-indicator-color-active;
     }
   }
 
@@ -58,18 +61,19 @@
     box-shadow: $bitstyles-button-tab-box-shadow-selected;
 
     &::after {
-      background-color: $bitstyles-button-tab-border-color-selected;
+      background-color: $bitstyles-button-tab-indicator-color-selected;
     }
   }
 
   &:disabled {
     color: $bitstyles-button-tab-color-disabled;
     cursor: default;
+    border: $bitstyles-button-tab-border-disabled;
     background: $bitstyles-button-tab-background-color-disabled;
     box-shadow: $bitstyles-button-tab-box-shadow-disabled;
 
     &::after {
-      background-color: $bitstyles-button-tab-border-color-disabled;
+      background-color: $bitstyles-button-tab-indicator-color-disabled;
     }
   }
 }

--- a/scss/bitstyles/atoms/button--tab/settings.scss
+++ b/scss/bitstyles/atoms/button--tab/settings.scss
@@ -12,7 +12,8 @@ $bitstyles-button-tab-transition:
 
 $bitstyles-button-tab-color: palette('gray', '60') !default;
 $bitstyles-button-tab-background-color: transparent !default;
-$bitstyles-button-tab-border-color: transparent !default;
+$bitstyles-button-tab-indicator-color: transparent !default;
+$bitstyles-button-tab-border: 2px solid transparent !default;
 $bitstyles-button-tab-box-shadow: none !default;
 
 //
@@ -20,7 +21,8 @@ $bitstyles-button-tab-box-shadow: none !default;
 
 $bitstyles-button-tab-color-hover: palette('brand-1', '70') !default;
 $bitstyles-button-tab-background-color-hover: transparent !default;
-$bitstyles-button-tab-border-color-hover: palette('brand-1', '70') !default;
+$bitstyles-button-tab-indicator-color-hover: palette('brand-1', '70') !default;
+$bitstyles-button-tab-border-hover: 2px solid transparent !default;
 $bitstyles-button-tab-box-shadow-hover: none !default;
 
 //
@@ -28,7 +30,8 @@ $bitstyles-button-tab-box-shadow-hover: none !default;
 
 $bitstyles-button-tab-color-active: palette('brand-1', '90') !default;
 $bitstyles-button-tab-background-color-active: transparent !default;
-$bitstyles-button-tab-border-color-active: palette('brand-1', '90') !default;
+$bitstyles-button-tab-indicator-color-active: palette('brand-1', '90') !default;
+$bitstyles-button-tab-border-active: 2px solid transparent !default;
 $bitstyles-button-tab-box-shadow-active: none !default;
 
 //
@@ -36,7 +39,7 @@ $bitstyles-button-tab-box-shadow-active: none !default;
 
 $bitstyles-button-tab-color-selected: palette('gray', '90') !default;
 $bitstyles-button-tab-background-color-selected: transparent !default;
-$bitstyles-button-tab-border-color-selected: palette('brand-1', '90') !default;
+$bitstyles-button-tab-indicator-color-selected: palette('brand-1', '90') !default;
 $bitstyles-button-tab-box-shadow-selected: none !default;
 
 //
@@ -44,5 +47,6 @@ $bitstyles-button-tab-box-shadow-selected: none !default;
 
 $bitstyles-button-tab-color-disabled: palette('black', '50') !default;
 $bitstyles-button-tab-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-tab-border-color-disabled: transparent !default;
+$bitstyles-button-tab-indicator-color-disabled: transparent !default;
+$bitstyles-button-tab-border-disabled: 2px solid transparent !default;
 $bitstyles-button-tab-box-shadow-disabled: none !default;

--- a/scss/bitstyles/atoms/button/settings.scss
+++ b/scss/bitstyles/atoms/button/settings.scss
@@ -1,7 +1,7 @@
 //
 // Base styles ////////////////////////////////////////
 
-$bitstyles-button-padding-vertical: spacing('s') !default;
+$bitstyles-button-padding-vertical: spacing('xs') !default;
 $bitstyles-button-padding-horizontal: spacing('m') !default;
 $bitstyles-button-border-radius: spacing('xs') !default;
 $bitstyles-button-transition:
@@ -16,7 +16,7 @@ $bitstyles-button-icon-spacing: spacing('s') !default;
 
 $bitstyles-button-color: palette('white') !default;
 $bitstyles-button-background-color: palette('brand-1', '80') !default;
-$bitstyles-button-border: none !default;
+$bitstyles-button-border: 2px solid palette('brand-1', '80') !default;
 $bitstyles-button-box-shadow: 0 0 spacing('xs') rgba(palette('brand-1', '80'), 0.2) !default;
 
 //
@@ -24,7 +24,7 @@ $bitstyles-button-box-shadow: 0 0 spacing('xs') rgba(palette('brand-1', '80'), 0
 
 $bitstyles-button-color-hover: palette('white') !default;
 $bitstyles-button-background-color-hover: palette('brand-1') !default;
-$bitstyles-button-border-hover: none !default;
+$bitstyles-button-border-hover: 2px solid palette('brand-1') !default;
 $bitstyles-button-box-shadow-hover: 0 0 spacing('s') rgba(palette('brand-1'), 0.2) !default;
 
 //
@@ -32,7 +32,7 @@ $bitstyles-button-box-shadow-hover: 0 0 spacing('s') rgba(palette('brand-1'), 0.
 
 $bitstyles-button-color-active: palette('white') !default;
 $bitstyles-button-background-color-active: palette('brand-2', '100') !default;
-$bitstyles-button-border-active: none !default;
+$bitstyles-button-border-active: 2px solid palette('brand-2', '100')  !default;
 $bitstyles-button-box-shadow-active: 0 0 spacing('s') rgba(palette('brand-1', '100'), 0.3) !default;
 
 //
@@ -40,5 +40,5 @@ $bitstyles-button-box-shadow-active: 0 0 spacing('s') rgba(palette('brand-1', '1
 
 $bitstyles-button-color-disabled: palette('black', '50') !default;
 $bitstyles-button-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-border-disabled: none !default;
+$bitstyles-button-border-disabled: 2px solid palette('black', '10')  !default;
 $bitstyles-button-box-shadow-disabled: none !default;

--- a/scss/bitstyles/atoms/button/settings.scss
+++ b/scss/bitstyles/atoms/button/settings.scss
@@ -32,7 +32,7 @@ $bitstyles-button-box-shadow-hover: 0 0 spacing('s') rgba(palette('brand-1'), 0.
 
 $bitstyles-button-color-active: palette('white') !default;
 $bitstyles-button-background-color-active: palette('brand-2', '100') !default;
-$bitstyles-button-border-active: 2px solid palette('brand-2', '100')  !default;
+$bitstyles-button-border-active: 2px solid palette('brand-2', '100') !default;
 $bitstyles-button-box-shadow-active: 0 0 spacing('s') rgba(palette('brand-1', '100'), 0.3) !default;
 
 //
@@ -40,5 +40,5 @@ $bitstyles-button-box-shadow-active: 0 0 spacing('s') rgba(palette('brand-1', '1
 
 $bitstyles-button-color-disabled: palette('black', '50') !default;
 $bitstyles-button-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-border-disabled: 2px solid palette('black', '10')  !default;
+$bitstyles-button-border-disabled: 2px solid palette('black', '10') !default;
 $bitstyles-button-box-shadow-disabled: none !default;

--- a/scss/bitstyles/ui/section-heading.stories.mdx
+++ b/scss/bitstyles/ui/section-heading.stories.mdx
@@ -1,0 +1,92 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="UI/Content/Section heading" />
+
+# Section heading
+
+A heading with optional actions, badges and labels. Be sure to use the correct h-level heading element (all heading here are `<h3>`s).
+
+## Section heading
+
+<Canvas>
+  <Story name="Section heading">
+    {`
+      <div class="u-padding-m--bottom u-border--bottom">
+        <h3 class="u-margin-0 u-margin-m--right">Recent bookings</h3>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Section headings with labels and badges
+
+Next to the heading text is a good place to add important information about the content referred to, such as its current state or counts.
+
+<Canvas>
+  <Story name="Section heading with count">
+    {`
+      <div class="u-flex u-items-center u-padding-m--bottom u-border--bottom">
+        <h3 class="u-margin-0 u-margin-xs--right">
+          Recent bookings
+        </h3>
+        <span class="u-fg--gray-50 u-font--normal u-h6">[3/10]<span>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Section heading with badge">
+    {`
+      <div class="u-flex u-items-center u-padding-m--bottom u-border--bottom">
+        <h3 class="u-margin-0 u-margin-xs--right">
+          Recent bookings
+        </h3>
+        <span class="a-badge a-badge--brand-1 u-h6">New<span>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Section headings with actions
+
+Section headings are a good place for important actions relating to the content the heading’s referring to, and can be combined with badges and labels.
+
+<Canvas>
+  <Story name="Section heading with actions">
+    {`
+      <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m--bottom u-border--bottom">
+        <h3 class="u-margin-0 u-margin-m--right">Recent bookings</h3>
+        <ul class="a-list-reset u-flex u-flex--wrap u-flex__shrink-0">
+          <li class="u-margin-s--right">
+            <button type="button" class="a-button a-button--ui">Edit</button>
+          </li>
+          <li class="u-margin-s--right">
+            <button type="button" class="a-button">Create</button>
+          </li>
+        </ul>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Section heading with badge and actions">
+    {`
+      <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m--bottom u-border--bottom">
+        <div class="u-flex u-items-center">
+          <h3 class="u-margin-0 u-margin-m--right">Recent bookings</h3>
+          <span class="a-badge a-badge--brand-1 u-h6">New<span>
+        </div>
+        <ul class="a-list-reset u-flex u-flex--wrap u-flex__shrink-0">
+          <li class="u-margin-s--right">
+            <button type="button" class="a-button a-button--ui">Edit</button>
+          </li>
+          <li class="u-margin-s--right">
+            <button type="button" class="a-button">Create</button>
+          </li>
+        </ul>
+      </div>
+    `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/utilities/border/_.scss
+++ b/scss/bitstyles/utilities/border/_.scss
@@ -1,0 +1,3 @@
+.u-border--bottom {
+  border-bottom: 1px solid palette('gray', '10');
+}

--- a/scss/bitstyles/utilities/border/border.stories.mdx
+++ b/scss/bitstyles/utilities/border/border.stories.mdx
@@ -1,0 +1,15 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="utilities/Border" />
+
+# Border
+
+Apply a standard border.
+
+<Canvas >
+  <Story name="Border--bottom">
+    {`
+      <h3 class="u-border-bottom">Recent bookings</h3>
+    `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/utilities/box-alignment/_.scss
+++ b/scss/bitstyles/utilities/box-alignment/_.scss
@@ -29,3 +29,13 @@
 .#{$bitstyles-namespace}u-self-end {
   align-self: flex-end;
 }
+
+@include media-query('m') {
+  .#{$bitstyles-namespace}u-justify-between\@m {
+    justify-content: space-between;
+  }
+
+  .#{$bitstyles-namespace}u-items-center\@m {
+    align-items: center;
+  }
+}

--- a/scss/bitstyles/utilities/flex/_.scss
+++ b/scss/bitstyles/utilities/flex/_.scss
@@ -21,3 +21,9 @@
 .#{$bitstyles-namespace}u-flex__shrink-0 {
   flex-shrink: 0;
 }
+
+@include media-query('m') {
+  .#{$bitstyles-namespace}u-flex\@m {
+    display: flex;
+  }
+}


### PR DESCRIPTION
Fixes #407 

Adds some section headers, with variants labels, badges, and buttons.

Looks like:

<img width="1008" alt="Screenshot 2021-03-09 at 17 36 08" src="https://user-images.githubusercontent.com/2479422/110504921-f165e480-80fd-11eb-830e-46083a7fa316.png">
