### PR TITLE
[#456] Don’t center all button content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Changed
 
 - Webfonts are now included in the release
+- [Docs] Navbar examples are now in iframes of fixed height, so the examples are clearly visible in docs view
+
+## Fixed
+
+- `a-button--nav` and `a-button--nav-large` are no longer centered
 
 
 # [1.0.6] - 2021-03-31

--- a/scss/bitstyles/atoms/button--icon/_.scss
+++ b/scss/bitstyles/atoms/button--icon/_.scss
@@ -2,6 +2,7 @@
 
 .#{$bitstyles-namespace}a-button--icon {
   padding: $bitstyles-button-icon-padding-vertical $bitstyles-button-icon-padding-horizontal;
+  justify-content: flex-start;
   border-radius: $bitstyles-button-icon-border-radius;
 
   &,

--- a/scss/bitstyles/atoms/button--menu/_.scss
+++ b/scss/bitstyles/atoms/button--menu/_.scss
@@ -4,6 +4,7 @@
   display: flex;
   min-height: 0;
   padding: $bitstyles-button-menu-padding-vertical $bitstyles-button-menu-padding-horizontal;
+  justify-content: flex-start;
   border-radius: 0;
 
   &,

--- a/scss/bitstyles/atoms/button--nav-large/_.scss
+++ b/scss/bitstyles/atoms/button--nav-large/_.scss
@@ -3,6 +3,7 @@
 .a-button--nav-large {
   display: flex;
   padding: $bitstyles-button-nav-large-padding-vertical $bitstyles-button-nav-large-padding-horizontal;
+  justify-content: flex-start;
   border-radius: $bitstyles-button-nav-large-border-radius;
 
   &,

--- a/scss/bitstyles/atoms/button--nav/_.scss
+++ b/scss/bitstyles/atoms/button--nav/_.scss
@@ -2,6 +2,7 @@
 
 .a-button--nav {
   padding: $bitstyles-button-nav-padding-vertical $bitstyles-button-nav-padding-horizontal;
+  justify-content: flex-start;
   border-radius: $bitstyles-button-nav-border-radius;
 
   &,

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -34,7 +34,7 @@ Give the active link the `aria-current="page"` attribute.
 </details>
 
 <Canvas>
-  <Story name="Navbar" inline={false}>
+  <Story name="Navbar" inline={false} height="80vh">
     {`
       <nav class="u-bg--gray-80 u-padding-s--top u-padding-s--bottom u-relative">
         <div class="u-padding-m--x u-flex u-justify-between u-items-center u-flex--wrap">

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -33,8 +33,8 @@ Give the active link the `aria-current="page"` attribute.
   </ul>
 </details>
 
-<Canvas>
-  <Story name="Navbar">
+<Canvas >
+  <Story name="Navbar" inline={false}>
     {`
       <nav class="u-bg--gray-80 u-padding-s--top u-padding-s--bottom u-relative">
         <div class="u-padding-m--x u-flex u-justify-between u-items-center u-flex--wrap">
@@ -101,7 +101,7 @@ Give the active link the `aria-current="page"` attribute.
 This navbar is only intended to hold a few link to the main sections of your site. If you absolutely must have more links than can be easily handled, the navbar will scroll:
 
 <Canvas>
-  <Story name="Navbar with many links">
+  <Story name="Navbar with many links" inline={false} height="80vh">
     {`
       <nav class="u-bg--gray-80 u-padding-s--top u-padding-s--bottom u-relative">
         <div class="u-padding-m--x u-flex u-justify-between u-items-center">
@@ -190,10 +190,10 @@ This navbar is only intended to hold a few link to the main sections of your sit
 
 ## Sidebar
 
-A vertical navbar that can make better use of screenspace in some circumstnces, and is capable of containing more links confortably.
+A vertical navbar that can make better use of screenspace in some circumstances, and is capable of containing more links confortably.
 
 <Canvas>
-   <Story name="Sidebar">
+   <Story name="Sidebar" inline={false} height="80vh">
      {`
         <div class="u-flex u-height-100vh">
           <nav class="u-flex">
@@ -266,7 +266,7 @@ A vertical navbar that can make better use of screenspace in some circumstnces, 
                 </a>
               </div>
             </div>
-            <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex--col">
+            <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex--col u-hidden@l">
               <button class="u-flex__shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs--left" title="Toggle menu" aria-controls="navbar-1" aria-expanded="true">
                 <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
                   <use xlink:href="${icons}#icon-hamburger"></use>

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -33,7 +33,7 @@ Give the active link the `aria-current="page"` attribute.
   </ul>
 </details>
 
-<Canvas >
+<Canvas>
   <Story name="Navbar" inline={false}>
     {`
       <nav class="u-bg--gray-80 u-padding-s--top u-padding-s--bottom u-relative">


### PR DESCRIPTION
Fixes #456 

- nav and icon buttons are no longer centered horizontally
- Navbar & sidebar examples are now in iframes to ensure the absolutely-positioned elements don’t bleed into the main page

Looks like:

<img width="286" alt="Screenshot 2021-04-13 at 17 23 36" src="https://user-images.githubusercontent.com/2479422/114578216-fed23980-9c7c-11eb-98ed-75762c2cf2df.png">


