### PR TITLE
[#431] Breadcrumb arrows to the right

### DIFF
--- a/scss/bitstyles/ui/breadcrumbs.stories.mdx
+++ b/scss/bitstyles/ui/breadcrumbs.stories.mdx
@@ -5,7 +5,7 @@ import icons from '../../../test/assets/images/icons.svg';
 
 # Breadcrumbs
 
-A list of links charting the user’s place in the site structure. The title of the current page should be in an `<h1>` on the page, so it isn’t needed here.
+A list of links charting the user’s place in the site structure. The title of the current page is most often in an `<h1>` on the page, so it isn’t needed here.
 
 <Canvas isColumn>
   <Story name="Breadcrumbs">
@@ -13,25 +13,28 @@ A list of links charting the user’s place in the site structure. The title of 
       <ol class="c-breadcrumbs u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
         <li class="u-margin-xs--right u-flex u-items-center">
           <a href="/">Main section</a>
-        </li>
-        <li class="u-margin-xs--right u-flex u-items-center">
-          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <use xlink:href="${icons}#icon-caret-right"></use>
           </svg>
+        </li>
+        <li class="u-margin-xs--right u-flex u-items-center">
           <a href="/">Sub section</a>
-        </li>
-        <li class="u-margin-xs--right u-flex u-items-center">
-          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <use xlink:href="${icons}#icon-caret-right"></use>
           </svg>
+        </li>
+        <li class="u-margin-xs--right u-flex u-items-center">
           <a href="/">Sub page</a>
+          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <use xlink:href="${icons}#icon-caret-right"></use>
+          </svg>
         </li>
       </ol>
     `}
   </Story>
 </Canvas>
 
-Using the same structure, your root page might be represented with an icon, to make it really quick to spot.
+Using the same structure, your root page might be represented with an icon, for visual simplicity and to make it really quick to spot.
 
 <Canvas>
   <Story name="Breadcrumbs with icon">
@@ -43,19 +46,22 @@ Using the same structure, your root page might be represented with an icon, to m
               <use xlink:href="${icons}#icon-home"></use>
             </svg>
             <span class="u-sr-only">Home</span>
+            <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <use xlink:href="${icons}#icon-caret-right"></use>
+          </svg>
           </a>
         </li>
         <li class="u-margin-xs--right u-flex u-items-center">
-          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+          <a href="/">Sub section</a>
+          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <use xlink:href="${icons}#icon-caret-right"></use>
           </svg>
-          <a href="/">Sub section</a>
         </li>
         <li class="u-margin-xs--right u-flex u-items-center">
-          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+          <a href="/">Sub page</a>
+          <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs--left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
             <use xlink:href="${icons}#icon-caret-right"></use>
           </svg>
-          <a href="/">Sub page</a>
         </li>
       </ol>
     `}


### PR DESCRIPTION
Fixes #432 

Order of right-arrows and text labels in Breadcrumbs is switched, so that the last link always has an arrow after it, as the title of the current resource/object is normally the title after/below it.

Looks like:

<img width="422" alt="Screenshot 2021-03-18 at 10 06 53" src="https://user-images.githubusercontent.com/2479422/111662295-151cdf00-8810-11eb-8edc-f95cab319de5.png">
