### PR TITLE
[#475] Full-width dropdown in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Added
+
+- Dropdown atom has a new variant `.a-dropdown--full-width` that causes the dropdown to span the full width of its nearest `position: relative` parent element. Combinable with `a-dropdown--top`
+
 # [[1.2.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v1.2.0) - 2021-05-04
 
 ## Added

--- a/scss/bitstyles/atoms/dropdown/_.scss
+++ b/scss/bitstyles/atoms/dropdown/_.scss
@@ -31,6 +31,13 @@
   bottom: 100%;
 }
 
+.a-dropdown--full-width {
+  right: 0;
+  left: 0;
+  width: 100%;
+  max-width: none;
+}
+
 @include media-query('s') {
   .a-dropdown {
     right: spacing('m');

--- a/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
+++ b/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
@@ -110,3 +110,59 @@ A floating container for a list of links.
     `}
   </Story>
 </Canvas>
+
+## Full-width
+
+Sometimes you need your dropdown to fill the width of the container.
+
+### Full-width bottom
+
+<Canvas>
+  <Story name="Dropdown--bottom dropdown--full" inline={false} height="20rem">
+    {`
+      <div class="u-relative u-flex" style="height: 10rem; width: 100%">
+        <ul class="a-dropdown a-dropdown--full-width u-overflow--y a-list-reset" aria-hidden="false">
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Settings</a>
+          </li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Help</a>
+          </li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Privacy</a>
+          </li>
+          <li role="separator"></li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Sign out</a>
+          </li>
+        </ul>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Full-width top
+
+<Canvas>
+  <Story name="Dropdown--top dropdown--full" inline={false} height="20rem">
+    {`
+      <div class="u-relative u-flex" style="height: 10rem; width: 100%">
+        <ul class="a-dropdown a-dropdown--top a-dropdown--full-width u-overflow--y a-list-reset" aria-hidden="false">
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Settings</a>
+          </li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Help</a>
+          </li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Privacy</a>
+          </li>
+          <li role="separator"></li>
+          <li>
+            <a href="/" class="a-button a-button--menu u-h6">Sign out</a>
+          </li>
+        </ul>
+      </div>
+    `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/ui/dropdown-menu.stories.mdx
+++ b/scss/bitstyles/ui/dropdown-menu.stories.mdx
@@ -352,3 +352,115 @@ You can also combine `.a-dropdown--top` with `.a-dropdown--right`:
     `}
   </Story>
 </Canvas>
+
+
+## Full-width dropdowns
+
+Sometimes you need your dropdown to fill the width of the container.
+
+<Canvas>
+  <Story name="Dropdown, full-width" inline={false} height="20rem">
+    {`
+      <div style="height: 20rem" class="u-flex u-flex--col">
+        <div class="u-relative u-flex u-justify-end">
+          <button type="button" class="a-button a-button--ui u-h6" aria-controls="dropdown-3" aria-expanded="true">
+            <span class="a-button__label">Account</span>
+            <svg width="14" height="14" class="a-button__icon a-icon a-icon-m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <use xlink:href="${icons}#icon-caret-down"></use>
+            </svg>
+          </button>
+          <ul class="a-dropdown a-dropdown--full-width u-overflow--y a-list-reset u-margin-s--bottom" aria-hidden="false" id="dropdown-3">
+            <li>
+              <div class="u-padding-xs--top u-padding-xs--bottom u-padding-s--left u-padding-s--right u-flex u-items-center u-h6 u-line-height--min">
+                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s--right">
+                  <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
+                </div>
+                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span>Username</span>
+                </div>
+              </div>
+            </li>
+            <li role="separator"></li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Settings
+              </a>
+            </li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Help
+              </a>
+            </li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Privacy
+              </a>
+            </li>
+            <li role="separator"></li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Sign out
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+`.a-dropdown--full-width` can also be combined with `a-dropdown--top`:
+
+<Canvas>
+  <Story name="Dropdown, full-width top" inline={false} height="20rem">
+    {`
+      <div style="height: 20rem" class="u-flex u-flex--col">
+        <div class="u-flex__grow-1"></div>
+        <div class="u-relative u-flex u-justify-end">
+          <button type="button" class="a-button a-button--ui u-h6" aria-controls="dropdown-3" aria-expanded="true">
+            <span class="a-button__label">Account</span>
+            <svg width="14" height="14" class="a-button__icon a-icon a-icon-m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <use xlink:href="${icons}#icon-caret-down"></use>
+            </svg>
+          </button>
+          <ul class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow--y a-list-reset u-margin-s--bottom" aria-hidden="false" id="dropdown-3">
+            <li>
+              <div class="u-padding-xs--top u-padding-xs--bottom u-padding-s--left u-padding-s--right u-flex u-items-center u-h6 u-line-height--min">
+                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s--right">
+                  <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
+                </div>
+                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span>Username</span>
+                </div>
+              </div>
+            </li>
+            <li role="separator"></li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Settings
+              </a>
+            </li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Help
+              </a>
+            </li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Privacy
+              </a>
+            </li>
+            <li role="separator"></li>
+            <li>
+              <a href="/" class="a-button a-button--menu u-h6">
+                Sign out
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `}
+  </Story>
+</Canvas>

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -350,3 +350,209 @@ View this example in a small viewport.
     `}
   </Story>
 </Canvas>
+
+## Sidebar with open dropdown menu
+
+<Canvas>
+   <Story name="Sidebar [open dropdown]" inline={false} height="80vh">
+    {`
+      <div class="u-flex u-height-100vh">
+        <nav class="u-flex">
+          <div class="u-hidden o-sidebar--large u-flex__shrink-0 u-bg--gray-80 u-padding-m--top u-flex@l u-flex--col">
+            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-m--left u-margin-m--right u-margin-m--bottom" />
+            <ul class="u-flex__grow-1 u-flex__shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs--right u-padding-xs--left">
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-home"></use>
+                  </svg>
+                  Dashboard
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1" aria-current="page">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-filter"></use>
+                  </svg>
+                  Projects
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-mail"></use>
+                  </svg>
+                  Team
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-check"></use>
+                  </svg>
+                  Customers
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-pencil"></use>
+                  </svg>
+                  <span class="u-truncate">Privacy policies has a long title</span>
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-bin"></use>
+                  </svg>
+                  Bookings
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-search"></use>
+                  </svg>
+                  Sales
+                </a>
+              </li>
+            </ul>
+            <div class="u-flex__shrink-0 u-padding-xs--y u-margin-xs--left u-margin-xs--right u-border--top u-relative u-flex u-flex--col">
+              <button type="button" class="a-button a-button--nav-large" aria-controls="dropdown-3" aria-expanded="true">
+                <div class="a-button__icon a-avatar">
+                  <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
+                </div>
+                <span class="a-button__label">Jane Dobermann</span>
+              </button>
+              <ul class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow--y a-list-reset u-margin-s--bottom" aria-hidden="false" id="dropdown-3">
+                <li>
+                  <div class="u-padding-xs--top u-padding-xs--bottom u-padding-s--left u-padding-s--right u-flex u-items-center u-h6 u-line-height--min">
+                    <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s--right">
+                      <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
+                    </div>
+                    <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                      <span class="u-fg--gray-40">Signed in as</span>
+                      <span>Username</span>
+                    </div>
+                  </div>
+                </li>
+                <li role="separator"></li>
+                <li>
+                  <a href="/" class="a-button a-button--menu u-h6">
+                    Settings
+                  </a>
+                </li>
+                <li>
+                  <a href="/" class="a-button a-button--menu u-h6">
+                    Help
+                  </a>
+                </li>
+                <li>
+                  <a href="/" class="a-button a-button--menu u-h6">
+                    Privacy
+                  </a>
+                </li>
+                <li role="separator"></li>
+                <li>
+                  <a href="/" class="a-button a-button--menu u-h6">
+                    Sign out
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex--col u-hidden">
+            <button class="u-flex__shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs--left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
+              <svg width="16" height="16" class="a-icon a-icon--l" aria-hidden="true" focusable="false">
+                <use xlink:href="${icons}#icon-cross"></use>
+              </svg>
+              <span class="u-sr-only">Close menu</span>
+            </button>
+            <ul class="u-flex__grow-1 u-flex__shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs--right u-padding-xs--left">
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-home"></use>
+                  </svg>
+                  Dashboard
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1" aria-current="page">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-filter"></use>
+                  </svg>
+                  Projects
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-mail"></use>
+                  </svg>
+                  Team
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-check"></use>
+                  </svg>
+                  Customers
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-pencil"></use>
+                  </svg>
+                  <span class="u-truncate">Privacy policies has a long title</span>
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-bin"></use>
+                  </svg>
+                  Bookings
+                </a>
+              </li>
+              <li class="u-margin-xs--bottom u-flex">
+                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                  <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s--right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
+                    <use xlink:href="${icons}#icon-search"></use>
+                  </svg>
+                  Sales
+                </a>
+              </li>
+            </ul>
+            <div class="u-flex__shrink-0 u-padding-xs--y u-margin-xs--left u-margin-xs--right u-border--top">
+              <a href="/" class="a-button a-button--nav-large">
+                <div class="a-button__icon a-avatar">
+                  <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
+                </div>
+                <span class="a-button__label">Jane Dobermann</span>
+              </a>
+            </div>
+          </div>
+        </nav>
+        <main class="u-flex__grow u-padding-xxl--left@l u-padding-xl--right@l u-padding-xl--bottom u-padding-m u-overflow--y">
+          <div class="u-flex u-items-center u-margin-m--bottom">
+            <button class="u-flex__shrink-0 u-margin-neg-m--left a-button a-button--icon a-button--icon-reversed u-margin-xs--right u-hidden@l" title="Open menu" aria-controls="navbar-1" aria-expanded="true">
+              <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
+                <use xlink:href="${icons}#icon-hamburger"></use>
+              </svg>
+              <span class="u-sr-only">Open menu</span>
+            </button>
+            <h1 class="u-margin-0">Projects</h1>
+          </div>
+          <p>Cotton candy chupa chups gummi bears cupcake candy canes sweet gummi bears macaroon lollipop. Danish toffee cheesecake chocolate bar jelly-o chocolate cake. Candy canes gummi bears pie fruitcake candy canes powder cheesecake. Jelly marshmallow marzipan apple pie jelly cupcake. Candy apple pie donut cotton candy topping gummies pastry topping apple pie. Gummies ice cream cookie pudding caramels candy canes pie. Ice cream macaroon halvah pastry lemon drops cheesecake. Chocolate cake croissant marzipan gummi bears topping brownie. Donut cookie pie muffin sesame snaps. Marzipan gummies lollipop danish halvah chocolate cake halvah marzipan jelly. Donut cheesecake gummies macaroon tootsie roll croissant. Powder chupa chups icing.</p>
+          <p>Cheesecake dragée cake chocolate bar oat cake. Muffin bear claw apple pie topping carrot cake pie sugar plum. Carrot cake croissant fruitcake. Toffee cotton candy cotton candy jelly-o liquorice. Croissant sugar plum sweet roll. Topping halvah jelly croissant sweet roll chocolate bar. Sesame snaps sweet roll tart. Cake chocolate bar caramels. Macaroon ice cream candy canes croissant. Pastry marzipan macaroon. Soufflé sweet chupa chups caramels. Soufflé candy sweet. Biscuit biscuit caramels wafer pudding jujubes.</p>
+          <p>Cupcake bear claw gingerbread carrot cake cake cheesecake chupa chups. Sesame snaps pudding muffin chocolate. Chupa chups soufflé jujubes dragée. Marshmallow bonbon caramels gummi bears marzipan apple pie. Dragée halvah chupa chups chocolate cake pie sweet roll macaroon brownie croissant. Ice cream fruitcake gummies. Candy canes wafer dragée gummi bears. Pudding ice cream chocolate bar. Chocolate bar donut jelly-o lemon drops brownie topping. Caramels pudding macaroon chocolate gingerbread cheesecake. Danish jelly-o liquorice biscuit oat cake dessert icing. Pudding chocolate bar tiramisu marshmallow. Jelly-o donut pudding chocolate. Pie pie chocolate bar apple pie chocolate cake croissant caramels.</p>
+          <p>Chocolate jelly-o wafer. Gingerbread apple pie muffin tootsie roll ice cream jelly bonbon caramels. Wafer gummi bears pudding. Pudding cotton candy pie croissant cookie. Gummies jelly wafer chocolate. Fruitcake cake gummies cupcake gummies. Sugar plum chupa chups chocolate cake macaroon cupcake dessert. Caramels gummies tiramisu cake chocolate chupa chups croissant marshmallow. Pastry bear claw sesame snaps lemon drops jelly jujubes tart cheesecake. Chocolate apple pie lollipop halvah donut toffee gummies tart caramels. Carrot cake macaroon biscuit wafer jujubes. Cake candy canes cupcake chupa chups chocolate cake wafer powder. Marzipan wafer pudding toffee pastry.</p>
+        </main>
+      </div>
+    `}
+  </Story>
+</Canvas>


### PR DESCRIPTION
Fixes #475 

- Adds a new dropdown variant that spans the full width of its nearest `position: relative` parent element
- Adds examples of this to the dropdown atom
- Adds examples of this to the UI dropdownmenu component
- Uses the new dropdown variant in the UI/sidebar component

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)

Looks like:

<img width="436" alt="Screenshot 2021-05-17 at 12 26 03" src="https://user-images.githubusercontent.com/2479422/118475580-b808b100-b70c-11eb-92f7-5a2542d5d185.png">

