### PR TITLE
[#397] Update modal component

### DIFF
--- a/scss/bitstyles/atoms/button/_.scss
+++ b/scss/bitstyles/atoms/button/_.scss
@@ -4,6 +4,7 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   flex-shrink: 0;
   max-width: 100%;
   min-height: calc(#{$bitstyles-button-padding-vertical  * 2} + 1em);

--- a/scss/bitstyles/atoms/content/_.scss
+++ b/scss/bitstyles/atoms/content/_.scss
@@ -7,3 +7,7 @@
 .#{$bitstyles-namespace}a-content--s {
   max-width: $bitstyles-content-max-width-s;
 }
+
+.#{$bitstyles-namespace}a-content--m {
+  max-width: $bitstyles-content-max-width-m;
+}

--- a/scss/bitstyles/atoms/content/settings.scss
+++ b/scss/bitstyles/atoms/content/settings.scss
@@ -1,4 +1,5 @@
 $bitstyles-content-max-width-s: 25rem !default;
+$bitstyles-content-max-width-m: 35rem !default;
 $bitstyles-content-max-width: 65rem !default;
 $bitstyles-content-horizontal-padding: spacing('m') !default;
 $bitstyles-content-horizontal-padding-large: spacing('l') !default;

--- a/scss/bitstyles/organisms/modal/_.scss
+++ b/scss/bitstyles/organisms/modal/_.scss
@@ -31,11 +31,9 @@
   top: 50%;
   left: 50%;
   z-index: 20;
