### PR TITLE
[#429] Improve form examples

### DIFF
--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -81,5 +81,6 @@
 @import 'bitstyles/utilities/block/';
 @import 'bitstyles/utilities/flex/';
 @import 'bitstyles/utilities/grid/';
+@import 'bitstyles/utilities/gap/';
 @import 'bitstyles/utilities/margin/';
 @import 'bitstyles/utilities/padding/';

--- a/scss/bitstyles/atoms/bordered-header/settings.scss
+++ b/scss/bitstyles/atoms/bordered-header/settings.scss
@@ -1,3 +1,3 @@
 $bitstyles-bordered-header-line-min-width: 20% !default;
-$bitstyles-bordered-header-gutter: 1em !default;
-$bitstyles-bordered-header-border: 1px solid palette('black', '20') !default;
+$bitstyles-bordered-header-gutter: spacing('m') !default;
+$bitstyles-bordered-header-border: spacing('xxxs') solid palette('gray', '10') !default;

--- a/scss/bitstyles/atoms/bordered-header/settings.scss
+++ b/scss/bitstyles/atoms/bordered-header/settings.scss
@@ -1,3 +1,2 @@
-$bitstyles-bordered-header-line-min-width: 20% !default;
 $bitstyles-bordered-header-gutter: spacing('m') !default;
 $bitstyles-bordered-header-border: spacing('xxxs') solid palette('gray', '10') !default;

--- a/scss/bitstyles/base/forms/settings-fieldset.scss
+++ b/scss/bitstyles/base/forms/settings-fieldset.scss
@@ -2,7 +2,7 @@ $bitstyles-fieldset-padding: 0 !default;
 $bitstyles-fieldset-border: 0 !default;
 $bitstyles-fieldset-border-radius: 0 !default;
 $bitstyles-fieldset-background: transparent !default;
-$bitstyles-legend-padding: 0 0 spacing('m') !default;
+$bitstyles-legend-padding: 0 !default;
 $bitstyles-legend-background-color: transparent !default;
 $bitstyles-legend-border: 0 !default;
 $bitstyles-legend-border-radius: 0 !default;

--- a/scss/bitstyles/base/forms/settings-input.scss
+++ b/scss/bitstyles/base/forms/settings-input.scss
@@ -20,14 +20,14 @@ $bitstyles-input-box-shadow: 0 0 spacing('xs') rgba(palette('gray', '90'), 0.05)
 
 $bitstyles-input-background-hover: palette('gray', '1') !default;
 $bitstyles-input-color-hover: palette('gray', '70') !default;
-$bitstyles-input-border-color-hover: 2px solid palette('gray', '60') !default;
+$bitstyles-input-border-color-hover: palette('gray', '60') !default;
 $bitstyles-input-box-shadow-hover: 0 0 spacing('s') rgba(palette('brand-1', '90'), 0.05);
 
 //
 // Active colors ////////////////////////////////////////
 
 $bitstyles-input-color-active: palette('gray', '80') !default;
-$bitstyles-input-border-color-active: 2px solid palette('gray', '80') !default;
+$bitstyles-input-border-color-active: palette('gray', '80') !default;
 $bitstyles-input-background-active: palette('white') !default;
 $bitstyles-input-box-shadow-active: 0 0 spacing('xxs') rgba(palette('brand-1', '90'), 0.15);
 
@@ -36,7 +36,7 @@ $bitstyles-input-box-shadow-active: 0 0 spacing('xxs') rgba(palette('brand-1', '
 
 $bitstyles-input-background-disabled: palette('black', '10') !default;
 $bitstyles-input-color-disabled: palette('text') !default;
-$bitstyles-input-border-color-disabled: 2px solid palette('black', '20') !default;
+$bitstyles-input-border-color-disabled: palette('black', '20') !default;
 $bitstyles-input-box-shadow-disabled: none;
 
 //

--- a/scss/bitstyles/base/forms/settings-select.scss
+++ b/scss/bitstyles/base/forms/settings-select.scss
@@ -1,6 +1,6 @@
 //
 // Base styles ////////////////////////////////////////
-$bitstyles-select-padding-vertical: spacing('s') !default;
+$bitstyles-select-padding-vertical: spacing('xs') !default;
 $bitstyles-select-padding-horizontal: spacing('m') !default;
 $bitstyles-select-border-radius: spacing('xs') !default;
 
@@ -8,14 +8,14 @@ $bitstyles-select-border-radius: spacing('xs') !default;
 // Base appearance ////////////////////////////////////////
 $bitstyles-select-color: palette('gray', '60') !default;
 $bitstyles-select-border-width: spacing('xxxs');
-$bitstyles-select-border-color: palette('gray', '40') !default;
-$bitstyles-select-background-color: transparent !default;
+$bitstyles-select-border-color: palette('gray', '10') !default;
+$bitstyles-select-background-color: palette('white') !default;
 $bitstyles-select-background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '60')}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;
 
 //
 // Hover styles ////////////////////////////////////////
 $bitstyles-select-color-hover: palette('gray', '80') !default;
-$bitstyles-select-border-color-hover: palette('gray', '80') !default;
+$bitstyles-select-border-color-hover: palette('gray', '60') !default;
 $bitstyles-select-background-color-hover: palette('gray', '1') !default;
 $bitstyles-select-background-image-hover: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-hover}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;
 
