### PR TITLE
[#410] Equalise button borders

### DIFF
--- a/scss/bitstyles/atoms/button--danger/_.scss
+++ b/scss/bitstyles/atoms/button--danger/_.scss
@@ -5,7 +5,7 @@
   &:visited {
     color: $bitstyles-button-danger-color;
     background: $bitstyles-button-danger-background-color;
-    border: $bitstyles-button-danger-border;
+    border-color: $bitstyles-button-danger-border-color;
     box-shadow: $bitstyles-button-danger-box-shadow;
   }
 
@@ -14,7 +14,7 @@
     color: $bitstyles-button-danger-color-hover;
     text-decoration: none;
     background: $bitstyles-button-danger-background-color-hover;
-    border: $bitstyles-button-danger-border-hover;
+    border-color: $bitstyles-button-danger-border-color-hover;
     outline: none;
     box-shadow: $bitstyles-button-danger-box-shadow-hover;
   }
@@ -22,7 +22,7 @@
   &:active {
     color: $bitstyles-button-danger-color-active;
     background: $bitstyles-button-danger-background-color-active;
-    border: $bitstyles-button-danger-border-active;
+    border-color: $bitstyles-button-danger-border-color-active;
     box-shadow: $bitstyles-button-danger-box-shadow-active;
   }
 
@@ -30,7 +30,7 @@
     color: $bitstyles-button-danger-color-disabled;
     cursor: default;
     background: $bitstyles-button-danger-background-color-disabled;
-    border: $bitstyles-button-danger-border-disabled;
+    border-color: $bitstyles-button-danger-border-color-disabled;
     box-shadow: $bitstyles-button-danger-box-shadow-disabled;
   }
 }

--- a/scss/bitstyles/atoms/button--danger/settings.scss
+++ b/scss/bitstyles/atoms/button--danger/settings.scss
@@ -12,7 +12,7 @@ $bitstyles-button-danger-transition:
 
 $bitstyles-button-danger-color: palette('white') !default;
 $bitstyles-button-danger-background-color: palette('brand-1', '80') !default;
-$bitstyles-button-danger-border: none !default;
+$bitstyles-button-danger-border-color: palette('brand-1', '80') !default;
 $bitstyles-button-danger-box-shadow: 0 0 spacing('s') rgba(palette('brand-2', '80'), 0.3) !default;
 
 //
