### PR TITLE
[#466] Dropdown component: add a ‘top’ variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 - More aspects of the sidebar organism can now be specified in Sass variables
+- `a-dropdown--top` variant of dropdown component
 
 ## Changed
 
@@ -10,8 +11,8 @@
 
 ## Breaking
 
-- Sidebar Sass variables have been renamed, so if you were using or overriding those variables in your project, you’ll need to rename `$sidebar-width` -to `$bitstyles-sidebar-large-width`
-
+- Sidebar Sass variables have been renamed, so if you were using or overriding those variables in your project, you’ll need to rename `$sidebar-width` to `$bitstyles-sidebar-large-width`
+- Renames `.a-dropdown--reverse` to `.a-dropdown--right`
 
 # [1.1.0] - 2021-04-15
 

--- a/scss/bitstyles/atoms/dropdown/_.scss
+++ b/scss/bitstyles/atoms/dropdown/_.scss
@@ -22,8 +22,13 @@
   }
 }
 
-.a-dropdown--reverse {
+.a-dropdown--right {
   right: 0;
+}
+
+.a-dropdown--top {
+  top: auto;
+  bottom: 100%;
 }
 
 @include media-query('s') {

--- a/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
+++ b/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
@@ -6,11 +6,13 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 A floating container for a list of links.
 
-<Canvas isColumn>
-  <Story name="Dropdown">
+## Left-alignment (default)
+
+<Canvas>
+  <Story name="Dropdown" inline={false} height="20rem">
     {`
       <div class="u-relative" style="height: 10rem; width: 30rem">
-        <ul class="a-dropdown u-overflow--y a-list-reset">
+        <ul class="a-dropdown u-overflow--y a-list-reset" aria-hidden="false">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -28,10 +30,41 @@ A floating container for a list of links.
       </div>
     `}
   </Story>
-  <Story name="Dropdown [active]">
+</Canvas>
+
+## Right-alignment
+
+<Canvas>
+  <Story name="Dropdown--right" inline={false} height="20rem">
     {`
-      <div class="u-relative" style="height: 10rem; width: 30rem">
-        <ul class="a-dropdown u-overflow--y a-list-reset" aria-hidden="false">
+      <div class="u-relative" style="height: 10rem; width: 100%">
+        <ul class="a-dropdown a-dropdown--right u-overflow--y a-list-reset" aria-hidden="false">
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Settings</a>
+          </li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Help</a>
+          </li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Privacy</a>
+          </li>
+          <li role="separator"></li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Sign out</a>
+          </li>
+        </ul>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Top-alignment
+
+<Canvas>
+  <Story name="Dropdown--top" inline={false} height="20rem">
+    {`
+      <div class="u-relative u-flex" style="height: 10rem; width: 100%">
+        <ul class="a-dropdown a-dropdown--top u-overflow--y a-list-reset" aria-hidden="false">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>

--- a/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
+++ b/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
@@ -6,7 +6,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 A floating container for a list of links.
 
-## Left-alignment (default)
+## Left alignment (default)
 
 <Canvas>
   <Story name="Dropdown" inline={false} height="20rem">
@@ -32,7 +32,7 @@ A floating container for a list of links.
   </Story>
 </Canvas>
 
-## Right-alignment
+## Right alignment
 
 <Canvas>
   <Story name="Dropdown--right" inline={false} height="20rem">
@@ -58,13 +58,40 @@ A floating container for a list of links.
   </Story>
 </Canvas>
 
-## Top-alignment
+## Top alignment
 
 <Canvas>
   <Story name="Dropdown--top" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
         <ul class="a-dropdown a-dropdown--top u-overflow--y a-list-reset" aria-hidden="false">
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Settings</a>
+          </li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Help</a>
+          </li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Privacy</a>
+          </li>
+          <li role="separator"></li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Sign out</a>
+          </li>
+        </ul>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+
+## Top-right alignment
+
+<Canvas>
+  <Story name="Dropdown--top dropdown--right" inline={false} height="20rem">
+    {`
+      <div class="u-relative u-flex" style="height: 10rem; width: 100%">
+        <ul class="a-dropdown a-dropdown--top a-dropdown--right u-overflow--y a-list-reset" aria-hidden="false">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>

--- a/scss/bitstyles/ui/dropdown-menu.stories.mdx
+++ b/scss/bitstyles/ui/dropdown-menu.stories.mdx
@@ -297,3 +297,58 @@ Give your dropdown the `.a-dropdown--top` class you need the menu to appear abov
     `}
   </Story>
 </Canvas>
+
+You can also combine `.a-dropdown--top` with `.a-dropdown--right`:
+
+<Canvas>
+  <Story name="Dropdown, top-right aligned" inline={false} height="20rem">
+    {`
+      <div style="height: 20rem" class="u-flex u-flex--col">
+        <div class="u-flex__grow-1"></div>
+        <div class="u-relative u-flex u-justify-end">
+          <button type="button" class="a-button a-button--ui u-h6" aria-controls="dropdown-3" aria-expanded="true">
+            <span class="a-button__label">Account</span>
+            <svg width="14" height="14" class="a-button__icon a-icon a-icon-m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <use xlink:href="${icons}#icon-caret-down"></use>
+            </svg>
+          </button>
+          <ul class="a-dropdown a-dropdown--top a-dropdown--right u-overflow--y a-list-reset u-margin-s--bottom" aria-hidden="false" id="dropdown-3">
+            <li>
+              <div class="u-padding-xs--top u-padding-xs--bottom u-padding-s--left u-padding-s--right u-flex u-items-center u-h6 u-line-height--min">
+                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s--right">
+                  <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
+                </div>
+                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span>Username</span>
+                </div>
+              </div>
+            </li>
+            <li role="separator"></li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Settings
+              </a>
+            </li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Help
+              </a>
+            </li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Privacy
+              </a>
+            </li>
+            <li role="separator"></li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Sign out
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/ui/dropdown-menu.stories.mdx
+++ b/scss/bitstyles/ui/dropdown-menu.stories.mdx
@@ -30,7 +30,7 @@ For the sake of clarity, the examples shown here are all presented with the menu
 </details>
 
 <Canvas>
-  <Story name="Dropdown menu">
+  <Story name="Dropdown menu" inline={false} height="20rem">
     {`
       <div style="min-height:15rem;">
         <div class="u-relative">
@@ -84,7 +84,7 @@ For the sake of clarity, the examples shown here are all presented with the menu
 The structure can be a little simpler if your menu items do not need icons. Here we’ve also added a link to the user’s profile (with their avatar) at the top of the menu.
 
 <Canvas>
-  <Story name="Dropdown with avatar user-profile link">
+  <Story name="Dropdown with avatar user-profile link" inline={false} height="20rem">
     {`
       <div style="min-height:15rem;">
         <div class="u-relative">
@@ -138,7 +138,7 @@ The structure can be a little simpler if your menu items do not need icons. Here
 You can include non-link content in the menu too — this version of the avatar is not a link to a profile page, but is informing the user which account is currently signed-in.
 
 <Canvas>
-  <Story name="Dropdown with non-button/link content">
+  <Story name="Dropdown with non-button/link content" inline={false} height="20rem">
     {`
       <div style="min-height:15rem;">
         <div class="u-relative">
@@ -189,20 +189,75 @@ You can include non-link content in the menu too — this version of the avatar 
   </Story>
 </Canvas>
 
-When you know the menu will be at the right edge of the viewport, give your dropdown `.a-dropdown--reverse` to align the menu flush to the right.
+When you know the menu will be at the right edge of the viewport, give your dropdown `.a-dropdown--right` to align the menu flush to the right.
 
 <Canvas>
-  <Story name="Dropdown, reverse-aligned">
+  <Story name="Dropdown, right-aligned" inline={false} height="20rem">
     {`
       <div style="height: 15rem">
-        <div class="u-relative u-flex u-justify-end" >
+        <div class="u-relative u-flex u-justify-end">
           <button type="button" class="a-button a-button--ui u-h6" aria-controls="dropdown-3" aria-expanded="true">
             <span class="a-button__label">Account</span>
             <svg width="14" height="14" class="a-button__icon a-icon a-icon-m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-down"></use>
             </svg>
           </button>
-          <ul class="a-dropdown a-dropdown--reverse u-overflow--y a-list-reset u-margin-s--top" aria-hidden="false" id="dropdown-3">
+          <ul class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s--top" aria-hidden="false" id="dropdown-3">
+            <li>
+              <div class="u-padding-xs--top u-padding-xs--bottom u-padding-s--left u-padding-s--right u-flex u-items-center u-h6 u-line-height--min">
+                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s--right">
+                  <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
+                </div>
+                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span>Username</span>
+                </div>
+              </div>
+            </li>
+            <li role="separator"></li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Settings
+              </a>
+            </li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Help
+              </a>
+            </li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Privacy
+              </a>
+            </li>
+            <li role="separator"></li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Sign out
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+Give your dropdown the `.a-dropdown--top` class you need the menu to appear above the button (e.g. your dropdown is pinned to the bottom of your layout)
+
+<Canvas>
+  <Story name="Dropdown, top-aligned" inline={false} height="20rem">
+    {`
+      <div style="height: 20rem" class="u-flex u-flex--col">
+        <div class="u-flex__grow-1"></div>
+        <div class="u-relative">
+          <button type="button" class="a-button a-button--ui u-h6" aria-controls="dropdown-3" aria-expanded="true">
+            <span class="a-button__label">Account</span>
+            <svg width="14" height="14" class="a-button__icon a-icon a-icon-m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <use xlink:href="${icons}#icon-caret-down"></use>
+            </svg>
+          </button>
+          <ul class="a-dropdown a-dropdown--top u-overflow--y a-list-reset u-margin-s--bottom" aria-hidden="false" id="dropdown-3">
             <li>
               <div class="u-padding-xs--top u-padding-xs--bottom u-padding-s--left u-padding-s--right u-flex u-items-center u-h6 u-line-height--min">
                 <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s--right">

--- a/scss/bitstyles/ui/filter.stories.mdx
+++ b/scss/bitstyles/ui/filter.stories.mdx
@@ -133,7 +133,7 @@ Some fields such as names and emails will need to be filtered by user-entered fr
                   <path d="M2.78,32.83a6.07,6.07,0,0,1,8.58-8.59L45.71,58.59a6.07,6.07,0,0,0,8.58,0L88.64,24.24a6.07,6.07,0,1,1,8.58,8.59L54.29,75.76a6.07,6.07,0,0,1-8.58,0Z" fill-rule="evenodd"/>
                 </svg>
               </button>
-              <ul class="a-dropdown a-dropdown--reverse u-overflow--y a-list-reset u-margin-s--top" aria-hidden="false" id="dropdown-1">
+              <ul class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s--top" aria-hidden="false" id="dropdown-1">
                 <li>
                   <label class="a-button a-button--menu u-h6 u-flex u-items-center">
                     <input type="checkbox" name="all" checked />

--- a/scss/bitstyles/ui/page-header.stories.mdx
+++ b/scss/bitstyles/ui/page-header.stories.mdx
@@ -143,7 +143,7 @@ This first example shows a header with all these slots filled:
                         <use xlink:href="${icons}#icon-caret-down"></use>
                       </svg>
                     </button>
-                    <ul class="a-dropdown a-dropdown--reverse u-overflow--y a-list-reset u-margin-s--top" aria-hidden="false" id="dropdown-1">
+                    <ul class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s--top" aria-hidden="false" id="dropdown-1">
                       <li>
                         <a href="/" class="a-button a-button--menu u-h6">
                           <svg width="18" height="18" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">


### PR DESCRIPTION
Fixes #466 

- Adds a `.a-dropdown--top` variant of dropdown
- Renames `.a-dropdown--reverse` -> `.a-dropdown--right`
- Adds new example to atom & UI layers, updates existing dropdown examples

Looks like:

<img width="660" alt="Screenshot 2021-04-29 at 15 42 51" src="https://user-images.githubusercontent.com/2479422/116560336-91bbd680-a901-11eb-8de1-59b3cce6c993.png">