@@ -29,13 +29,13 @@ $bitstyles-select-background-image-active: url("data:image/svg+xml,%3Csvg width=
 //
 // Invalid styles ////////////////////////////////////////
 $bitstyles-select-color-invalid: palette('warning') !default;
-$bitstyles-select-border-invalid: 2px solid palette('warning') !default;
+$bitstyles-select-border-color-invalid: palette('warning') !default;
 $bitstyles-select-background-color-invalid: palette('white') !default;
 $bitstyles-select-background-image-invalid: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('warning')}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;
 
 //
 // Disabled styles ////////////////////////////////////////
 $bitstyles-select-color-disabled: palette('text') !default;
-$bitstyles-select-border-color-disabled: 2px solid palette('black', '20') !default;
+$bitstyles-select-border-color-disabled: palette('black', '20') !default;
 $bitstyles-select-background-color-disabled: palette('black', '10') !default;
 $bitstyles-select-background-image-disabled: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '50')}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;

--- a/scss/bitstyles/base/typography/_.scss
+++ b/scss/bitstyles/base/typography/_.scss
@@ -4,7 +4,7 @@ html {
   line-height: $bitstyles-line-height-base;
   color: palette('text');
   -webkit-text-size-adjust: 100%; // stylelint-disable-line property-no-vendor-prefix
-  background: palette('background');
+  background: palette('background', '95');
 }
 
 h1,

--- a/scss/bitstyles/tools/_bordered-header.scss
+++ b/scss/bitstyles/tools/_bordered-header.scss
@@ -1,26 +1,12 @@
 @mixin bordered-header() {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(1px, 1fr);
+  grid-gap: spacing('m');
   align-items: center;
-  justify-content: center;
   width: 100%;
-  text-align: center;
-  white-space: nowrap;
 
-  &::before,
   &::after {
-    display: inline-block;
-    min-width: $bitstyles-bordered-header-line-min-width;
-    vertical-align: middle;
-    flex-grow: 1;
     border-top: $bitstyles-bordered-header-border;
     content: '';
-  }
-
-  &::before {
-    margin-right: $bitstyles-bordered-header-gutter;
-  }
-
-  &::after {
-    margin-left: $bitstyles-bordered-header-gutter;
   }
 }