@@ -20,7 +20,7 @@ $bitstyles-button-danger-box-shadow: 0 0 spacing('s') rgba(palette('brand-2', '8
 
 $bitstyles-button-danger-color-hover: palette('white') !default;
 $bitstyles-button-danger-background-color-hover: palette('danger', '100') !default;
-$bitstyles-button-danger-border-hover: none !default;
+$bitstyles-button-danger-border-color-hover: palette('danger', '100') !default;
 $bitstyles-button-danger-box-shadow-hover: 0 0 spacing('m') rgba(palette('danger', '100'), 0.3) !default;
 
 //
@@ -28,7 +28,7 @@ $bitstyles-button-danger-box-shadow-hover: 0 0 spacing('m') rgba(palette('danger
 
 $bitstyles-button-danger-color-active: palette('white') !default;
 $bitstyles-button-danger-background-color-active: palette('danger', '100') !default;
-$bitstyles-button-danger-border-active: none !default;
+$bitstyles-button-danger-border-color-active: palette('danger', '100') !default;
 $bitstyles-button-danger-box-shadow-active: 0 0 spacing('xs') rgba(palette('danger', '100'), 0.3) !default;
 
 //
@@ -36,5 +36,5 @@ $bitstyles-button-danger-box-shadow-active: 0 0 spacing('xs') rgba(palette('dang
 
 $bitstyles-button-danger-color-disabled: palette('black', '50') !default;
 $bitstyles-button-danger-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-danger-border-disabled: none !default;
+$bitstyles-button-danger-border-color-disabled: palette('black', '10') !default;
 $bitstyles-button-danger-box-shadow-disabled: none !default;

--- a/scss/bitstyles/atoms/button--icon-reversed/_.scss
+++ b/scss/bitstyles/atoms/button--icon-reversed/_.scss
@@ -5,7 +5,7 @@
   &:visited {
     color: var(--button-fg, $bitstyles-button-icon-reversed-color);
     background: var(--button-bg, $bitstyles-button-icon-reversed-background-color);
-    border: $bitstyles-button-icon-reversed-border;
+    border-color: $bitstyles-button-icon-reversed-border-color;
     box-shadow: $bitstyles-button-icon-reversed-box-shadow;
   }
 
@@ -14,7 +14,7 @@
     color: var(--button-fg-hover, $bitstyles-button-icon-reversed-color-hover);
     text-decoration: none;
     background: var(--button-bg-hover, $bitstyles-button-icon-reversed-background-color-hover);
-    border: $bitstyles-button-icon-reversed-border-hover;
+    border-color: $bitstyles-button-icon-reversed-border-color-hover;
     outline: none;
     box-shadow: $bitstyles-button-icon-reversed-box-shadow-hover;
   }
@@ -22,7 +22,7 @@
   &:active {
     color: $bitstyles-button-icon-reversed-color-active;
     background: $bitstyles-button-icon-reversed-background-color-active;
-    border: $bitstyles-button-icon-reversed-border-active;
+    border-color: $bitstyles-button-icon-reversed-border-color-active;
     box-shadow: $bitstyles-button-icon-reversed-box-shadow-active;
   }
 
@@ -30,7 +30,7 @@
     color: $bitstyles-button-icon-reversed-color-disabled;
     cursor: default;
     background: $bitstyles-button-icon-reversed-background-color-disabled;
-    border: $bitstyles-button-icon-reversed-border-disabled;
+    border-color: $bitstyles-button-icon-reversed-border-color-disabled;
     box-shadow: $bitstyles-button-icon-reversed-box-shadow-disabled;
   }
 }

--- a/scss/bitstyles/atoms/button--icon-reversed/settings.scss
+++ b/scss/bitstyles/atoms/button--icon-reversed/settings.scss
@@ -9,7 +9,7 @@ $bitstyles-button-icon-reversed-padding-horizontal: spacing('m') !default;
 
 $bitstyles-button-icon-reversed-color: palette('gray', '20') !default;
 $bitstyles-button-icon-reversed-background-color: transparent !default;
-$bitstyles-button-icon-reversed-border: none !default;
+$bitstyles-button-icon-reversed-border-color: transparent !default;
 $bitstyles-button-icon-reversed-border-radius: spacing('s') !default;
 $bitstyles-button-icon-reversed-box-shadow: none !default;
 
@@ -18,7 +18,7 @@ $bitstyles-button-icon-reversed-box-shadow: none !default;
 
 $bitstyles-button-icon-reversed-color-hover: palette('white') !default;
 $bitstyles-button-icon-reversed-background-color-hover: palette('gray', '80') !default;
-$bitstyles-button-icon-reversed-border-hover: none !default;
+$bitstyles-button-icon-reversed-border-color-hover: palette('gray', '80') !default;
 $bitstyles-button-icon-reversed-box-shadow-hover: none !default;
 
 //
@@ -26,7 +26,7 @@ $bitstyles-button-icon-reversed-box-shadow-hover: none !default;
 
 $bitstyles-button-icon-reversed-color-active: palette('white') !default;
 $bitstyles-button-icon-reversed-background-color-active: palette('gray', '80') !default;
-$bitstyles-button-icon-reversed-border-active: none !default;
+$bitstyles-button-icon-reversed-border-color-active: palette('gray', '80') !default;
 $bitstyles-button-icon-reversed-box-shadow-active: none !default;
 
 //
@@ -34,5 +34,5 @@ $bitstyles-button-icon-reversed-box-shadow-active: none !default;
 
 $bitstyles-button-icon-reversed-color-disabled: palette('black', '50') !default;
 $bitstyles-button-icon-reversed-background-color-disabled: transparent !default;
-$bitstyles-button-icon-reversed-border-disabled: none !default;
+$bitstyles-button-icon-reversed-border-color-disabled: transparent !default;
 $bitstyles-button-icon-reversed-box-shadow-disabled: none !default;

--- a/scss/bitstyles/atoms/button--icon/_.scss
+++ b/scss/bitstyles/atoms/button--icon/_.scss
@@ -8,7 +8,7 @@
   &:visited {
     color: $bitstyles-button-icon-color;
     background-color: $bitstyles-button-icon-background-color;
-    border: $bitstyles-button-icon-border;
+    border-color: $bitstyles-button-icon-border-color;
     box-shadow: $bitstyles-button-icon-box-shadow;
   }
 
@@ -16,21 +16,21 @@
   &:focus {
     color: $bitstyles-button-icon-color-hover;
     background: $bitstyles-button-icon-background-color-hover;
-    border: $bitstyles-button-icon-border-hover;
+    border-color: $bitstyles-button-icon-border-color-hover;
     box-shadow: $bitstyles-button-icon-box-shadow-hover;
   }
 
   &:active {
     color: $bitstyles-button-icon-color-active;
     background: $bitstyles-button-icon-background-color-active;
-    border: $bitstyles-button-icon-border-active;
+    border-color: $bitstyles-button-icon-border-color-active;
     box-shadow: $bitstyles-button-icon-box-shadow-active;
   }
 
   &:disabled {
     color: $bitstyles-button-icon-color-disabled;
     background: $bitstyles-button-icon-background-color-disabled;
-    border: $bitstyles-button-icon-border-disabled;
+    border-color: $bitstyles-button-icon-border-color-disabled;
     box-shadow: $bitstyles-button-icon-box-shadow-disabled;
   }
 

--- a/scss/bitstyles/atoms/button--icon/settings.scss
+++ b/scss/bitstyles/atoms/button--icon/settings.scss
@@ -9,7 +9,7 @@ $bitstyles-button-icon-padding-horizontal: spacing('m') !default;
 
 $bitstyles-button-icon-color: palette('gray', '50') !default;
 $bitstyles-button-icon-background-color: palette('gray', '5') !default;
-$bitstyles-button-icon-border: none !default;
+$bitstyles-button-icon-border-color: palette('gray', '5') !default;
 $bitstyles-button-icon-border-radius: spacing('s') !default;
 $bitstyles-button-icon-box-shadow: none !default;
 
@@ -18,7 +18,7 @@ $bitstyles-button-icon-box-shadow: none !default;
 
 $bitstyles-button-icon-color-hover: palette('gray', '80') !default;
 $bitstyles-button-icon-background-color-hover: palette('gray', '10') !default;
-$bitstyles-button-icon-border-hover: none !default;
+$bitstyles-button-icon-border-color-hover: palette('gray', '10') !default;
 $bitstyles-button-icon-box-shadow-hover: none !default;
 
 //
@@ -26,7 +26,7 @@ $bitstyles-button-icon-box-shadow-hover: none !default;
 
 $bitstyles-button-icon-color-active: palette('white') !default;
 $bitstyles-button-icon-background-color-active: palette('brand-1', '100') !default;
-$bitstyles-button-icon-border-active: none !default;
+$bitstyles-button-icon-border-color-active: palette('brand-1', '100') !default;
 $bitstyles-button-icon-box-shadow-active: none !default;
 
 //
@@ -34,5 +34,5 @@ $bitstyles-button-icon-box-shadow-active: none !default;
 
 $bitstyles-button-icon-color-disabled: palette('gray', '20') !default;
 $bitstyles-button-icon-background-color-disabled: palette('gray', '1') !default;
-$bitstyles-button-icon-border-disabled: none !default;
+$bitstyles-button-icon-border-color-disabled: palette('gray', '1') !default;
 $bitstyles-button-icon-box-shadow-disabled: none !default;

--- a/scss/bitstyles/atoms/button--menu/_.scss
+++ b/scss/bitstyles/atoms/button--menu/_.scss
@@ -10,7 +10,7 @@
   &:visited {
     color: $bitstyles-button-menu-color;
     background: $bitstyles-button-menu-background-color;
-    border: $bitstyles-button-menu-border;
+    border-color: $bitstyles-button-menu-border-color;
     box-shadow: none;
   }
 
@@ -19,7 +19,7 @@
     color: $bitstyles-button-menu-color-hover;
     text-decoration: none;
     background: $bitstyles-button-menu-background-color-hover;
-    border: $bitstyles-button-menu-border-hover;
+    border-color: $bitstyles-button-menu-border-color-hover;
     outline: none;
     box-shadow: none;
   }
@@ -27,7 +27,7 @@
   &:active {
     color: $bitstyles-button-menu-color-active;
     background: $bitstyles-button-menu-background-color-active;
-    border: $bitstyles-button-menu-border-active;
+    border-color: $bitstyles-button-menu-border-color-active;
     box-shadow: none;
   }
 }

--- a/scss/bitstyles/atoms/button--menu/settings.scss
+++ b/scss/bitstyles/atoms/button--menu/settings.scss
@@ -9,18 +9,18 @@ $bitstyles-button-menu-padding-horizontal: spacing('m') !default;
 
 $bitstyles-button-menu-color: palette('gray', '60') !default;
 $bitstyles-button-menu-background-color: palette('white', '100') !default;
-$bitstyles-button-menu-border: 0 !default;
+$bitstyles-button-menu-border-color: palette('white', '100') !default;
 
 //
 // Hover colors ////////////////////////////////////////
 
 $bitstyles-button-menu-color-hover: palette('gray', '80') !default;
 $bitstyles-button-menu-background-color-hover: palette('gray', '1') !default;
-$bitstyles-button-menu-border-hover: 0 !default;
+$bitstyles-button-menu-border-color-hover: palette('gray', '1') !default;
 
 //
 // Active colors ////////////////////////////////////////
 
 $bitstyles-button-menu-color-active: palette('white') !default;
 $bitstyles-button-menu-background-color-active: palette('brand-2', '100') !default;
-$bitstyles-button-menu-border-active: 0 !default;
+$bitstyles-button-menu-border-color-active: palette('brand-2', '100') !default;

--- a/scss/bitstyles/atoms/button--mode/_.scss
+++ b/scss/bitstyles/atoms/button--mode/_.scss
@@ -12,7 +12,7 @@
   &:visited {
     color: $bitstyles-button-mode-color;
     background: $bitstyles-button-mode-background-color;
-    border: $bitstyles-button-mode-border;
+    border-color: $bitstyles-button-mode-border-color;
     box-shadow: $bitstyles-button-mode-box-shadow;
   }
 
@@ -20,21 +20,21 @@
   &:focus {
     color: $bitstyles-button-mode-color-hover;
     background: $bitstyles-button-mode-background-color-hover;
-    border: $bitstyles-button-mode-border-hover;
+    border-color: $bitstyles-button-mode-border-color-hover;
     box-shadow: $bitstyles-button-mode-box-shadow-hover;
   }
 
   &:active {
     color: $bitstyles-button-mode-color-active;
     background: $bitstyles-button-mode-background-color-active;
-    border: $bitstyles-button-mode-border-active;
+    border-color: $bitstyles-button-mode-border-color-active;
     box-shadow: $bitstyles-button-mode-box-shadow-active;
   }
 
   &[aria-pressed="true"] {
     color: $bitstyles-button-mode-color-pressed;
     background: $bitstyles-button-mode-background-color-pressed;
-    border: $bitstyles-button-mode-border-pressed;
+    border-color: $bitstyles-button-mode-border-color-pressed;
     box-shadow: $bitstyles-button-mode-box-shadow-pressed;
   }
 
@@ -42,7 +42,7 @@
     color: $bitstyles-button-mode-color-disabled;
     cursor: default;
     background: $bitstyles-button-mode-background-color-disabled;
-    border: $bitstyles-button-mode-border-disabled;
+    border-color: $bitstyles-button-mode-border-color-disabled;
     box-shadow: $bitstyles-button-mode-box-shadow-disabled;
   }
 }

