### PR TITLE
[#425] More permissive button states

### DIFF
--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -24,7 +24,6 @@
 @import 'bitstyles/atoms/list-reset/';
 @import 'bitstyles/atoms/icon/';
 @import 'bitstyles/atoms/button/';
-@import 'bitstyles/atoms/button--danger/';
 @import 'bitstyles/atoms/button--icon/';
 @import 'bitstyles/atoms/button--icon-reversed/';
 @import 'bitstyles/atoms/button--nav/';
@@ -34,6 +33,7 @@
 @import 'bitstyles/atoms/button--menu/';
 @import 'bitstyles/atoms/button--mode/';
 @import 'bitstyles/atoms/button--tab/';
+@import 'bitstyles/atoms/button--danger/';
 @import 'bitstyles/atoms/bordered-header/';
 @import 'bitstyles/atoms/link/';
 @import 'bitstyles/atoms/avatar/';

--- a/scss/bitstyles/atoms/button--danger/_.scss
+++ b/scss/bitstyles/atoms/button--danger/_.scss
@@ -1,14 +1,6 @@
 @import './settings';
 
 .a-button--danger {
-  &,
-  &:visited {
-    color: $bitstyles-button-danger-color;
-    background: $bitstyles-button-danger-background-color;
-    border-color: $bitstyles-button-danger-border-color;
-    box-shadow: $bitstyles-button-danger-box-shadow;
-  }
-
   &:hover,
   &:focus {
     color: $bitstyles-button-danger-color-hover;

--- a/scss/bitstyles/atoms/button--danger/button--danger.stories.mdx
+++ b/scss/bitstyles/atoms/button--danger/button--danger.stories.mdx
@@ -14,6 +14,13 @@ A button that performs any action the user should be wary off, most often someth
       </a>
     `}
   </Story>
+  <Story name="Danger/UI">
+    {`
+      <a href="/" class="a-button a-button--ui a-button--danger">
+        Destroy
+      </a>
+    `}
+  </Story>
 </Canvas>
 
 These buttons are often placed in a list of possible actions:
@@ -23,17 +30,17 @@ These buttons are often placed in a list of possible actions:
     {`
       <ul class="a-list-reset u-flex">
         <li class="u-margin-s--right">
-          <a href="/" class="a-button a-button">
+          <a href="/" class="a-button a-button--ui">
             Show
           </a>
         </li>
         <li class="u-margin-s--right">
-          <a href="/" class="a-button a-button">
+          <a href="/" class="a-button a-button--ui">
             Edit
           </a>
         </li>
         <li class="u-margin-s--right">
-          <a href="/" class="a-button a-button--danger">
+          <a href="/" class="a-button a-button--ui a-button--danger">
             Delete
           </a>
         </li>

--- a/scss/bitstyles/atoms/button--danger/settings.scss
+++ b/scss/bitstyles/atoms/button--danger/settings.scss
@@ -1,21 +1,4 @@
 //
-// Base styles ////////////////////////////////////////
-
-$bitstyles-button-danger-transition:
-  color $bitstyles-transition-duration $bitstyles-transition-easing,
-  background-color $bitstyles-transition-duration $bitstyles-transition-easing,
-  border $bitstyles-transition-duration $bitstyles-transition-easing,
-  box-shadow $bitstyles-transition-duration $bitstyles-transition-easing !default;
-
-//
-// Base colors ////////////////////////////////////////
-
-$bitstyles-button-danger-color: palette('white') !default;
-$bitstyles-button-danger-background-color: palette('brand-1', '80') !default;
-$bitstyles-button-danger-border-color: palette('brand-1', '80') !default;
-$bitstyles-button-danger-box-shadow: 0 0 spacing('s') rgba(palette('brand-2', '80'), 0.3) !default;
-
-//
 // Hover colors ////////////////////////////////////////
 
 $bitstyles-button-danger-color-hover: palette('white') !default;

--- a/scss/bitstyles/atoms/button--nav-large/_.scss
+++ b/scss/bitstyles/atoms/button--nav-large/_.scss
@@ -31,7 +31,8 @@
     box-shadow: $bitstyles-button-nav-large-box-shadow-active;
   }
 
-  &[aria-current] {
+  &[aria-current],
+  &[aria-expanded="true"] {
     color: $bitstyles-button-nav-large-color-current;
     background: $bitstyles-button-nav-large-background-color-current;
     border: $bitstyles-button-nav-large-border-current;

--- a/scss/bitstyles/atoms/button--nav-large/_.scss
+++ b/scss/bitstyles/atoms/button--nav-large/_.scss
@@ -3,14 +3,13 @@
 .a-button--nav-large {
   display: flex;
   padding: $bitstyles-button-nav-large-padding-vertical $bitstyles-button-nav-large-padding-horizontal;
-  border: 0;
   border-radius: $bitstyles-button-nav-large-border-radius;
 
   &,
   &:visited {
     color: $bitstyles-button-nav-large-color;
     background: $bitstyles-button-nav-large-background-color;
-    border: $bitstyles-button-nav-large-border;
+    border-color: $bitstyles-button-nav-large-border-color;
     box-shadow: $bitstyles-button-nav-large-box-shadow;
   }
 
@@ -19,7 +18,7 @@
     color: $bitstyles-button-nav-large-color-hover;
     text-decoration: none;
     background: $bitstyles-button-nav-large-background-color-hover;
-    border: $bitstyles-button-nav-large-border-hover;
+    border-color: $bitstyles-button-nav-large-border-color-hover;
     outline: none;
     box-shadow: $bitstyles-button-nav-large-box-shadow-hover;
   }
@@ -27,7 +26,7 @@
   &:active {
     color: $bitstyles-button-nav-large-color-active;
     background: $bitstyles-button-nav-large-background-color-active;
-    border: $bitstyles-button-nav-large-border-active;
+    border-color: $bitstyles-button-nav-large-border-color-active;
     box-shadow: $bitstyles-button-nav-large-box-shadow-active;
   }
 
@@ -35,7 +34,7 @@
   &[aria-expanded="true"] {
     color: $bitstyles-button-nav-large-color-current;
     background: $bitstyles-button-nav-large-background-color-current;
-    border: $bitstyles-button-nav-large-border-current;
+    border-color: $bitstyles-button-nav-large-border-color-current;
     box-shadow: $bitstyles-button-nav-large-box-shadow-current;
   }
 
@@ -43,7 +42,7 @@
     color: $bitstyles-button-nav-large-color-disabled;
     cursor: default;
     background: $bitstyles-button-nav-large-background-color-disabled;
-    border: $bitstyles-button-nav-large-border-disabled;
+    border: $bitstyles-button-nav-large-border-color-disabled;
     box-shadow: $bitstyles-button-nav-large-box-shadow-disabled;
   }
 }

--- a/scss/bitstyles/atoms/button--nav-large/settings.scss
+++ b/scss/bitstyles/atoms/button--nav-large/settings.scss
@@ -14,23 +14,23 @@ $bitstyles-button-nav-large-transition:
 
 $bitstyles-button-nav-large-color: palette('gray', '5') !default;
 $bitstyles-button-nav-large-background-color: palette('gray', '80') !default;
-$bitstyles-button-nav-large-border: none !default;
+$bitstyles-button-nav-large-border-color: palette('gray', '80') !default;
 $bitstyles-button-nav-large-box-shadow: none !default;
 
 //
 // Hover colors ////////////////////////////////////////
 
 $bitstyles-button-nav-large-color-hover: palette('white') !default;
-$bitstyles-button-nav-large-background-color-hover: palette('gray', '70') !default;
-$bitstyles-button-nav-large-border-hover: none !default;
+$bitstyles-button-nav-large-background-color-hover: palette('gray', '60') !default;
+$bitstyles-button-nav-large-border-color-hover: palette('gray', '60') !default;
 $bitstyles-button-nav-large-box-shadow-hover: none !default;
 
 //
 // Active colors ////////////////////////////////////////
 
-$bitstyles-button-nav-large-color-active: palette('white') !default;
-$bitstyles-button-nav-large-background-color-active: palette('brand-1', '70') !default;
-$bitstyles-button-nav-large-border-active: none !default;
+$bitstyles-button-nav-large-color-active: palette('text') !default;
+$bitstyles-button-nav-large-background-color-active: palette('gray', '10') !default;
+$bitstyles-button-nav-large-border-color-active: palette('gray', '10') !default;
 $bitstyles-button-nav-large-box-shadow-active: none !default;
 
 //
@@ -38,7 +38,7 @@ $bitstyles-button-nav-large-box-shadow-active: none !default;
 
 $bitstyles-button-nav-large-color-disabled: palette('black', '50') !default;
 $bitstyles-button-nav-large-background-color-disabled: palette('black', '10') !default;
-$bitstyles-button-nav-large-border-disabled: none !default;
+$bitstyles-button-nav-large-border-color-disabled: palette('black', '10') !default;
 $bitstyles-button-nav-large-box-shadow-disabled: none !default;
 
 //
@@ -46,5 +46,5 @@ $bitstyles-button-nav-large-box-shadow-disabled: none !default;
 
 $bitstyles-button-nav-large-color-current: palette('white', '100') !default;
 $bitstyles-button-nav-large-background-color-current: palette('gray', '100') !default;
-$bitstyles-button-nav-large-border-current: none !default;
+$bitstyles-button-nav-large-border-color-current: palette('gray', '100') !default;
 $bitstyles-button-nav-large-box-shadow-current: none !default;

--- a/scss/bitstyles/atoms/button--nav/_.scss
+++ b/scss/bitstyles/atoms/button--nav/_.scss
@@ -29,7 +29,8 @@
     box-shadow: $bitstyles-button-nav-box-shadow-active;
   }
 
-  &[aria-current] {
+  &[aria-current],
+  &[aria-expanded="true"] {
     color: $bitstyles-button-nav-color-current;
     background: $bitstyles-button-nav-background-color-current;
     border-color: $bitstyles-button-nav-border-color-current;

--- a/scss/bitstyles/atoms/button--nav/settings.scss
+++ b/scss/bitstyles/atoms/button--nav/settings.scss
@@ -29,9 +29,9 @@ $bitstyles-button-nav-box-shadow-hover: 0 0 spacing('l') rgba(palette('black', '
 //
 // Active colors ////////////////////////////////////////
 
-$bitstyles-button-nav-color-active: palette('white') !default;
-$bitstyles-button-nav-background-color-active: palette('brand-1', '100') !default;
-$bitstyles-button-nav-border-color-active: palette('brand-1', '100') !default;
+$bitstyles-button-nav-color-active: palette('text') !default;
+$bitstyles-button-nav-background-color-active: palette('gray', '10') !default;
+$bitstyles-button-nav-border-color-active: palette('gray', '10') !default;
 $bitstyles-button-nav-box-shadow-active: 0 0 spacing('xs') rgba(palette('black', '100'), 0.3) !default;
 
 //
@@ -46,6 +46,6 @@ $bitstyles-button-nav-box-shadow-disabled: none !default;
 // Current colors ////////////////////////////////////////
 
 $bitstyles-button-nav-color-current: palette('white', '100') !default;
-$bitstyles-button-nav-background-color-current: palette('gray', '100') !default;
-$bitstyles-button-nav-border-color-current: palette('gray', '100') !default;
+$bitstyles-button-nav-background-color-current: palette('black', '100') !default;
+$bitstyles-button-nav-border-color-current: palette('gray', '80') !default;
 $bitstyles-button-nav-box-shadow-current: none !default;

--- a/scss/bitstyles/atoms/button--tab/_.scss
+++ b/scss/bitstyles/atoms/button--tab/_.scss
@@ -56,7 +56,8 @@
     }
   }
 
-  &[aria-selected="true"] {
+  &[aria-selected="true"],
+  &[aria-current] {
     color: $bitstyles-button-tab-color-selected;
     background: $bitstyles-button-tab-background-color-selected;
     box-shadow: $bitstyles-button-tab-box-shadow-selected;

--- a/scss/bitstyles/atoms/button--ui/_.scss
+++ b/scss/bitstyles/atoms/button--ui/_.scss
@@ -33,7 +33,8 @@
   }
 
   &[aria-pressed="true"],
-  &[aria-expanded="true"] {
+  &[aria-expanded="true"],
+  &[aria-current] {
     color: $bitstyles-button-ui-color-pressed;
     background: $bitstyles-button-ui-background-color-pressed;
     border-color: $bitstyles-button-ui-border-color-pressed;

--- a/scss/bitstyles/atoms/button--ui/button--ui.stories.mdx
+++ b/scss/bitstyles/atoms/button--ui/button--ui.stories.mdx
@@ -37,7 +37,7 @@ The same buttons are used for dropdown menus
 When you’re representing state in the UI, use the `aria-pressed="true"` attribute to indicate the currently-pressed button.
 
 <Canvas>
-  <Story name="UI [aria-pressed]">
+  <Story name="[aria-pressed]">
     {`
       <button type="button" class="a-button a-button--ui u-h6" aria-pressed="true">
         Pressed

--- a/scss/bitstyles/atoms/button--ui/settings.scss
+++ b/scss/bitstyles/atoms/button--ui/settings.scss
@@ -12,14 +12,14 @@ $bitstyles-button-ui-transition:
 
 $bitstyles-button-ui-color: palette('gray', '60') !default;
 $bitstyles-button-ui-background-color: palette('gray', '1') !default;
-$bitstyles-button-ui-border-color: palette('gray', '40') !default;
+$bitstyles-button-ui-border-color: palette('gray', '5') !default;
 
 //
 // Hover colors ////////////////////////////////////////
 
 $bitstyles-button-ui-color-hover: palette('gray', '80') !default;
 $bitstyles-button-ui-background-color-hover: palette('gray', '10') !default;
-$bitstyles-button-ui-border-color-hover: palette('gray', '60') !default;
+$bitstyles-button-ui-border-color-hover: palette('gray', '20') !default;
 
 //
 // Active colors ////////////////////////////////////////

--- a/scss/bitstyles/atoms/dropdown/_.scss
+++ b/scss/bitstyles/atoms/dropdown/_.scss
@@ -19,10 +19,6 @@
     margin: $bitstyles-dropdown-separator-spacing 0;
     border-top: 1px solid $bitstyles-dropdown-separator-border;
   }
-
-  &[aria-hidden="false"] {
-    border: $bitstyles-dropdown-border-active;
-  }
 }
 
 .a-dropdown--reverse {

--- a/scss/bitstyles/atoms/dropdown/settings.scss
+++ b/scss/bitstyles/atoms/dropdown/settings.scss
@@ -1,7 +1,6 @@
 $bitstyles-dropdown-max-height: 20rem;
 $bitstyles-dropdown-border-radius: spacing('xs');
-$bitstyles-dropdown-border: 2px solid palette('gray', '5');
-$bitstyles-dropdown-border-active: 2px solid palette('brand-2', '100');
+$bitstyles-dropdown-border: 2px solid palette('brand-2', '100');
 $bitstyles-dropdown-background-color: palette('white', '100');
 $bitstyles-dropdown-box-shadow: 0 0 spacing('m') rgba(palette('gray', '80'), 0.1);
 $bitstyles-dropdown-separator-border: 1px solid palette('gray', '1');

--- a/scss/bitstyles/organisms/navbar/_.scss
+++ b/scss/bitstyles/organisms/navbar/_.scss
@@ -3,4 +3,5 @@
   top: 100%;
   right: 0;
   left: 0;
+  z-index: 1;
 }

--- a/scss/bitstyles/organisms/navbar/navbar.stories.mdx
+++ b/scss/bitstyles/organisms/navbar/navbar.stories.mdx
@@ -20,7 +20,7 @@ A top-level navigation container, with two sections separated to the left & righ
             <div class="u-hidden u-block@l">
               <ul class="u-flex a-list-reset">
                 <li class="u-margin-m--right">
-                  <a href="/" class="a-button a-button--nav">Team</a>
+                  <a href="/" class="a-button a-button--nav" aria-current="page">Team</a>
                 </li>
                 <li class="u-margin-m--right">
                   <a href="/" class="a-button a-button--nav">Projects</a>
@@ -32,7 +32,7 @@ A top-level navigation container, with two sections separated to the left & righ
             </div>
           </div>
           <div class="u-hidden u-block@l">
-            <a href="/" class="a-button a-button--nav" aria-current="page">
+            <a href="/" class="a-button a-button--nav">
               <span class="a-button__label">Jane Dobermann</span>
               <div class="a-button__icon a-avatar">
                 <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -48,7 +48,7 @@ A top-level navigation container, with two sections separated to the left & righ
             </button>
             <ul class="u-flex u-flex--col a-list-reset c-navbar u-padding-s u-bg--gray-80" id="navbar-1">
               <li class="u-margin-s--bottom">
-                <a href="/" class="a-button a-button--nav-large" aria-current="page">
+                <a href="/" class="a-button a-button--nav-large">
                   <div class="a-button__icon a-avatar">
                     <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
                   </div>
@@ -56,7 +56,7 @@ A top-level navigation container, with two sections separated to the left & righ
                 </a>
               </li>
               <li class="u-margin-s--bottom">
-                <a href="/" class="a-button a-button--nav-large">Team</a>
+                <a href="/" class="a-button a-button--nav-large" aria-current="page">Team</a>
               </li>
               <li class="u-margin-s--bottom">
                 <a href="/" class="a-button a-button--nav-large">Projects</a>

--- a/scss/bitstyles/ui/buttons.stories.mdx
+++ b/scss/bitstyles/ui/buttons.stories.mdx
@@ -18,6 +18,13 @@ All the buttons produce a larger-than-text hit target, and by default react to `
   <Story id="atoms-button-base--button-with-icon-reversed" />
 </Canvas>
 
+## UI buttons
+
+<Canvas isColumn>
+  <Story id="atoms-button-ui--ui" />
+  <Story id="atoms-button-ui--dropdown" />
+</Canvas>
+
 ## Icon buttons
 
 <Canvas>

--- a/scss/bitstyles/ui/joined-buttons.stories.mdx
+++ b/scss/bitstyles/ui/joined-buttons.stories.mdx
@@ -61,6 +61,8 @@ For a series of buttons that are very directly related e.g.
   </Story>
 </Canvas>
 
+Mark the current page in a series of pagination buttons, by giving the link the `aria-current="page"` attribute.
+
 <Canvas>
   <Story name="Joined buttons - pagination">
     {`
@@ -79,7 +81,7 @@ For a series of buttons that are very directly related e.g.
           </a>
         </li>
         <li class="u-flex">
-          <a href="/" class="a-button a-button--ui o-ui-group__item u-round-0 u-h6">
+          <a href="/" class="a-button a-button--ui o-ui-group__item u-round-0 u-h6" aria-current="page">
             2
           </a>
         </li>

--- a/scss/bitstyles/ui/mode-switch-buttons.stories.mdx
+++ b/scss/bitstyles/ui/mode-switch-buttons.stories.mdx
@@ -6,6 +6,8 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 A series of buttons to switch between modes of a view. In the example below, the user is shown the list of available modes, and which is currently-selected, in a calendar view.
 
+The currently-selected mode is indicated with the `aria-pressed="true"` attribute.
+
 <Canvas>
   <Story name="Mode-switch buttons">
     {`


### PR DESCRIPTION
Fixes #425 

A bunch of extra states for buttons, so that we can use certain button types in different situations, which fixes e.g. highlighting current page in pagination:

- `.a-button--nav` and `.a-button--nav-large` both now respond to `aria-expanded="true"`
- `.a-button--tab` and `.a-button--ui` now respond to `aria-current`
- `.a-button--ui` border is now more subtle
- `.a-button--danger` no applies no colors until hover, so it can be used with any button class

Also fixes a couple of issues found while implementing these components in a live project:

- `.a-dropdown` border is now always applied, as we show/hide by adding `display: none` with JS
- `.a-navbar` is now rendered over other content (z-index)

Looks like:

<img width="631" alt="Screenshot 2021-03-17 at 13 51 25" src="https://user-images.githubusercontent.com/2479422/111470194-e0355d00-8727-11eb-90cb-edc7bc294a85.png">