--- a/scss/bitstyles/tools/_bordered-header.scss
+++ b/scss/bitstyles/tools/_bordered-header.scss
@@ -1,7 +1,7 @@
 @mixin bordered-header() {
   display: grid;
   grid-template-columns: auto minmax(1px, 1fr);
-  grid-gap: spacing('m');
+  grid-gap: $bitstyles-bordered-header-gutter;
   align-items: center;
   width: 100%;
 

--- a/scss/bitstyles/tools/_select.scss
+++ b/scss/bitstyles/tools/_select.scss
@@ -4,7 +4,7 @@
   padding: $bitstyles-select-padding-vertical ($bitstyles-select-padding-horizontal * 2) $bitstyles-select-padding-vertical $bitstyles-select-padding-horizontal;
   overflow: hidden;
   font: inherit;
-  line-height: inherit;
+  line-height: $bitstyles-line-height-min;
   color: $bitstyles-select-color;
   text-overflow: ellipsis;
   cursor: pointer;
@@ -45,7 +45,7 @@
     color: $bitstyles-select-color-invalid;
     background-color: $bitstyles-select-background-color-invalid;
     background-image: $bitstyles-select-background-image-invalid;
-    border: $bitstyles-select-border-invalid;
+    border: $bitstyles-select-border-color-invalid;
   }
 
   &[disabled] {

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -80,9 +80,8 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
             </li>
             <li class="u-margin-m--bottom u-flex u-flex--col">
               <label for="password">Password</label>
-              <input id="password" type="password" autocomplete="current-password" aria-invalid="true" aria-describedby="password-help-text" />
-              <div class="u-flex u-justify-between u-margin-xs--top">
-                <span id="password-help-text" class="u-fg--warning">Incorrect password</span>
+              <input id="password" type="password" autocomplete="current-password" />
+              <div class="u-flex u-justify-end u-margin-xs--top">
                 <a href="/">Forgot password?</a>
               </div>
             </li>

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -179,7 +179,7 @@ For a more complex form, `.u-grid--6-col@m` allows for fields of different sizes
             <div class="u-grid__col-span-2@l">
               <p class="u-h6 u-fg--gray-50 u-padding-l--y@l u-padding-xl--right@m">Some intro text can go here, to describe this section</p>
             </div>
-            <ul class="a-list-reset u-grid__col-3@l u-grid__col-span-4@l u-grid u-gap-m u-grid--6-col@m u-gap-x-s@m">
+            <ul class="a-list-reset u-grid__col-3@l u-grid__col-span-4@l u-grid u-gap-m u-grid--6-col@m">
               <li class="u-grid__col-span-4@m u-grid__col-span-3@l">
                 <label for="street">Street</label>
                 <input id="street" type="text" autocomplete="address-line1" />
@@ -188,11 +188,11 @@ For a more complex form, `.u-grid--6-col@m` allows for fields of different sizes
                 <label for="house">House Nr.</label>
                 <input id="house" type="text" />
               </li>
-              <li class="u-grid__col-1@m u-grid__col-1@l u-grid__col-span-3@m u-grid__col-span-3@l">
+              <li class="u-grid__col-1@m u-grid__col-1@l u-grid__col-span-3@m">
                 <label for="city">City</label>
                 <input id="city" type="text" autocomplete="address-line2" />
               </li>
-              <li class="u-grid__col-span-3@m u-grid__col-span-3@l">
+              <li class="u-grid__col-span-3@m">
                 <label for="country">Country</label>
                 <input id="country" type="text" autocomplete="country-name" />
               </li>

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -147,19 +147,21 @@ For a more complex form, `.u-grid--6-col@m` allows for fields of different sizes
     {`
       <form action="" method="POST" class="a-content">
         <h2>Profile</h2>
-        <div class="a-card@m u-padding-xl@m u-padding-xl--bottom u-margin-xl--bottom">
-          <fieldset>
+        <fieldset class="u-margin-xl--bottom u-padding-xl--bottom">
+          <div class="a-bordered-header u-margin-xl--bottom">
             <legend class="u-h3 u-font--bold">Account details</legend>
-            <ul class="a-list-reset u-grid u-grid--6-col@m">
-              <li class="u-grid__col-span-4@m u-grid__col-span-3@l">
+          </div>
+          <div class="u-grid u-gap-m u-grid--6-col@l">
+            <ul class="a-list-reset u-grid__col-3@l u-grid u-gap-m u-grid--6-col@m u-grid__col-span-4@l">
+              <li class="u-grid__col-span-4@m u-grid__col-1@m u-grid__col-span-3@l">
                 <label for="name">Name</label>
                 <input id="name" type="text" autocomplete="name" value="Jon Doe" />
               </li>
-              <li class="u-grid__col-1@m u-grid__col-1@l u-grid__col-span-4@m u-grid__col-span-3@l">
+              <li class="u-grid__col-span-4@m u-grid__col-1@m u-grid__col-span-3@l">
                 <label for="email">Email</label>
                 <input id="email" type="text" autocomplete="email" value="jon.doe@gmx.de" />
               </li>
-              <li class="u-grid__col-1@m u-grid__col-1@l u-grid__col-span-2@m u-grid__col-span-1@l">
+              <li class="u-grid__col-1@m u-grid__col-span-2@m">
                 <label for="type">Account type</label>
                 <select id="type">
                   <option value="user">User</option>
@@ -167,43 +169,47 @@ For a more complex form, `.u-grid--6-col@m` allows for fields of different sizes
                 </select>
               </li>
             </ul>
-          </fieldset>
-        </div>
-        <div class="a-card@m u-padding-xl@m u-padding-xl--bottom u-margin-xl--bottom">
-          <fieldset>
-            <legend class="u-h3 u-font--bold">Address</legend>
-            <ul class="a-list-reset u-grid u-grid--6-col@m">
-              <li class="u-grid__col-span-3@m">
+          </div>
+        </fieldset>
+        <fieldset class="u-margin-xl--bottom u-padding-xl--bottom">
+          <div class="a-bordered-header u-margin-xl--bottom">
+            <legend class="u-h3 u-font--bold a-bordered-header">Address</legend>
+          </div>
+          <div class="u-grid u-gap-m u-grid--6-col@l">
+            <ul class="a-list-reset u-grid__col-3@l u-grid__col-span-4@l u-grid u-gap-m u-grid--6-col@m u-gap-x-s@m">
+              <li class="u-grid__col-span-4@m u-grid__col-span-3@l">
                 <label for="street">Street</label>
                 <input id="street" type="text" autocomplete="address-line1" />
               </li>
               <li class="u-grid__col-span-2@m u-grid__col-span-1@l">
-                <label for="house">House number</label>
+                <label for="house">House Nr.</label>
                 <input id="house" type="text" />
               </li>
-              <li class="u-grid__col-1@m u-grid__col-1@l u-grid__col-span-3@m u-grid__col-span-2@l">
+              <li class="u-grid__col-1@m u-grid__col-1@l u-grid__col-span-3@m u-grid__col-span-3@l">
                 <label for="city">City</label>
                 <input id="city" type="text" autocomplete="address-line2" />
               </li>
-              <li class="u-grid__col-span-3@m u-grid__col-span-2@l">
+              <li class="u-grid__col-span-3@m u-grid__col-span-3@l">
                 <label for="country">Country</label>
                 <input id="country" type="text" autocomplete="country-name" />
               </li>
-              <li class="u-grid__col-span-3@m u-grid__col-span-2@l">
+              <li class="u-grid__col-span-2@m">
                 <label for="postal-code">Postal code</label>
                 <input id="postal-code" type="text" autocomplete="postal-code" />
               </li>
             </ul>
-          </fieldset>
+          <div>
+        </fieldset>
+        <div class="u-grid u-gap-m u-grid--6-col@l u-margin-xl--bottom">
+          <ul class="a-list-reset u-flex u-items-center u-grid__col-3@l u-grid__col-span-4@l">
+            <li class="u-margin-l--right">
+              <button type="submit" class="a-button">Save changes</button>
+            </li>
+            <li>
+              <a href="/"> or cancel</a>
+            </li>
+          </ul>
         </div>
-        <ul class="a-list-reset u-flex u-items-center">
-          <li class="u-margin-l--right">
-            <button type="submit" class="a-button">Save changes</button>
-          </li>
-          <li>
-            <a href="/"> or cancel</a>
-          </li>
-        </ul>
       </form>
     `}
   </Story>

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -138,12 +138,12 @@ This form has the commonly-required fields for creating an account. Note the wor
   </Story>
 </Canvas>
 
-## User profile
+## Complex, multi-section form
 
-For a more complex form, `.u-grid--6-col@m` allows for fields of different sizes on larger screens.
+For a more complex form, `.u-grid--6-col@m` allows for fields of different sizes on larger screens. Combine it width fieldsets, legends, and the [bordered-header](/?path=/docs/atoms-bordered-header--bordered-header) atom.
 
 <Canvas>
-  <Story name="User profile form">
+  <Story name="Complex, multi-section form">
     {`
       <form action="" method="POST" class="a-content">
         <h2>Profile</h2>
@@ -176,6 +176,9 @@ For a more complex form, `.u-grid--6-col@m` allows for fields of different sizes
             <legend class="u-h3 u-font--bold a-bordered-header">Address</legend>
           </div>
           <div class="u-grid u-gap-m u-grid--6-col@l">
+            <div class="u-grid__col-span-2@l">
+              <p class="u-h6 u-fg--gray-50 u-padding-l--y@l u-padding-xl--right@m">Some intro text can go here, to describe this section</p>
+            </div>
             <ul class="a-list-reset u-grid__col-3@l u-grid__col-span-4@l u-grid u-gap-m u-grid--6-col@m u-gap-x-s@m">
               <li class="u-grid__col-span-4@m u-grid__col-span-3@l">
                 <label for="street">Street</label>
@@ -214,6 +217,44 @@ For a more complex form, `.u-grid--6-col@m` allows for fields of different sizes
     `}
   </Story>
 </Canvas>
+
+## Simple resource editing
+
+Some forms are always going to be small and simple, with just a few text inputs and nothing else.
+
+<Canvas>
+  <Story name="Simple resource editing">
+    {`
+      <form action="" method="POST" class="a-content">
+        <fieldset>
+          <legend class="u-sr-only">User LKJHAS786SGLKJHAFGO7YEGKJBF</legend>
+          <div class="u-grid u-gap-m u-grid--6-col@l u-margin-xl--bottom">
+            <ul class="a-list-reset u-grid u-gap-m u-grid--6-col@m u-grid__col-span-4@l">
+              <li class="u-grid__col-span-4@m u-grid__col-1@m">
+                <label for="name">Name</label>
+                <input id="name" type="text" autocomplete="name" value="Jon Doe" />
+              </li>
+              <li class="u-grid__col-span-4@m u-grid__col-1@m">
+                <label for="email">Email</label>
+                <input id="email" type="text" autocomplete="email" value="jon.doe@gmx.de" />
+              </li>
+            </ul>
+          </div>
+        </fieldset>
+        <ul class="a-list-reset u-flex u-items-center u-margin-xl--bottom">
+          <li class="u-margin-l--right">
+            <button type="submit" class="a-button">Save changes</button>
+          </li>
+          <li>
+            <a href="/"> or cancel</a>
+          </li>
+        </ul>
+      </form>
+    `}
+  </Story>
+</Canvas>
+
+
 
 ## Search form
 

--- a/scss/bitstyles/utilities/gap/_.scss
+++ b/scss/bitstyles/utilities/gap/_.scss
@@ -1,0 +1,3 @@
+.#{$bitstyles-namespace}u-gap-m {
+  gap: spacing('m');
+}