--- a/scss/bitstyles/atoms/button--mode/settings.scss
+++ b/scss/bitstyles/atoms/button--mode/settings.scss
@@ -16,7 +16,7 @@ $bitstyles-button-mode-icon-spacing: spacing('s') !default;
 
 $bitstyles-button-mode-color: palette('gray', '90') !default;
 $bitstyles-button-mode-background-color: transparent !default;
-$bitstyles-button-mode-border: none !default;
+$bitstyles-button-mode-border-color: transparent !default;
 $bitstyles-button-mode-box-shadow: none !default;
 
 //
@@ -24,7 +24,7 @@ $bitstyles-button-mode-box-shadow: none !default;
 
 $bitstyles-button-mode-color-hover: palette('gray', '90') !default;
 $bitstyles-button-mode-background-color-hover: palette('white', '95') !default;
-$bitstyles-button-mode-border-hover: none !default;
+$bitstyles-button-mode-border-color-hover: palette('white', '95') !default;
 $bitstyles-button-mode-box-shadow-hover: 0 0 spacing('m') rgba(palette('brand-1'), 0.1) !default;
 
 //
@@ -32,7 +32,7 @@ $bitstyles-button-mode-box-shadow-hover: 0 0 spacing('m') rgba(palette('brand-1'
 
 $bitstyles-button-mode-color-active: palette('white') !default;
 $bitstyles-button-mode-background-color-active: palette('brand-2', '100') !default;
-$bitstyles-button-mode-border-active: none !default;
+$bitstyles-button-mode-border-color-active: palette('brand-2', '100') !default;
 $bitstyles-button-mode-box-shadow-active: 0 0 spacing('xs') rgba(palette('brand-1', '100'), 0.1) !default;
 
 //
@@ -40,7 +40,7 @@ $bitstyles-button-mode-box-shadow-active: 0 0 spacing('xs') rgba(palette('brand-
 
 $bitstyles-button-mode-color-pressed: palette('gray', '80') !default;
 $bitstyles-button-mode-background-color-pressed: palette('white', '100') !default;
-$bitstyles-button-mode-border-pressed: none !default;
+$bitstyles-button-mode-border-color-pressed: palette('white', '100') !default;
 $bitstyles-button-mode-box-shadow-pressed: 0 0 spacing('s') rgba(palette('brand-1', '100'), 0.1) !default;
 
 //
@@ -48,5 +48,5 @@ $bitstyles-button-mode-box-shadow-pressed: 0 0 spacing('s') rgba(palette('brand-
 
 $bitstyles-button-mode-color-disabled: palette('black', '50') !default;
 $bitstyles-button-mode-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-mode-border-disabled: none !default;
+$bitstyles-button-mode-border-color-disabled: palette('black', '10') !default;
 $bitstyles-button-mode-box-shadow-disabled: none !default;

--- a/scss/bitstyles/atoms/button--nav-large/_.scss
+++ b/scss/bitstyles/atoms/button--nav-large/_.scss
@@ -3,6 +3,7 @@
 .a-button--nav-large {
   display: flex;
   padding: $bitstyles-button-nav-large-padding-vertical $bitstyles-button-nav-large-padding-horizontal;
+  border: 0;
   border-radius: $bitstyles-button-nav-large-border-radius;
 
   &,

--- a/scss/bitstyles/atoms/button--nav-large/_.scss
+++ b/scss/bitstyles/atoms/button--nav-large/_.scss
@@ -10,7 +10,7 @@
   &:visited {
     color: $bitstyles-button-nav-large-color;
     background: $bitstyles-button-nav-large-background-color;
-    border-bottom: $bitstyles-button-nav-large-border;
+    border: $bitstyles-button-nav-large-border;
     box-shadow: $bitstyles-button-nav-large-box-shadow;
   }
 
@@ -19,7 +19,7 @@
     color: $bitstyles-button-nav-large-color-hover;
     text-decoration: none;
     background: $bitstyles-button-nav-large-background-color-hover;
-    border-bottom: $bitstyles-button-nav-large-border-hover;
+    border: $bitstyles-button-nav-large-border-hover;
     outline: none;
     box-shadow: $bitstyles-button-nav-large-box-shadow-hover;
   }
@@ -27,14 +27,14 @@
   &:active {
     color: $bitstyles-button-nav-large-color-active;
     background: $bitstyles-button-nav-large-background-color-active;
-    border-bottom: $bitstyles-button-nav-large-border-active;
+    border: $bitstyles-button-nav-large-border-active;
     box-shadow: $bitstyles-button-nav-large-box-shadow-active;
   }
 
   &[aria-current] {
     color: $bitstyles-button-nav-large-color-current;
     background: $bitstyles-button-nav-large-background-color-current;
-    border-bottom: $bitstyles-button-nav-large-border-current;
+    border: $bitstyles-button-nav-large-border-current;
     box-shadow: $bitstyles-button-nav-large-box-shadow-current;
   }
 
@@ -42,7 +42,7 @@
     color: $bitstyles-button-nav-large-color-disabled;
     cursor: default;
     background: $bitstyles-button-nav-large-background-color-disabled;
-    border-bottom: $bitstyles-button-nav-large-border-disabled;
+    border: $bitstyles-button-nav-large-border-disabled;
     box-shadow: $bitstyles-button-nav-large-box-shadow-disabled;
   }
 }

--- a/scss/bitstyles/atoms/button--nav-large/settings.scss
+++ b/scss/bitstyles/atoms/button--nav-large/settings.scss
@@ -29,7 +29,7 @@ $bitstyles-button-nav-large-box-shadow-hover: none !default;
 // Active colors ////////////////////////////////////////
 
 $bitstyles-button-nav-large-color-active: palette('white') !default;
-$bitstyles-button-nav-large-background-color-active: palette('brand-1', '100') !default;
+$bitstyles-button-nav-large-background-color-active: palette('brand-1', '70') !default;
 $bitstyles-button-nav-large-border-active: none !default;
 $bitstyles-button-nav-large-box-shadow-active: none !default;
 

--- a/scss/bitstyles/atoms/button--nav/_.scss
+++ b/scss/bitstyles/atoms/button--nav/_.scss
@@ -8,7 +8,7 @@
   &:visited {
     color: $bitstyles-button-nav-color;
     background: $bitstyles-button-nav-background-color;
-    border: $bitstyles-button-nav-border;
+    border-color: $bitstyles-button-nav-border-color;
     box-shadow: $bitstyles-button-nav-box-shadow;
   }
 
@@ -17,7 +17,7 @@
     color: $bitstyles-button-nav-color-hover;
     text-decoration: none;
     background: $bitstyles-button-nav-background-color-hover;
-    border: $bitstyles-button-nav-border-hover;
+    border-color: $bitstyles-button-nav-border-color-hover;
     outline: none;
     box-shadow: $bitstyles-button-nav-box-shadow-hover;
   }
@@ -25,14 +25,14 @@
   &:active {
     color: $bitstyles-button-nav-color-active;
     background: $bitstyles-button-nav-background-color-active;
-    border: $bitstyles-button-nav-border-active;
+    border-color: $bitstyles-button-nav-border-color-active;
     box-shadow: $bitstyles-button-nav-box-shadow-active;
   }
 
   &[aria-current] {
     color: $bitstyles-button-nav-color-current;
     background: $bitstyles-button-nav-background-color-current;
-    border: $bitstyles-button-nav-border-current;
+    border-color: $bitstyles-button-nav-border-color-current;
     box-shadow: $bitstyles-button-nav-box-shadow-current;
   }
 
@@ -40,7 +40,7 @@
     color: $bitstyles-button-nav-color-disabled;
     cursor: default;
     background: $bitstyles-button-nav-background-color-disabled;
-    border: $bitstyles-button-nav-border-disabled;
+    border-color: $bitstyles-button-nav-border-color-disabled;
     box-shadow: $bitstyles-button-nav-box-shadow-disabled;
   }
 }

--- a/scss/bitstyles/atoms/button--nav/settings.scss
+++ b/scss/bitstyles/atoms/button--nav/settings.scss
@@ -15,7 +15,7 @@ $bitstyles-button-nav-transition:
 
 $bitstyles-button-nav-color: palette('gray', '20') !default;
 $bitstyles-button-nav-background-color: transparent !default;
-$bitstyles-button-nav-border: none !default;
+$bitstyles-button-nav-border-color: transparent !default;
 $bitstyles-button-nav-box-shadow: none !default;
 
 //
@@ -23,7 +23,7 @@ $bitstyles-button-nav-box-shadow: none !default;
 
 $bitstyles-button-nav-color-hover: palette('white') !default;
 $bitstyles-button-nav-background-color-hover: palette('gray', '60') !default;
-$bitstyles-button-nav-border-hover: none !default;
+$bitstyles-button-nav-border-color-hover: palette('gray', '60') !default;
 $bitstyles-button-nav-box-shadow-hover: 0 0 spacing('l') rgba(palette('black', '100'), 0.3) !default;
 
 //
@@ -31,7 +31,7 @@ $bitstyles-button-nav-box-shadow-hover: 0 0 spacing('l') rgba(palette('black', '
 
 $bitstyles-button-nav-color-active: palette('white') !default;
 $bitstyles-button-nav-background-color-active: palette('brand-1', '100') !default;
-$bitstyles-button-nav-border-active: none !default;
+$bitstyles-button-nav-border-color-active: palette('brand-1', '100') !default;
 $bitstyles-button-nav-box-shadow-active: 0 0 spacing('xs') rgba(palette('black', '100'), 0.3) !default;
 
 //
@@ -39,7 +39,7 @@ $bitstyles-button-nav-box-shadow-active: 0 0 spacing('xs') rgba(palette('black',
 
 $bitstyles-button-nav-color-disabled: palette('black', '50') !default;
 $bitstyles-button-nav-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-nav-border-disabled: none !default;
+$bitstyles-button-nav-border-color-disabled: palette('black', '10') !default;
 $bitstyles-button-nav-box-shadow-disabled: none !default;
 
 //
@@ -47,5 +47,5 @@ $bitstyles-button-nav-box-shadow-disabled: none !default;
 
 $bitstyles-button-nav-color-current: palette('white', '100') !default;
 $bitstyles-button-nav-background-color-current: palette('gray', '100') !default;
-$bitstyles-button-nav-border-current: none !default;
+$bitstyles-button-nav-border-color-current: palette('gray', '100') !default;
 $bitstyles-button-nav-box-shadow-current: none !default;

--- a/scss/bitstyles/atoms/button--tab/_.scss
+++ b/scss/bitstyles/atoms/button--tab/_.scss
@@ -8,6 +8,7 @@
 
 .a-button--tab {
   position: relative;
+  border: 0;
   border-radius: $bitstyles-button-tab-border-radius;
 
   &,

--- a/scss/bitstyles/atoms/button--ui/_.scss
+++ b/scss/bitstyles/atoms/button--ui/_.scss
@@ -5,7 +5,7 @@
   &:visited {
     color: $bitstyles-button-ui-color;
     background: $bitstyles-button-ui-background-color;
-    border: $bitstyles-button-ui-border;
+    border-color: $bitstyles-button-ui-border-color;
     box-shadow: none;
   }
 
@@ -14,14 +14,14 @@
     color: $bitstyles-button-ui-color-hover;
     text-decoration: none;
     background: $bitstyles-button-ui-background-color-hover;
-    border: $bitstyles-button-ui-border-hover;
+    border-color: $bitstyles-button-ui-border-color-hover;
     box-shadow: none;
   }
 
   &:active {
     color: $bitstyles-button-ui-color-active;
     background: $bitstyles-button-ui-background-color-active;
-    border: $bitstyles-button-ui-border-active;
+    border-color: $bitstyles-button-ui-border-color-active;
     box-shadow: none;
   }
 
@@ -29,7 +29,7 @@
     color: $bitstyles-button-ui-color-disabled;
     cursor: default;
     background: $bitstyles-button-ui-background-color-disabled;
-    border: $bitstyles-button-ui-border-disabled;
+    border-color: $bitstyles-button-ui-border-color-disabled;
     box-shadow: none;
   }
 
@@ -37,6 +37,6 @@
   &[aria-expanded="true"] {
     color: $bitstyles-button-ui-color-pressed;
     background: $bitstyles-button-ui-background-color-pressed;
-    border: $bitstyles-button-ui-border-pressed;
+    border-color: $bitstyles-button-ui-border-color-pressed;
   }
 }

--- a/scss/bitstyles/atoms/button--ui/settings.scss
+++ b/scss/bitstyles/atoms/button--ui/settings.scss
@@ -12,32 +12,32 @@ $bitstyles-button-ui-transition:
 
 $bitstyles-button-ui-color: palette('gray', '60') !default;
 $bitstyles-button-ui-background-color: palette('gray', '1') !default;
-$bitstyles-button-ui-border: 2px solid palette('gray', '40') !default;
+$bitstyles-button-ui-border-color: palette('gray', '40') !default;
 
 //
 // Hover colors ////////////////////////////////////////
 
 $bitstyles-button-ui-color-hover: palette('gray', '80') !default;
 $bitstyles-button-ui-background-color-hover: palette('gray', '10') !default;
-$bitstyles-button-ui-border-hover: 2px solid palette('gray', '60') !default;
+$bitstyles-button-ui-border-color-hover: palette('gray', '60') !default;
 
 //
 // Active colors ////////////////////////////////////////
 
 $bitstyles-button-ui-color-active: palette('white') !default;
 $bitstyles-button-ui-background-color-active: palette('brand-2', '100') !default;
-$bitstyles-button-ui-border-active: 2px solid palette('brand-2', '100') !default;
+$bitstyles-button-ui-border-color-active: palette('brand-2', '100') !default;
 
 //
 // Pressed colors ////////////////////////////////////////
 
 $bitstyles-button-ui-color-pressed: palette('gray', '90') !default;
 $bitstyles-button-ui-background-color-pressed: palette('brand-2', '100') !default;
-$bitstyles-button-ui-border-pressed: 2px solid palette('brand-2', '100') !default;
+$bitstyles-button-ui-border-color-pressed: palette('brand-2', '100') !default;
 
 //
 // Disabled colors ////////////////////////////////////////
 
 $bitstyles-button-ui-color-disabled: palette('black', '50') !default;
 $bitstyles-button-ui-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-ui-border-disabled: 2px solid palette('gray', '5') !default;
+$bitstyles-button-ui-border-color-disabled: palette('gray', '5') !default;

--- a/scss/bitstyles/atoms/button/_.scss
+++ b/scss/bitstyles/atoms/button/_.scss
@@ -26,7 +26,7 @@
   &:visited {
     color: $bitstyles-button-color;
     background: $bitstyles-button-background-color;
-    border: $bitstyles-button-border;
+    border: $bitstyles-button-border-width solid $bitstyles-button-border-color;
     box-shadow: $bitstyles-button-box-shadow;
   }
 

--- a/scss/bitstyles/atoms/button/_.scss
+++ b/scss/bitstyles/atoms/button/_.scss
@@ -35,7 +35,7 @@
     color: $bitstyles-button-color-hover;
     text-decoration: none;
     background: $bitstyles-button-background-color-hover;
-    border: $bitstyles-button-border-hover;
+    border-color: $bitstyles-button-border-color-hover;
     outline: none;
     box-shadow: $bitstyles-button-box-shadow-hover;
   }
@@ -43,7 +43,7 @@
   &:active {
     color: $bitstyles-button-color-active;
     background: $bitstyles-button-background-color-active;
-    border: $bitstyles-button-border-active;
+    border-color: $bitstyles-button-border-color-active;
     box-shadow: $bitstyles-button-box-shadow-active;
   }
 
@@ -51,7 +51,7 @@
     color: $bitstyles-button-color-disabled;
     cursor: default;
     background: $bitstyles-button-background-color-disabled;
-    border: $bitstyles-button-border-disabled;
+    border-color: $bitstyles-button-border-color-disabled;
     box-shadow: $bitstyles-button-box-shadow-disabled;
   }
 }