-  width: 100%;
-  height: 100%;
-  max-height: 100vh;
-  padding-top: $bitstyles-modal-padding;
-  padding-bottom: $bitstyles-modal-padding;
+  width: calc(100% - 2 * #{$bitstyles-modal-padding});
+  height: auto;
+  max-height: calc(100vh - 2 * #{$bitstyles-modal-padding});
   overflow: scroll;
   -webkit-overflow-scrolling: touch;
   background-color: $bitstyles-modal-background-color;
@@ -56,8 +54,6 @@
 
 @include media-query($bitstyles-modal-breakpoint) {
   .#{$bitstyles-namespace}c-modal__content {
-    width: calc(100% - 2 * #{$bitstyles-modal-padding});
-    height: auto;
     transition: all $bitstyles-modal-transition-duration $bitstyles-modal-transition-easing, visibility 0 $bitstyles-modal-transition-easing;
 
     [aria-hidden="true"] & {
@@ -65,12 +61,6 @@
       transition: all $bitstyles-modal-transition-duration $bitstyles-modal-transition-easing, visibility 0 $bitstyles-modal-transition-easing $bitstyles-modal-transition-duration;
     }
   }
-}
-
-.#{$bitstyles-namespace}c-modal__close {
-  position: absolute;
-  top: $bitstyles-modal-padding;
-  right: $bitstyles-modal-padding;
 }
 
 @mixin modal-variation($state) {

--- a/scss/bitstyles/organisms/modal/modal.stories.mdx
+++ b/scss/bitstyles/organisms/modal/modal.stories.mdx
@@ -1,4 +1,5 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import icons from '../../../../test/assets/images/icons.svg';
 
 <Meta title="UI/Modal" />
 
@@ -10,25 +11,36 @@ Set modal size using the usual layout classes e.g. `.a-content`. At smaller scre
 
 Modals are a common UI component that needs Javascript — use a suitable package for your project. [A11y-dialog.js](https://github.com/edenspiekermann/a11y-dialog) is a great example of what to look for. The package needs to be keyboard navigable, trap focus, add and remove aria-hidden attributes, respond to click on the overlay behind it, stop scrolling of the main content, and present a close button with some text content for screenreaders.
 
+
+## Informational
+
+You may want to inform the user of the success or failure of an action, give a little explanatory text, and provide a button to dismiss the modal.
+
 <Canvas>
-  <Story name="Modal">
+  <Story name="Informational modal" inline={false} height="80vh">
     {`
-      <main aria-label="Content" id="main" class="a-content">
+      <main id="main" class="a-content">
         <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
         <p class="u-text--center"><button class="a-link" data-a11y-dialog-show="dialog_1">open dialogue</button></p>
         <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
       </main>
-      <div class="c-modal" id="dialog_1" aria-hidden="false">
-        <div class="c-modal__overlay" tabindex="-1" data-a11y-dialog-hide></div>
-        <div class="a-content c-modal__content a-card u-padding-xl" role="dialog" aria-labelledby="dialog-title">
-          <div role="document">
-            <h1 class="u-h1" id="dialog-title" tabindex="0">Dialog Title</h1>
-            <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
-            <p>Gummies cake topping ice cream dessert. Jelly beans marzipan toffee biscuit cookie lollipop cake pie. Apple pie sweet bonbon candy jujubes. Gummi bears biscuit cheesecake marshmallow chupa chups danish carrot cake. Cookie croissant ice cream bonbon ice cream. Cotton candy halvah bear claw. Pudding apple pie tootsie roll gummi bears halvah icing jelly-o jelly beans. Jujubes lemon drops macaroon wafer tart dragée. Gummies danish lollipop cupcake oat cake. Ice cream candy canes brownie chocolate bar pie macaroon biscuit tootsie roll. Tootsie roll carrot cake fruitcake. Wafer chupa chups jelly beans. Pie cake jujubes caramels wafer.</p>
-            <button class="a-button c-modal__close" type="button" data-a11y-dialog-hide aria-label="Close this dialog window">
-              &times;
-            </button>
+      <div class="c-modal" id="dialog_1" aria-hidden="false" aria-labelledby="dialog-title">
+        <div class="c-modal__overlay" tabindex="-1" data-a11y-dialog-hide title="Close modal"></div>
+        <div class="a-content a-content--s c-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex--col" role="document">
+          <div class="u-flex u-flex--col u-items-center">
+            <div class="a-badge a-badge--positive u-padding-m u-margin-s--bottom">
+              <svg width="18" height="18" class="a-icon a-icon--xl" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                <use xlink:href="${icons}#icon-check"></use>
+              </svg>
+            </div>
+            <h1 class="u-flex__shrink-0 u-h2" id="dialog-title" tabindex="0">Confirmation email sent</h1>
           </div>
+          <div class="u-flex__grow-1 u-overflow--y u-fg--gray-50 u-text--center">
+            <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread.</p>
+          </div>
+          <button class="u-flex__shrink-0 u-margin-l--top a-button" type="button" data-a11y-dialog-hide>
+            Continue
+          </button>
         </div>
       </div>
     `}
@@ -37,26 +49,34 @@ Modals are a common UI component that needs Javascript — use a suitable packag
 
 ## Modal dialog
 
-Using the `modal-variation` mixin we can provide different animations depending on which of several buttons in the modal content the user clicks. Here we have ‘cancel’ and ‘ok’ buttons, with animations to emphasise the meaning of the chosen action (use JS to add the correct class to the modal element based on which button is clicked).
+If you have multiple options for the user, present them with any information they may need in order to decide, and as few options as possible.
 
 <Canvas>
-  <Story name="Modal dialog">
+  <Story name="Modal dialog" inline={false} height="80vh">
     {`
-    <main aria-label="Content" id="main" class="a-content">
+    <main id="main" class="a-content">
       <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
       <p class="u-text--center">
         <button class="a-link" data-a11y-dialog-show="dialog_1">open dialogue</button>
       </p>
       <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
     </main>
-    <div class="c-modal" id="dialog_1" aria-hidden="false">
-      <div class="c-modal__overlay" tabindex="-1" data-a11y-dialog-hide></div>
-      <div class="a-content a-content--s c-modal__content a-card u-padding-xl" role="dialog" aria-labelledby="dialog-title">
-        <div role="document">
-          <h1 class="u-h1" id="dialog-title" tabindex="0">Dialog Title</h1>
-          <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
-          <button class="a-button" type="button" id="#cancel_button">Cancel</button>
-          <button class="a-button" type="button" id="#ok_button">Ok</button>
+    <div class="c-modal" id="dialog_1" aria-hidden="false" aria-labelledby="dialog-title">
+      <div class="c-modal__overlay" tabindex="-1" title="Close modal" data-a11y-dialog-hide></div>
+      <div class="a-content a-content--m c-modal__content a-card u-padding-l u-padding-xl@m u-flex u-flex--col" role="document">
+        <header class="u-flex__shrink-0 u-flex u-items-center">
+          <h1 class="u-h2 u-flex__shrink-0 u-margin-0" id="dialog-title" tabindex="0">Dialog Title</h1>
+        </header>
+        <div class="u-flex__grow-1 u-overflow--y">
+          <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake.</p>
+          <ul class="a-list-reset u-grid u-grid--2-col@m u-margin-l--top">
+            <li class="u-margin-xl--right">
+              <button class="a-link" type="button">Cancel</button>
+            </li>
+            <li>
+              <button class="a-button" type="button">Ok</button>
+            </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/scss/bitstyles/organisms/modal/modal.stories.mdx
+++ b/scss/bitstyles/organisms/modal/modal.stories.mdx
@@ -88,3 +88,44 @@ If you have multiple options for the user, present them with any information the
   `}
   </Story>
 </Canvas>
+
+## Modal with long text
+
+Sometimes you just need to dump a load of text on the user, such as for legal documentation. Best avoided, but sometimes unavoidable. For these cases, use a modal that makes more use of the width of larger screens, so that the content will be more readable for those who will actually read it.
+
+<Canvas>
+  <Story name="Modal with long text" inline={false} height="80vh">
+    {`
+    <main id="main" class="a-content">
+      <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
+      <p class="u-text--center">
+        <button class="a-link" data-a11y-dialog-show="dialog_1">open dialogue</button>
+      </p>
+      <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
+    </main>
+    <div class="c-modal" id="dialog_1" aria-hidden="false" aria-labelledby="dialog-title">
+      <div class="c-modal__overlay" tabindex="-1" title="Close modal" data-a11y-dialog-hide></div>
+      <div class="a-content a-content--m c-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex--col" role="document">
+        <header class="u-flex u-flex--col u-items-center">
+          <div class="a-badge a-badge--brand-1 u-padding-m u-margin-s--bottom">
+            <svg width="18" height="18" class="a-icon a-icon--xl" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <use xlink:href="${icons}#icon-mail"></use>
+            </svg>
+          </div>
+          <h1 class="u-flex__shrink-0 u-h2 u-margin-0" id="dialog-title" tabindex="0">The legal stuff</h1>
+          <p class="u-h3">Please read and accept</p>
+        </header>
+        <div class="u-flex__grow-1 u-overflow--y u-fg--gray-50">
+          <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
+          <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
+          <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
+          <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
+        </div>
+        <button class="u-flex__shrink-0 u-margin-l--top u-margin-xl--top@m a-button" type="button" data-a11y-dialog-hide>
+          I accept
+        </button>
+      </div>
+    </div>
+  `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/organisms/modal/modal.stories.mdx
+++ b/scss/bitstyles/organisms/modal/modal.stories.mdx
@@ -27,19 +27,19 @@ You may want to inform the user of the success or failure of an action, give a l
       <div class="c-modal" id="dialog_1" aria-hidden="false" aria-labelledby="dialog-title">
         <div class="c-modal__overlay" tabindex="-1" data-a11y-dialog-hide title="Close modal"></div>
         <div class="a-content a-content--s c-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex--col" role="document">
-          <div class="u-flex u-flex--col u-items-center">
+          <header class="u-flex u-flex--col u-items-center">
             <div class="a-badge a-badge--positive u-padding-m u-margin-s--bottom">
               <svg width="18" height="18" class="a-icon a-icon--xl" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-check"></use>
               </svg>
             </div>
             <h1 class="u-flex__shrink-0 u-h2" id="dialog-title" tabindex="0">Confirmation email sent</h1>
-          </div>
+          </header>
           <div class="u-flex__grow-1 u-overflow--y u-fg--gray-50 u-text--center">
-            <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread.</p>
+            <p>We sent the email to your primary email address. If you do not receive it shortly, please contact your admin.</p>
           </div>
           <button class="u-flex__shrink-0 u-margin-l--top a-button" type="button" data-a11y-dialog-hide>
-            Continue
+            Got it
           </button>
         </div>
       </div>
@@ -63,21 +63,26 @@ If you have multiple options for the user, present them with any information the
     </main>
     <div class="c-modal" id="dialog_1" aria-hidden="false" aria-labelledby="dialog-title">
       <div class="c-modal__overlay" tabindex="-1" title="Close modal" data-a11y-dialog-hide></div>
-      <div class="a-content a-content--m c-modal__content a-card u-padding-l u-padding-xl@m u-flex u-flex--col" role="document">
-        <header class="u-flex__shrink-0 u-flex u-items-center">
-          <h1 class="u-h2 u-flex__shrink-0 u-margin-0" id="dialog-title" tabindex="0">Dialog Title</h1>
+      <div class="a-content a-content--s c-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex--col" role="document">
+        <header class="u-flex u-flex--col u-items-center">
+          <div class="a-badge a-badge--brand-1 u-padding-m u-margin-s--bottom">
+            <svg width="18" height="18" class="a-icon a-icon--xl" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <use xlink:href="${icons}#icon-mail"></use>
+            </svg>
+          </div>
+          <h1 class="u-flex__shrink-0 u-h2" id="dialog-title" tabindex="0">Send confirmation email?</h1>
         </header>
-        <div class="u-flex__grow-1 u-overflow--y">
-          <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake.</p>
-          <ul class="a-list-reset u-grid u-grid--2-col@m u-margin-l--top">
-            <li class="u-margin-xl--right">
-              <button class="a-link" type="button">Cancel</button>
-            </li>
-            <li>
-              <button class="a-button" type="button">Ok</button>
-            </li>
-          </ul>
+        <div class="u-flex__grow-1 u-overflow--y u-fg--gray-50 u-text--center">
+          <p>The previous email we sent to email@example.com will no longer be valid.</p>
         </div>
+        <ul class="a-list-reset u-grid u-grid--2-col@m u-gap-m u-items-center u-margin-l--top">
+          <li class="u-flex u-flex--col">
+            <button class="a-button a-button--ui" type="button">Cancel</button>
+          </li>
+          <li class="u-flex u-flex--col">
+            <button class="a-button" type="button">Send</button>
+          </li>
+        </ul>
       </div>
     </div>
   `}

--- a/scss/bitstyles/organisms/modal/settings.scss
+++ b/scss/bitstyles/organisms/modal/settings.scss
@@ -1,6 +1,6 @@
 $bitstyles-modal-padding: spacing('m') !default;
 $bitstyles-modal-background-color: palette('background') !default;
-$bitstyles-modal-overlay-color: rgba(palette('white'), 0.7) !default;
+$bitstyles-modal-overlay-color: rgba(palette('white'), 0.85) !default;
 $bitstyles-modal-transition-easing: ease-in-out !default;
 $bitstyles-modal-transition-duration: 0.3s !default;
 $bitstyles-modal-transition-duration-smallscreen: 0.25s !default;

--- a/scss/bitstyles/organisms/modal/settings.scss
+++ b/scss/bitstyles/organisms/modal/settings.scss
@@ -1,6 +1,6 @@
 $bitstyles-modal-padding: spacing('m') !default;
 $bitstyles-modal-background-color: palette('background') !default;
-$bitstyles-modal-overlay-color: rgba(palette('white'), 0.85) !default;
+$bitstyles-modal-overlay-color: rgba(palette('white'), 0.95) !default;
 $bitstyles-modal-transition-easing: ease-in-out !default;
 $bitstyles-modal-transition-duration: 0.3s !default;
 $bitstyles-modal-transition-duration-smallscreen: 0.25s !default;

--- a/test/css-stats.json
+++ b/test/css-stats.json
@@ -35,9 +35,9 @@
     "selectorsById": 0,
     "selectorsByPseudo": 157,
     "selectorsByTag": 110,
-    "length": 39523,
+    "length": 39474,
     "rules": 541,
-    "declarations": 1074
+    "declarations": 1069
   },
   "offenders": {
     "duplicatedProperties": [
@@ -45,33 +45,33 @@
     ],
     "mediaQueries": [
       "@media screen and (min-width:30em) (7 rules) @ 1:3379",
-      "@media screen and (max-width:29.9375em) (1 rules) @ 1:21396",
-      "@media screen and (min-width:30em) (1 rules) @ 1:21550",
-      "@media screen and (min-width:30em) (1 rules) @ 1:21792",
-      "@media screen and (min-width:55em) (1 rules) @ 1:22155",
-      "@media screen and (min-width:30em) (2 rules) @ 1:23678",
-      "@media screen and (min-width:30em) (7 rules) @ 1:25576",
-      "@media screen and (min-width:30em) (1 rules) @ 1:27732",
-      "@media screen and (min-width:30em) (1 rules) @ 1:27927",
-      "@media screen and (min-width:30em) (1 rules) @ 1:28074",
-      "@media screen and (max-width:29.9375em) (1 rules) @ 1:28361",
-      "@media screen and (min-width:55em) (1 rules) @ 1:28428",
-      "@media screen and (max-width:29.9375em) (1 rules) @ 1:28513",
-      "@media screen and (min-width:30em) (1 rules) @ 1:28580",
-      "@media screen and (min-width:55em) (1 rules) @ 1:28642",
-      "@media screen and (min-width:30em) (1 rules) @ 1:28929",
-      "@media screen and (min-width:55em) (1 rules) @ 1:28989",
-      "@media screen and (min-width:30em) (11 rules) @ 1:29507",
-      "@media screen and (min-width:55em) (11 rules) @ 1:30069",
-      "@media screen and (max-width:29.9375em) (42 rules) @ 1:32430",
-      "@media screen and (min-width:30em) (42 rules) @ 1:34017",
-      "@media screen and (min-width:30em) (42 rules) @ 1:37651"
+      "@media screen and (max-width:29.9375em) (1 rules) @ 1:21419",
+      "@media screen and (min-width:30em) (1 rules) @ 1:21573",
+      "@media screen and (min-width:30em) (1 rules) @ 1:21815",
+      "@media screen and (min-width:55em) (1 rules) @ 1:22178",
+      "@media screen and (min-width:30em) (2 rules) @ 1:23723",
+      "@media screen and (min-width:30em) (7 rules) @ 1:25527",
+      "@media screen and (min-width:30em) (1 rules) @ 1:27683",
+      "@media screen and (min-width:30em) (1 rules) @ 1:27878",
+      "@media screen and (min-width:30em) (1 rules) @ 1:28025",
+      "@media screen and (max-width:29.9375em) (1 rules) @ 1:28312",
+      "@media screen and (min-width:55em) (1 rules) @ 1:28379",
+      "@media screen and (max-width:29.9375em) (1 rules) @ 1:28464",
+      "@media screen and (min-width:30em) (1 rules) @ 1:28531",
+      "@media screen and (min-width:55em) (1 rules) @ 1:28593",
+      "@media screen and (min-width:30em) (1 rules) @ 1:28880",
+      "@media screen and (min-width:55em) (1 rules) @ 1:28940",
+      "@media screen and (min-width:30em) (11 rules) @ 1:29458",
+      "@media screen and (min-width:55em) (11 rules) @ 1:30020",
+      "@media screen and (max-width:29.9375em) (42 rules) @ 1:32381",
+      "@media screen and (min-width:30em) (42 rules) @ 1:33968",
+      "@media screen and (min-width:30em) (42 rules) @ 1:37602"
     ],
     "multiClassesSelectors": [
-      ".a-button--icon.a-button--small @ 1:15944"
+      ".a-button--icon.a-button--small @ 1:15967"
     ],
     "importants": [
-      ".u-sr-only {position: absolute!important} @ 1:28154"
+      ".u-sr-only {position: absolute!important} @ 1:28105"
     ],
     "colors": [
       "#ffffff (27 times)",


### PR DESCRIPTION
Fixes #397 

Overhauls the modal styles, and the example components. Adds three example components:
- Simple informational modal
- Modal dialog with 2 options
- Modal with a long text for the user to read & accept

Looks like:

<img width="652" alt="Screenshot 2021-04-07 at 17 33 12" src="https://user-images.githubusercontent.com/2479422/113893502-6264ee80-97c7-11eb-9647-04ed0842d6e1.png">

<img width="366" alt="Screenshot 2021-04-07 at 17 30 11" src="https://user-images.githubusercontent.com/2479422/113893524-67c23900-97c7-11eb-8aa4-080436bf3cae.png">


<img width="652" alt="Screenshot 2021-04-07 at 17 33 05" src="https://user-images.githubusercontent.com/2479422/113893572-73156480-97c7-11eb-97c3-b2c809701ed0.png">

<img width="366" alt="Screenshot 2021-04-07 at 17 30 38" src="https://user-images.githubusercontent.com/2479422/113893616-7c9ecc80-97c7-11eb-8b15-56b06c583300.png">


<img width="756" alt="Screenshot 2021-04-07 at 17 33 25" src="https://user-images.githubusercontent.com/2479422/113893644-81fc1700-97c7-11eb-84c2-4263a5fe86f2.png">

<img width="366" alt="Screenshot 2021-04-07 at 17 30 19" src="https://user-images.githubusercontent.com/2479422/113893658-858f9e00-97c7-11eb-85ca-81aec0d0471c.png">