--- a/scss/bitstyles/utilities/gap/gap.stories.mdx
+++ b/scss/bitstyles/utilities/gap/gap.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/Gap" />
+
+# Gap
+
+The gap classes specify gaps on your grid elements — space between each grid item, but no space around them (you need to handle the space outside yourself).
+
+<Canvas>
+  <Story name="u-gap-m">
+    {`
+      <div class="u-grid u-padding-m u-gap-m u-bg--gray-10">
+        <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
+        <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
+        <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
+        <div class="u-bg--background u-padding-m a-card">Grid child 4</div>
+        <div class="u-bg--background u-padding-m a-card">Grid child 5</div>
+        <div class="u-bg--background u-padding-m a-card">Grid child 6</div>
+      </div>
+    `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/utilities/grid/_.scss
+++ b/scss/bitstyles/utilities/grid/_.scss
@@ -2,7 +2,6 @@
 
 .#{$bitstyles-namespace}u-grid {
   display: grid;
-  grid-gap: $bitstyles-grid-gap;
 }
 
 .#{$bitstyles-namespace}u-grid--2-col {
@@ -33,6 +32,14 @@
   grid-column: span 4 / span 4;
 }
 
+.#{$bitstyles-namespace}u-grid__col-span-5 {
+  grid-column: span 5 / span 5;
+}
+
+.#{$bitstyles-namespace}u-grid__col-span-6 {
+  grid-column: span 6 / span 6;
+}
+
 .#{$bitstyles-namespace}u-grid__col-1 {
   grid-column-start: 1;
 }
