### PR TITLE
[#418] Add component: sidebar

### DIFF
--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -76,6 +76,7 @@
 @import 'bitstyles/utilities/clearfix/';
 @import 'bitstyles/utilities/box-alignment/';
 @import 'bitstyles/utilities/relative/';
+@import 'bitstyles/utilities/height/';
 @import 'bitstyles/utilities/sr-only/';
 @import 'bitstyles/utilities/hidden/';
 @import 'bitstyles/utilities/block/';

--- a/scss/bitstyles/atoms/button--nav/settings.scss
+++ b/scss/bitstyles/atoms/button--nav/settings.scss
@@ -13,7 +13,7 @@ $bitstyles-button-nav-transition:
 //
 // Base colors ////////////////////////////////////////
 
-$bitstyles-button-nav-color: palette('gray', '20') !default;
+$bitstyles-button-nav-color: palette('gray', '5') !default;
 $bitstyles-button-nav-background-color: transparent !default;
 $bitstyles-button-nav-border-color: transparent !default;
 $bitstyles-button-nav-box-shadow: none !default;

--- a/scss/bitstyles/atoms/button--nav/settings.scss
+++ b/scss/bitstyles/atoms/button--nav/settings.scss
@@ -3,7 +3,7 @@
 
 $bitstyles-button-nav-padding-vertical: spacing('xs') !default;
 $bitstyles-button-nav-padding-horizontal: spacing('m') !default;
-$bitstyles-button-nav-border-radius: spacing('s') !default;
+$bitstyles-button-nav-border-radius: spacing('xs') !default;
 $bitstyles-button-nav-transition:
   color $bitstyles-transition-duration $bitstyles-transition-easing,
   background-color $bitstyles-transition-duration $bitstyles-transition-easing,

--- a/scss/bitstyles/atoms/button/_.scss
+++ b/scss/bitstyles/atoms/button/_.scss
@@ -2,7 +2,7 @@
 
 .#{$bitstyles-namespace}a-button {
   position: relative;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   flex-shrink: 0;
   min-height: calc(#{$bitstyles-button-padding-vertical  * 2} + 1em);

--- a/scss/bitstyles/organisms/navbar/_.scss
+++ b/scss/bitstyles/organisms/navbar/_.scss
@@ -1,4 +1,4 @@
-.c-navbar {
+.o-navbar {
   position: absolute;
   top: 100%;
   right: 0;

--- a/scss/bitstyles/organisms/navbar/navbar.stories.mdx
+++ b/scss/bitstyles/organisms/navbar/navbar.stories.mdx
@@ -2,7 +2,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import logoLarge from '../../../../test/assets/images/logoLarge.svg';
 import logoSmall from '../../../../test/assets/images/logoSmall.svg';
 
-<Meta title="UI/Navigation/Navbar" />
+<Meta title="Organisms/Navbar" />
 
 # Navbar
 
@@ -12,60 +12,31 @@ A top-level navigation container, with two sections separated to the left & righ
   <Story name="Navbar">
     {`
       <nav class="u-bg--gray-80 u-padding-s--top u-padding-s--bottom u-relative">
-        <div class="a-content u-flex u-justify-between u-items-center u-flex--wrap">
-          <div class="u-flex u-items-center">
-            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-l--right u-hidden u-block@l" />
-            <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-l--right u-hidden@l" />
-            <div class="u-hidden u-block@l">
-              <ul class="u-flex a-list-reset">
-                <li class="u-margin-m--right">
-                  <a href="/" class="a-button a-button--nav">Team</a>
-                </li>
-                <li class="u-margin-m--right">
-                  <a href="/" class="a-button a-button--nav">Projects</a>
-                </li>
-                <li class="u-margin-m--right">
-                  <a href="/" class="a-button a-button--nav">Dashboard</a>
-                </li>
-              </ul>
-            </div>
-          </div>
-          <div class="u-hidden u-block@l">
-            <a href="/" class="a-button a-button--nav" aria-current="page">
-              <span class="a-button__label">Jane Dobermann</span>
+        <button class="a-button a-button--icon a-button--icon-reversed" title="Toggle menu" aria-controls="navbar-1" aria-expanded="true">
+          <svg class="a-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <path d="M6.64,14.23H93.36A5.63,5.63,0,0,1,99,19.86h0a5.63,5.63,0,0,1-5.64,5.64H6.64A5.63,5.63,0,0,1,1,19.86H1A5.63,5.63,0,0,1,6.64,14.23Zm0,30.14H93.36A5.63,5.63,0,0,1,99,50h0a5.63,5.63,0,0,1-5.64,5.63H6.64A5.63,5.63,0,0,1,1,50H1a5.64,5.64,0,0,1,5.63-5.64Zm0,30.13H93.36A5.63,5.63,0,0,1,99,80.13h0a5.63,5.63,0,0,1-5.64,5.64H6.64A5.63,5.63,0,0,1,1,80.13H1A5.63,5.63,0,0,1,6.63,74.5Z"/>
+          </svg>
+          <span class="u-sr-only">Toggle menu</span>
+        </button>
+        <ul class="u-flex u-flex--col a-list-reset o-navbar u-padding-s u-bg--gray-80" id="navbar-1">
+          <li class="u-margin-s--bottom">
+            <a href="/" class="a-button a-button--nav-large" aria-current="page">
               <div class="a-button__icon a-avatar">
                 <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
               </div>
+              <span class="a-button__label">Jane Dobermann</span>
             </a>
-          </div>
-          <div class="u-hidden@l">
-            <button class="a-button a-button--icon a-button--icon-reversed" title="Toggle menu" aria-controls="navbar-1" aria-expanded="true">
-              <svg class="a-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-                <path d="M6.64,14.23H93.36A5.63,5.63,0,0,1,99,19.86h0a5.63,5.63,0,0,1-5.64,5.64H6.64A5.63,5.63,0,0,1,1,19.86H1A5.63,5.63,0,0,1,6.64,14.23Zm0,30.14H93.36A5.63,5.63,0,0,1,99,50h0a5.63,5.63,0,0,1-5.64,5.63H6.64A5.63,5.63,0,0,1,1,50H1a5.64,5.64,0,0,1,5.63-5.64Zm0,30.13H93.36A5.63,5.63,0,0,1,99,80.13h0a5.63,5.63,0,0,1-5.64,5.64H6.64A5.63,5.63,0,0,1,1,80.13H1A5.63,5.63,0,0,1,6.63,74.5Z"/>
-              </svg>
-              <span class="u-sr-only">Toggle menu</span>
-            </button>
-            <ul class="u-flex u-flex--col a-list-reset c-navbar u-padding-s u-bg--gray-80" id="navbar-1">
-              <li class="u-margin-s--bottom">
-                <a href="/" class="a-button a-button--nav-large" aria-current="page">
-                  <div class="a-button__icon a-avatar">
-                    <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
-                  </div>
-                  <span class="a-button__label">Jane Dobermann</span>
-                </a>
-              </li>
-              <li class="u-margin-s--bottom">
-                <a href="/" class="a-button a-button--nav-large">Team</a>
-              </li>
-              <li class="u-margin-s--bottom">
-                <a href="/" class="a-button a-button--nav-large">Projects</a>
-              </li>
-              <li class="u-margin-s--bottom">
-                <a href="/" class="a-button a-button--nav-large">Dashboard</a>
-              </li>
-            </ul>
-          </div>
-        </div>
+          </li>
+          <li class="u-margin-s--bottom">
+            <a href="/" class="a-button a-button--nav-large">Team</a>
+          </li>
+          <li class="u-margin-s--bottom">
+            <a href="/" class="a-button a-button--nav-large">Projects</a>
+          </li>
+          <li class="u-margin-s--bottom">
+            <a href="/" class="a-button a-button--nav-large">Dashboard</a>
+          </li>
+        </ul>
       </nav>
     `}
   </Story>

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -80,24 +80,24 @@ A top-level navigation container, with two sections separated to the left & righ
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0" />
           </div>
           <ul class="a-list-reset u-flex u-flex--col u-padding-s--right u-padding-s--left">
-            <li class="u-margin-s--bottom">
-              <a href="/" class="a-button a-button--nav-large">
+            <li class="u-margin-xs--bottom">
+              <a href="/" class="a-button a-button--nav">
                 <svg class="a-icon a-icon--l u-margin-s--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                   <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
                 </svg>
                 Dashboard
               </a>
             </li>
-            <li class="u-margin-s--bottom">
-              <a href="/" class="a-button a-button--nav-large">
+            <li class="u-margin-xs--bottom">
+              <a href="/" class="a-button a-button--nav">
                 <svg class="a-icon a-icon--l u-margin-s--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                   <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
                 </svg>
                 Accounts
               </a>
             </li>
-            <li class="u-margin-s--bottom">
-              <a href="/" class="a-button a-button--nav-large">
+            <li class="u-margin-xs--bottom">
+              <a href="/" class="a-button a-button--nav">
                 <svg class="a-icon a-icon--l u-margin-s--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                   <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
                 </svg>

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -1,0 +1,115 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import logoLarge from '../../../test/assets/images/logoLarge.svg';
+import logoSmall from '../../../test/assets/images/logoSmall.svg';
+
+<Meta title="UI/Navigation/Navbar" />
+
+# Navbar
+
+A top-level navigation container, with two sections separated to the left & right. The left-hand side is commonly used for a logo and links, the right-hand side for user account menu and global search.
+
+<Canvas>
+  <Story name="Navbar">
+    {`
+      <nav class="u-bg--gray-80 u-padding-s--top u-padding-s--bottom u-relative">
+        <div class="a-content u-flex u-justify-between u-items-center u-flex--wrap">
+          <div class="u-flex u-items-center">
+            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-l--right u-hidden u-block@l" />
+            <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-l--right u-hidden@l" />
+            <div class="u-hidden u-block@l">
+              <ul class="u-flex a-list-reset">
+                <li class="u-margin-m--right">
+                  <a href="/" class="a-button a-button--nav">Team</a>
+                </li>
+                <li class="u-margin-m--right">
+                  <a href="/" class="a-button a-button--nav">Projects</a>
+                </li>
+                <li class="u-margin-m--right">
+                  <a href="/" class="a-button a-button--nav">Dashboard</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="u-hidden u-block@l">
+            <a href="/" class="a-button a-button--nav" aria-current="page">
+              <span class="a-button__label">Jane Dobermann</span>
+              <div class="a-button__icon a-avatar">
+                <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
+              </div>
+            </a>
+          </div>
+          <div class="u-hidden@l">
+            <button class="a-button a-button--icon a-button--icon-reversed" title="Toggle menu" aria-controls="navbar-1" aria-expanded="true">
+              <svg class="a-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                <path d="M6.64,14.23H93.36A5.63,5.63,0,0,1,99,19.86h0a5.63,5.63,0,0,1-5.64,5.64H6.64A5.63,5.63,0,0,1,1,19.86H1A5.63,5.63,0,0,1,6.64,14.23Zm0,30.14H93.36A5.63,5.63,0,0,1,99,50h0a5.63,5.63,0,0,1-5.64,5.63H6.64A5.63,5.63,0,0,1,1,50H1a5.64,5.64,0,0,1,5.63-5.64Zm0,30.13H93.36A5.63,5.63,0,0,1,99,80.13h0a5.63,5.63,0,0,1-5.64,5.64H6.64A5.63,5.63,0,0,1,1,80.13H1A5.63,5.63,0,0,1,6.63,74.5Z"/>
+              </svg>
+              <span class="u-sr-only">Toggle menu</span>
+            </button>
+            <ul class="u-flex u-flex--col a-list-reset o-navbar u-padding-s u-bg--gray-80" id="navbar-1">
+              <li class="u-margin-s--bottom">
+                <a href="/" class="a-button a-button--nav-large" aria-current="page">
+                  <div class="a-button__icon a-avatar">
+                    <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
+                  </div>
+                  <span class="a-button__label">Jane Dobermann</span>
+                </a>
+              </li>
+              <li class="u-margin-s--bottom">
+                <a href="/" class="a-button a-button--nav-large">Team</a>
+              </li>
+              <li class="u-margin-s--bottom">
+                <a href="/" class="a-button a-button--nav-large">Projects</a>
+              </li>
+              <li class="u-margin-s--bottom">
+                <a href="/" class="a-button a-button--nav-large">Dashboard</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Sidebar">
+    {`
+      <div class="u-flex u-height-100vh">
+        <nav class="u-flex__shrink-0 u-bg--gray-80 u-padding-m--y">
+          <div class="u-padding-m--bottom u-padding-xl--left u-padding-xl--right">
+            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0" />
+          </div>
+          <ul class="a-list-reset u-flex u-flex--col u-padding-s--right u-padding-s--left">
+            <li class="u-margin-s--bottom">
+              <a href="/" class="a-button a-button--nav-large">
+                <svg class="a-icon a-icon--l u-margin-s--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
+                </svg>
+                Dashboard
+              </a>
+            </li>
+            <li class="u-margin-s--bottom">
+              <a href="/" class="a-button a-button--nav-large">
+                <svg class="a-icon a-icon--l u-margin-s--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
+                </svg>
+                Accounts
+              </a>
+            </li>
+            <li class="u-margin-s--bottom">
+              <a href="/" class="a-button a-button--nav-large">
+                <svg class="a-icon a-icon--l u-margin-s--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
+                </svg>
+                Bookings
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <main class="u-flex__grow u-padding-m">
+          <h1>Main content</h1>
+        </main>
+      </div>
+    `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -82,8 +82,8 @@ A top-level navigation container, with two sections separated to the left & righ
           <ul class="a-list-reset u-flex u-flex--col u-padding-s--right u-padding-s--left">
             <li class="u-margin-xs--bottom">
               <a href="/" class="a-button a-button--nav">
-                <svg class="a-icon a-icon--l u-margin-s--right" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-                  <path d="M93.79,98H64.38a4.17,4.17,0,0,1-4.17-4.17V66.68H39.79V93.79A4.17,4.17,0,0,1,35.66,98H6.21A4.17,4.17,0,0,1,2,93.87V43.79a4.18,4.18,0,0,1,1.5-3.21L47.29,3a4.17,4.17,0,0,1,5.43,0L96.5,40.58A4.26,4.26,0,0,1,98,43.79V93.74A4.17,4.17,0,0,1,93.92,98Z"/>
+                <svg class="a-icon a-icon--l u-margin-s--right u-fg--gray-20" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <path d="M8.06,99A7.1,7.1,0,0,1,1,92V44.07a7.08,7.08,0,0,1,2.55-5.45L45.38,2.71a7.07,7.07,0,0,1,9.24,0L96.48,38.64A7.2,7.2,0,0,1,99,44.05V91.83A7.1,7.1,0,0,1,92.06,99H63.75a7.11,7.11,0,0,1-7.1-7.1V70a.9.9,0,0,0-.9-.9H44.24a.91.91,0,0,0-.9.9V91.88a7.08,7.08,0,0,1-7,7.13H8.06ZM50,7.22a.89.89,0,0,0-.57.21L7.56,43.36a.94.94,0,0,0-.35.71V92a.86.86,0,0,0,.27.59.83.83,0,0,0,.62.25H36.29a.87.87,0,0,0,.84-.88V70a7.12,7.12,0,0,1,7.11-7.11H55.75A7.12,7.12,0,0,1,62.87,70v22a.87.87,0,0,0,.88.88H92a.86.86,0,0,0,.79-.89V44.07a.93.93,0,0,0-.34-.7L50.58,7.43A.9.9,0,0,0,50,7.22Z"/>
                 </svg>
                 Dashboard
               </a>

--- a/scss/bitstyles/utilities/fg/settings.scss
+++ b/scss/bitstyles/utilities/fg/settings.scss
@@ -5,4 +5,5 @@ $foreground-colors: (
   'gray-50': palette('gray', '50'),
   'gray-40': palette('gray', '40'),
   'gray-30': palette('gray', '30'),
+  'gray-20': palette('gray', '20'),
 ) !default;

--- a/scss/bitstyles/utilities/height/_.scss
+++ b/scss/bitstyles/utilities/height/_.scss
@@ -1,0 +1,3 @@
+.u-height-100vh {
+  height: 100vh;
+}


### PR DESCRIPTION
Fixes #418 

Start of a sidebar variant of the existing navbar

TODO:
- new icons (add an svg icon sprite, so we can use `<use>`?)
- Add a page layout as a separate organism, that the sidebar can be dropped into (start a section on page layouts, or repurpose the current page-content section?)

So far looks like:

<img width="978" alt="Screenshot 2021-03-11 at 17 22 35" src="https://user-images.githubusercontent.com/2479422/110819765-c6f76100-828e-11eb-8f35-fef4685c119b.png">