--- a/scss/bitstyles/atoms/button/settings.scss
+++ b/scss/bitstyles/atoms/button/settings.scss
@@ -24,7 +24,7 @@ $bitstyles-button-box-shadow: 0 0 spacing('xs') rgba(palette('brand-1', '80'), 0
 
 $bitstyles-button-color-hover: palette('white') !default;
 $bitstyles-button-background-color-hover: palette('brand-1') !default;
-$bitstyles-button-border-hover: 2px solid palette('brand-1') !default;
+$bitstyles-button-border-color-hover: palette('brand-1') !default;
 $bitstyles-button-box-shadow-hover: 0 0 spacing('s') rgba(palette('brand-1'), 0.2) !default;
 
 //
@@ -32,7 +32,7 @@ $bitstyles-button-box-shadow-hover: 0 0 spacing('s') rgba(palette('brand-1'), 0.
 
 $bitstyles-button-color-active: palette('white') !default;
 $bitstyles-button-background-color-active: palette('brand-2', '100') !default;
-$bitstyles-button-border-active: 2px solid palette('brand-2', '100') !default;
+$bitstyles-button-border-color-active: palette('brand-2', '100')  !default;
 $bitstyles-button-box-shadow-active: 0 0 spacing('s') rgba(palette('brand-1', '100'), 0.3) !default;
 
 //
@@ -40,5 +40,5 @@ $bitstyles-button-box-shadow-active: 0 0 spacing('s') rgba(palette('brand-1', '1
 
 $bitstyles-button-color-disabled: palette('black', '50') !default;
 $bitstyles-button-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-border-disabled: 2px solid palette('black', '10') !default;
+$bitstyles-button-border-color-disabled: palette('black', '10')  !default;
 $bitstyles-button-box-shadow-disabled: none !default;

--- a/scss/bitstyles/atoms/button/settings.scss
+++ b/scss/bitstyles/atoms/button/settings.scss
@@ -16,7 +16,8 @@ $bitstyles-button-icon-spacing: spacing('s') !default;
 
 $bitstyles-button-color: palette('white') !default;
 $bitstyles-button-background-color: palette('brand-1', '80') !default;
-$bitstyles-button-border: 2px solid palette('brand-1', '80') !default;
+$bitstyles-button-border-width: spacing('xxxs') !default;
+$bitstyles-button-border-color: palette('brand-1', '80') !default;
 $bitstyles-button-box-shadow: 0 0 spacing('xs') rgba(palette('brand-1', '80'), 0.2) !default;
 
 //
@@ -32,7 +33,7 @@ $bitstyles-button-box-shadow-hover: 0 0 spacing('s') rgba(palette('brand-1'), 0.
 
 $bitstyles-button-color-active: palette('white') !default;
 $bitstyles-button-background-color-active: palette('brand-2', '100') !default;
-$bitstyles-button-border-color-active: palette('brand-2', '100')  !default;
+$bitstyles-button-border-color-active: palette('brand-2', '100') !default;
 $bitstyles-button-box-shadow-active: 0 0 spacing('s') rgba(palette('brand-1', '100'), 0.3) !default;
 
 //
@@ -40,5 +41,5 @@ $bitstyles-button-box-shadow-active: 0 0 spacing('s') rgba(palette('brand-1', '1
 
 $bitstyles-button-color-disabled: palette('black', '50') !default;
 $bitstyles-button-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-border-color-disabled: palette('black', '10')  !default;
+$bitstyles-button-border-color-disabled: palette('black', '10') !default;
 $bitstyles-button-box-shadow-disabled: none !default;

--- a/scss/bitstyles/base/forms/settings-checkbox.scss
+++ b/scss/bitstyles/base/forms/settings-checkbox.scss
@@ -6,29 +6,30 @@ $bitstyles-checkbox-border-radius: spacing('xxs') !default;
 // Base colors ////////////////////////////////////////
 $bitstyles-checkbox-color: palette('black', '80') !default;
 $bitstyles-checkbox-background-color: palette('background') !default;
-$bitstyles-checkbox-border: 2px solid !default;
+$bitstyles-checkbox-border-width: spacing('xxxs') !default;
+$bitstyles-checkbox-border-color: palette('black', '80') !default;
 
 //
 // Hover colors ////////////////////////////////////////
 $bitstyles-checkbox-color-hover: palette('brand-1') !default;
 $bitstyles-checkbox-background-color-hover: palette('background') !default;
-$bitstyles-checkbox-border-hover: 2px solid !default;
+$bitstyles-checkbox-border-color-hover: palette('brand-1') !default;
 
 //
 // Checked colors ////////////////////////////////////////
 $bitstyles-checkbox-color-checked: palette('background') !default;
 $bitstyles-checkbox-background-color-checked: palette('brand-1') !default;
-$bitstyles-checkbox-border-checked: 2px solid palette('brand-1') !default;
+$bitstyles-checkbox-border-color-checked: palette('brand-1') !default;
 $bitstyles-checkbox-background-image-checked: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='#ffffff' d='m83.07 11.71-44.41 44.59-21.73-21.81-15.93 15.99 37.65 37.81 60.35-60.59z'/%3E%3C/svg%3E") !default;
 
 //
 // Disabled colors ////////////////////////////////////////
 $bitstyles-checkbox-color-disabled: palette('black', '40') !default;
 $bitstyles-checkbox-background-color-disabled: palette('black', '20') !default;
-$bitstyles-checkbox-border-disabled: 2px solid !default;
+$bitstyles-checkbox-border-color-disabled: palette('black', '40') !default;
 
 //
 // Disabled-checked colors ////////////////////////////////////////
 $bitstyles-checkbox-color-disabled-checked: palette('text', '80') !default;
 $bitstyles-checkbox-background-color-disabled-checked: palette('black', '30') !default;
-$bitstyles-checkbox-border-disabled-checked: 2px solid palette('black', '30') !default;
+$bitstyles-checkbox-border-color-disabled-checked: palette('black', '30') !default;

--- a/scss/bitstyles/base/forms/settings-input.scss
+++ b/scss/bitstyles/base/forms/settings-input.scss
@@ -10,7 +10,8 @@ $bitstyles-input-checkbox-size: spacing('m') !default;
 // Base colors ////////////////////////////////////////
 
 $bitstyles-input-color: palette('text') !default;
-$bitstyles-input-border: 2px solid palette('gray', '40') !default;
+$bitstyles-input-border-width: spacing('xxxs');
+$bitstyles-input-border-color: palette('gray', '40') !default;
 $bitstyles-input-background: palette('white') !default;
 $bitstyles-input-box-shadow: 0 0 spacing('xs') rgba(palette('gray', '90'), 0.05);
 
@@ -19,14 +20,14 @@ $bitstyles-input-box-shadow: 0 0 spacing('xs') rgba(palette('gray', '90'), 0.05)
 
 $bitstyles-input-background-hover: palette('gray', '1') !default;
 $bitstyles-input-color-hover: palette('gray', '70') !default;
-$bitstyles-input-border-hover: 2px solid palette('gray', '60') !default;
+$bitstyles-input-border-color-hover: 2px solid palette('gray', '60') !default;
 $bitstyles-input-box-shadow-hover: 0 0 spacing('s') rgba(palette('brand-1', '90'), 0.05);
 
 //
 // Active colors ////////////////////////////////////////
 
 $bitstyles-input-color-active: palette('gray', '80') !default;
-$bitstyles-input-border-active: 2px solid palette('gray', '80') !default;
+$bitstyles-input-border-color-active: 2px solid palette('gray', '80') !default;
 $bitstyles-input-background-active: palette('white') !default;
 $bitstyles-input-box-shadow-active: 0 0 spacing('xxs') rgba(palette('brand-1', '90'), 0.15);
 
@@ -35,7 +36,7 @@ $bitstyles-input-box-shadow-active: 0 0 spacing('xxs') rgba(palette('brand-1', '
 
 $bitstyles-input-background-disabled: palette('black', '10') !default;
 $bitstyles-input-color-disabled: palette('text') !default;
-$bitstyles-input-border-disabled: 2px solid palette('black', '20') !default;
+$bitstyles-input-border-color-disabled: 2px solid palette('black', '20') !default;
 $bitstyles-input-box-shadow-disabled: none;
 
 //

--- a/scss/bitstyles/base/forms/settings-radio.scss
+++ b/scss/bitstyles/base/forms/settings-radio.scss
@@ -6,28 +6,29 @@ $bitstyles-radio-border-radius: $bitstyles-border-radius-round !default;
 // Base colors ////////////////////////////////////////
 $bitstyles-radio-color: palette('text', '80') !default;
 $bitstyles-radio-background-color: palette('background') !default;
-$bitstyles-radio-border: 2px solid !default;
+$bitstyles-radio-border-width: spacing('xxxs') !default;
+$bitstyles-radio-border-color: palette('text', '80') !default;
 
 //
 // Hover colors ////////////////////////////////////////
 $bitstyles-radio-color-hover: palette('brand-1') !default;
 $bitstyles-radio-background-color-hover: palette('background') !default;
-$bitstyles-radio-border-hover: 2px solid !default;
+$bitstyles-radio-border-color-hover: palette('brand-1') !default;
 
 //
 // Checked colors ////////////////////////////////////////
 $bitstyles-radio-color-checked: palette('brand-1') !default;
 $bitstyles-radio-background-color-checked: palette('background') !default;
-$bitstyles-radio-border-checked: 2px solid palette('brand-1') !default;
+$bitstyles-radio-border-color-checked: palette('brand-1') !default;
 
 //
 // Disabled colors ////////////////////////////////////////
 $bitstyles-radio-color-disabled: palette('black', '40') !default;
 $bitstyles-radio-background-color-disabled: palette('black', '20') !default;
-$bitstyles-radio-border-disabled: 2px solid !default;
+$bitstyles-radio-border-color-disabled: palette('black', '40') !default;
 
 //
 // Disabled-checked colors ////////////////////////////////////////
 $bitstyles-radio-color-disabled-checked: palette('black', '40') !default;
 $bitstyles-radio-background-color-disabled-checked: palette('black', '20') !default;
-$bitstyles-radio-border-disabled-checked: 2px solid !default;
+$bitstyles-radio-border-color-disabled-checked: palette('black', '40') !default;

--- a/scss/bitstyles/base/forms/settings-select.scss
+++ b/scss/bitstyles/base/forms/settings-select.scss
@@ -7,21 +7,22 @@ $bitstyles-select-border-radius: spacing('xs') !default;
 //
 // Base appearance ////////////////////////////////////////
 $bitstyles-select-color: palette('gray', '60') !default;
-$bitstyles-select-border: 2px solid palette('gray', '40') !default;
+$bitstyles-select-border-width: spacing('xxxs');
+$bitstyles-select-border-color: palette('gray', '40') !default;
 $bitstyles-select-background-color: transparent !default;
 $bitstyles-select-background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '60')}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
 
 //
 // Hover styles ////////////////////////////////////////
 $bitstyles-select-color-hover: palette('gray', '80') !default;
-$bitstyles-select-border-hover: 2px solid palette('gray', '80') !default;
+$bitstyles-select-border-color-hover: palette('gray', '80') !default;
 $bitstyles-select-background-color-hover: palette('gray', '1') !default;
 $bitstyles-select-background-image-hover: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-hover}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
 
 //
 // Active styles ////////////////////////////////////////
 $bitstyles-select-color-active: palette('gray', '80') !default;
-$bitstyles-select-border-active: 2px solid palette('gray', '80') !default;
+$bitstyles-select-border-color-active: palette('gray', '80') !default;
 $bitstyles-select-background-color-active: transparent !default;
 $bitstyles-select-background-image-active: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '80')}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;
 
@@ -35,6 +36,6 @@ $bitstyles-select-background-image-invalid: url("data:image/svg+xml,%3Csvg width
 //
 // Disabled styles ////////////////////////////////////////
 $bitstyles-select-color-disabled: palette('text') !default;
-$bitstyles-select-border-disabled: 2px solid palette('black', '20') !default;
+$bitstyles-select-border-color-disabled: 2px solid palette('black', '20') !default;
 $bitstyles-select-background-color-disabled: palette('black', '10') !default;
 $bitstyles-select-background-image-disabled: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '50')}' d='M52.8,68.9,86.32,36a4,4,0,0,0-2.8-6.86h-67A4,4,0,0,0,13.68,36L47.2,68.9A4,4,0,0,0,52.8,68.9Z'/%3E%3C/svg%3E") !default;

--- a/scss/bitstyles/tools/_input--checkbox.scss
+++ b/scss/bitstyles/tools/_input--checkbox.scss
@@ -1,14 +1,14 @@
 @mixin input--checkbox {
   color: $bitstyles-checkbox-color;
   background-color: $bitstyles-checkbox-background-color;
-  border: $bitstyles-checkbox-border;
+  border: $bitstyles-checkbox-border-width solid $bitstyles-checkbox-border-color;
   border-radius: $bitstyles-checkbox-border-radius;
 
   &:hover,
   &:focus {
     color: $bitstyles-checkbox-color-hover;
     background-color: $bitstyles-checkbox-background-color-hover;
-    border: $bitstyles-checkbox-border-hover;
+    border-color: $bitstyles-checkbox-border-color-hover;
     outline: none;
   }
 
@@ -29,7 +29,7 @@
   &:checked {
     color: $bitstyles-checkbox-color-checked;
     background-color: $bitstyles-checkbox-background-color-checked;
-    border: $bitstyles-checkbox-border-checked;
+    border-color: $bitstyles-checkbox-border-color-checked;
 
     &::after {
       opacity: 1;
@@ -40,12 +40,12 @@
   &[disabled] {
     color: $bitstyles-checkbox-color-disabled;
     background-color: $bitstyles-checkbox-background-color-disabled;
-    border: $bitstyles-checkbox-border-disabled;
+    border-color: $bitstyles-checkbox-border-color-disabled;
 
     &:checked {
       color: $bitstyles-checkbox-color-disabled-checked;
       background-color: $bitstyles-checkbox-background-color-disabled-checked;
-      border: $bitstyles-checkbox-border-disabled-checked;
+      border-color: $bitstyles-checkbox-border-color-disabled-checked;
     }
   }
 }

--- a/scss/bitstyles/tools/_input--radio.scss
+++ b/scss/bitstyles/tools/_input--radio.scss
@@ -1,7 +1,7 @@
 @mixin input--radio {
   color: $bitstyles-radio-color;
   background-color: $bitstyles-radio-background-color;
-  border: $bitstyles-radio-border;
+  border: $bitstyles-radio-border-width solid $bitstyles-radio-border-color;
   border-radius: $bitstyles-radio-border-radius;
 
   &::after {
@@ -22,14 +22,14 @@
   &:focus {
     color: $bitstyles-radio-color-hover;
     background-color: $bitstyles-radio-background-color-hover;
-    border: $bitstyles-radio-border-hover;
+    border-color: $bitstyles-radio-border-color-hover;
     outline: none;
   }
 
   &:checked {
     color: $bitstyles-radio-color-checked;
     background-color: $bitstyles-radio-background-color-checked;
-    border: $bitstyles-radio-border-checked;
+    border-color: $bitstyles-radio-border-color-checked;
 
     &::after {
       opacity: 1;
@@ -40,12 +40,12 @@
   &[disabled] {
     color: $bitstyles-radio-color-disabled;
     background-color: $bitstyles-radio-background-color-disabled;
-    border: $bitstyles-radio-border-disabled;
+    border-color: $bitstyles-radio-border-color-disabled;
 
     &:checked {
       color: $bitstyles-radio-color-disabled-checked;
       background-color: $bitstyles-radio-background-color-disabled-checked;
-      border: $bitstyles-radio-border-disabled-checked;
+      border-color: $bitstyles-radio-border-color-disabled-checked;
     }
 
     &::after {

--- a/scss/bitstyles/tools/_input.scss
+++ b/scss/bitstyles/tools/_input.scss
@@ -27,14 +27,14 @@
   font-weight: $bitstyles-font-weight-medium;
   color: $bitstyles-input-color;
   background-color: $bitstyles-input-background;
-  border: $bitstyles-input-border;
+  border: $bitstyles-input-border-width solid $bitstyles-input-border-color;
   border-radius: $bitstyles-input-border-radius;
   box-shadow: $bitstyles-input-box-shadow;
 
   &:hover {
     color: $bitstyles-input-color-hover;
     background-color: $bitstyles-input-background-hover;
-    border: $bitstyles-input-border-hover;
+    border-color: $bitstyles-input-border-color-hover;
     box-shadow: $bitstyles-input-box-shadow-hover;
   }
 
@@ -42,7 +42,7 @@
   &:focus {
     color: $bitstyles-input-color-active;
     background-color: $bitstyles-input-background-active;
-    border: $bitstyles-input-border-active;
+    border-color: $bitstyles-input-border-color-active;
     outline: none;
     box-shadow: $bitstyles-input-box-shadow-active;
   }
@@ -59,7 +59,7 @@
     color: $bitstyles-input-color-disabled;
     cursor: default;
     background: $bitstyles-input-background-disabled;
-    border: $bitstyles-input-border-disabled;
+    border-color: $bitstyles-input-border-color-disabled;
     box-shadow: $bitstyles-input-box-shadow-disabled;
   }
 }

--- a/scss/bitstyles/tools/_select.scss
+++ b/scss/bitstyles/tools/_select.scss
@@ -13,7 +13,7 @@
   background-position: right 0.75em top 50%;
   background-repeat: no-repeat;
   background-size: 1em;
-  border: $bitstyles-select-border;
+  border: $bitstyles-select-border-width solid $bitstyles-select-border-color;
   border-radius: $bitstyles-select-border-radius;
   transition:
     color $bitstyles-transition-duration $bitstyles-transition-easing,
@@ -29,7 +29,7 @@
     color: $bitstyles-select-color-hover;
     background-color: $bitstyles-select-background-color-hover;
     background-image: $bitstyles-select-background-image-hover;
-    border: $bitstyles-select-border-hover;
+    border-color: $bitstyles-select-border-color-hover;
   }
 
   &:focus,
@@ -37,7 +37,7 @@
     color: $bitstyles-select-color-active;
     background-color: $bitstyles-select-background-color-active;
     background-image: $bitstyles-select-background-image-active;
-    border: $bitstyles-select-border-active;
+    border-color: $bitstyles-select-border-color-active;
     outline: none;
   }
 
@@ -53,6 +53,6 @@
     cursor: default;
     background-color: $bitstyles-select-background-color-disabled;
     background-image: $bitstyles-select-background-image-disabled;
-    border: $bitstyles-select-border-disabled;
+    border-color: $bitstyles-select-border-color-disabled;
   }
 }

--- a/scss/bitstyles/ui/buttons.stories.mdx
+++ b/scss/bitstyles/ui/buttons.stories.mdx
@@ -12,7 +12,7 @@ All the buttons produce a larger-than-text hit target, and by default react to `
 
 ## Base buttons
 
-<Canvas>
+<Canvas isColumn>
   <Story id="atoms-button-base--button-element" />
   <Story id="atoms-button-base--button-with-icon" />
   <Story id="atoms-button-base--button-with-icon-reversed" />
@@ -38,7 +38,7 @@ Use these in your main navigation (see [Navbar](/?path=/docs/ui-navigation-navba
 
 For dangerous or destructive actions, these show danger when you hover or focus them.
 
-<Canvas>
+<Canvas isColumn>
   <Story id="atoms-button-danger--danger" />
   <Story id="atoms-button-danger--danger-list" />
 </Canvas>


### PR DESCRIPTION
Fixes #410 

All buttons now only set their border-color to override the base button styles, and for each of their hover/active/etc states. This simplifies the buttons a little, avoids the case where border-width is changed on hover/etc, and makes sure that all button types can be placed next to each other and have equal heights.

Not really any visual difference (the border is a _tiny_ bit thinner, as it’s based on font-size now), but here’s some of the buttons:

<img width="376" alt="Screenshot 2021-03-10 at 10 19 19" src="https://user-images.githubusercontent.com/2479422/110606188-3899b700-818a-11eb-858a-a2434c5a1ea6.png">

<img width="376" alt="Screenshot 2021-03-10 at 10 19 26" src="https://user-images.githubusercontent.com/2479422/110606194-39324d80-818a-11eb-86fa-e8305bb9535a.png">

<img width="376" alt="Screenshot 2021-03-10 at 10 19 59" src="https://user-images.githubusercontent.com/2479422/110606195-39cae400-818a-11eb-8f22-ae6201543362.png">

<img width="376" alt="Screenshot 2021-03-10 at 10 19 11" src="https://user-images.githubusercontent.com/2479422/110606180-36cff380-818a-11eb-82c9-bebb17606936.png">