@@ -42,13 +49,8 @@
 }
 
 @include media-query('m') {
-  .#{$bitstyles-namespace}u-grid {
-    grid-gap: $bitstyles-grid-gap-m;
-  }
-
   .#{$bitstyles-namespace}u-grid\@m {
     display: grid;
-    grid-gap: $bitstyles-grid-gap-m;
   }
 
   .#{$bitstyles-namespace}u-grid--2-col\@m {
@@ -79,6 +81,14 @@
     grid-column: span 4 / span 4;
   }
 
+  .#{$bitstyles-namespace}u-grid__col-span-5\@m {
+    grid-column: span 5 / span 5;
+  }
+
+  .#{$bitstyles-namespace}u-grid__col-span-6\@m {
+    grid-column: span 6 / span 6;
+  }
+
   .#{$bitstyles-namespace}u-grid__col-1\@m {
     grid-column-start: 1;
   }
@@ -86,16 +96,15 @@
   .#{$bitstyles-namespace}u-grid__col-2\@m {
     grid-column-start: 2;
   }
+
+  .#{$bitstyles-namespace}u-grid__col-3\@m {
+    grid-column-start: 3;
+  }
 }
 
 @include media-query('l') {
-  .#{$bitstyles-namespace}u-grid {
-    grid-gap: $bitstyles-grid-gap-l;
-  }
-
   .#{$bitstyles-namespace}u-grid\@l {
     display: grid;
-    grid-gap: $bitstyles-grid-gap-l;
   }
 
   .#{$bitstyles-namespace}u-grid--2-col\@l {
@@ -132,5 +141,9 @@
 
   .#{$bitstyles-namespace}u-grid__col-2\@l {
     grid-column-start: 2;
+  }
+
+  .#{$bitstyles-namespace}u-grid__col-3\@l {
+    grid-column-start: 3;
   }
 }

--- a/scss/bitstyles/utilities/grid/_.scss
+++ b/scss/bitstyles/utilities/grid/_.scss
@@ -32,14 +32,6 @@
   grid-column: span 4 / span 4;
 }
 
-.#{$bitstyles-namespace}u-grid__col-span-5 {
-  grid-column: span 5 / span 5;
-}
-
-.#{$bitstyles-namespace}u-grid__col-span-6 {
-  grid-column: span 6 / span 6;
-}
-
 .#{$bitstyles-namespace}u-grid__col-1 {
   grid-column-start: 1;
 }
@@ -79,14 +71,6 @@
 
   .#{$bitstyles-namespace}u-grid__col-span-4\@m {
     grid-column: span 4 / span 4;
-  }
-
-  .#{$bitstyles-namespace}u-grid__col-span-5\@m {
-    grid-column: span 5 / span 5;
-  }
-
-  .#{$bitstyles-namespace}u-grid__col-span-6\@m {
-    grid-column: span 6 / span 6;
   }
 
   .#{$bitstyles-namespace}u-grid__col-1\@m {

--- a/scss/bitstyles/utilities/grid/grid.stories.mdx
+++ b/scss/bitstyles/utilities/grid/grid.stories.mdx
@@ -8,10 +8,12 @@ A responsive CSS grid system. Grids can be nested as much as you need.
 
 Giving an element the base class `.u-grid` alone will not create the columns you probably want — see the example below. The grid children have some space between them, but otherwise they behave like block elements.
 
+The grid classes are only rarely used without the [gap](/?path=/docs/utilities-gap--u-gap-m) utilities, as you normally want some space between items, and gap achieves that with no mathematics required.
+
 <Canvas>
   <Story name="u-grid">
     {`
-      <div class="u-grid u-padding-m u-bg--gray-10">
+      <div class="u-grid u-gap-m u-padding-m u-bg--gray-10">
         <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
         <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
         <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
@@ -28,7 +30,7 @@ If you’re rendering a list of related items, use a list element (could be a `<
 <Canvas>
   <Story name="u-grid (list)">
     {`
-      <ul class="u-grid a-list-reset u-padding-m u-bg--gray-10">
+      <ul class="u-grid u-gap-m a-list-reset u-padding-m u-bg--gray-10">
         <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -47,7 +49,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
 <Canvas isColumn>
   <Story name="u-grid--2-col">
     {`
-      <ul class="u-grid u-grid--2-col u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--2-col u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -59,7 +61,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
   </Story>
   <Story name="u-grid--3-col">
     {`
-      <ul class="u-grid u-grid--3-col u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--3-col u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -78,7 +80,7 @@ Column classes can be applied at specific breakpoints using the `@breakpoint` su
 <Canvas isColumn>
   <Story name="u-grid--2-col@m">
     {`
-      <ul class="u-grid u-grid--2-col@m u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--2-col@m u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -90,7 +92,7 @@ Column classes can be applied at specific breakpoints using the `@breakpoint` su
   </Story>
   <Story name="u-grid--3-col@m">
     {`
-      <ul class="u-grid u-grid--3-col@m u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--3-col@m u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -107,7 +109,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
 <Canvas isColumn>
   <Story name="u-grid__col-span-2">
     {`
-      <ul class="u-grid u-grid--2-col u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--2-col u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--brand-2 u-padding-m a-card u-grid__col-span-2">Grid child 1, span 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -119,7 +121,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-grid__col-span-2@m">
     {`
-      <ul class="u-grid u-grid--2-col@m u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--2-col@m u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--brand-2 u-padding-m a-card u-grid__col-span-2@m">Grid child 1, span 2 @m</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -131,7 +133,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-grid__col-span-3">
     {`
-      <ul class="u-grid u-grid--3-col u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--3-col u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--brand-2 u-padding-m a-card u-grid__col-span-3">Grid child 1, span 3</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -143,7 +145,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-grid__col-span-3@m">
     {`
-      <ul class="u-grid u-grid--3-col@m u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--3-col@m u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--brand-2 u-padding-m a-card u-grid__col-span-3@m">Grid child 1, span 3 @m</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
@@ -160,10 +162,10 @@ You can specify that a grid child should start a row using `.u-grid__col-1`.
 <Canvas isColumn>
   <Story name="u-grid__col-1">
     {`
-      <ul class="u-grid u-grid--3-col u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--3-col u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-grid__col-1">Grid child 3, cou-1</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-grid__col-1">Grid child 3, col-1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
@@ -172,10 +174,10 @@ You can specify that a grid child should start a row using `.u-grid__col-1`.
   </Story>
   <Story name="u-grid__col-1@m">
     {`
-      <ul class="u-grid u-grid--3-col@m u-padding-m u-bg--gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid--3-col@m u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-grid__col-1@m">Grid child 3, cou-1</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-grid__col-1@m">Grid child 3, col-1</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
         <li class="u-bg--background u-padding-m a-card">Grid child 6</li>


### PR DESCRIPTION
Fixes #429 

- Improved layout & visuals for non-login forms. Fieldsets, legends, and lots of grid to make it useful at different screensizes
- Adds an example for very simple forms
- Updates bordered-header to be left-aligned
- grid elements will now need to have the gap set using the gap utility classes.

Looks like:

<img width="1195" alt="Screenshot 2021-03-18 at 16 57 52" src="https://user-images.githubusercontent.com/2479422/111662715-780e7600-8810-11eb-80be-c5300fa82ca8.png">

<img width="828" alt="Screenshot 2021-03-18 at 16 58 06" src="https://user-images.githubusercontent.com/2479422/111662719-793fa300-8810-11eb-8f3e-34946625c95c.png">

<img width="413" alt="Screenshot 2021-03-18 at 16 58 21" src="https://user-images.githubusercontent.com/2479422/111662724-79d83980-8810-11eb-8f61-07345fa90e8b.png">


Simple form has less chrome around it, and a restricted width:

<img width="1172" alt="Screenshot 2021-03-18 at 17 19 53" src="https://user-images.githubusercontent.com/2479422/111662811-8e1c3680-8810-11eb-867a-57bb93a225f8.png">
