### PR TITLE
[#486] Missing classes: borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@
 - Gap sizes can now be specified, and the class suffixes named, using a Sass variable
 - You can now override which directions the margin and padding utility classes are output for (`top`, `bottom`, etc.), and what those classes are named independently of the CSS property, using `$bitstyles-margin-directions` and `$bitstyles-padding-directions` respectively
 - You can now override the sizes the margin & padding utility classes are output for, using `$bitstyles-margin-sizes` and `$bitstyles-padding-sizes` respectively
+- Border utility classes are now available at all four directions, and on a per-color basis. Currectly only `gray-10` and `gray-70`, this can now be customized using sass variables.
+- Border utility classes can now be available at breakpoints by overriding the `$bitstyles-border-breakpoints` variable
 
 ## Breaking
 
 - The double-dashes have been removed from the `.u-margin` and `.u-padding` classes (e.g. `.u-margin-m--top`). To migrate, replace the `--` in the classnames with `-`
+- The `.u-border--top` `.u-border--bottom` classes have been replaced with `.u-border-gray-70-top` and `.u-border-gray-10-bottom` respectively
 
 ## Breaking
 

--- a/scss/bitstyles/ui/section-heading.stories.mdx
+++ b/scss/bitstyles/ui/section-heading.stories.mdx
@@ -13,7 +13,7 @@ A heading with optional actions, badges and labels. Be sure to use the correct h
     <li><a href="/docs/atoms-button-ui--ui">a-button--ui</a></li>
     <li><a href="/docs/atoms-badge--badge">a-badge</a></li>
     <li><a href="/docs/atoms-list-reset--list-reset">a-list-reset</a></li>
-    <li><a href="/docs/utilities-border--border-bottom">u-border--bottom</a></li>
+    <li><a href="/docs/utilities-border--border-bottom">u-border-gray-10-bottom</a></li>
     <li><a href="/docs/utilities-color--gray-50">u-fg</a></li>
     <li><a href="/docs/utilities-flex--flex">u-flex</a></li>
     <li><a href="/docs/utilities-font--font-medium">u-font</a></li>
@@ -30,7 +30,7 @@ A heading with optional actions, badges and labels. Be sure to use the correct h
 <Canvas>
   <Story name="Section heading">
     {`
-      <div class="u-padding-m-bottom u-border--bottom">
+      <div class="u-padding-m-bottom u-border-gray-10-bottom">
         <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
       </div>
     `}
@@ -44,7 +44,7 @@ Next to the heading text is a good place to add important information about the 
 <Canvas>
   <Story name="Section heading with count">
     {`
-      <div class="u-flex u-items-center u-padding-m-bottom u-border--bottom">
+      <div class="u-flex u-items-center u-padding-m-bottom u-border-gray-10-bottom">
         <h3 class="u-margin-0 u-margin-xs-right">
           Recent bookings
         </h3>
@@ -57,7 +57,7 @@ Next to the heading text is a good place to add important information about the 
 <Canvas>
   <Story name="Section heading with badge">
     {`
-      <div class="u-flex u-items-center u-padding-m-bottom u-border--bottom">
+      <div class="u-flex u-items-center u-padding-m-bottom u-border-gray-10-bottom">
         <h3 class="u-margin-0 u-margin-xs-right">
           Recent bookings
         </h3>
@@ -74,7 +74,7 @@ Section headings are a good place for important actions relating to the content 
 <Canvas>
   <Story name="Section heading with actions">
     {`
-      <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m-bottom u-border--bottom">
+      <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m-bottom u-border-gray-10-bottom">
         <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
         <ul class="a-list-reset u-flex u-flex--wrap u-flex__shrink-0">
           <li class="u-margin-s-right">
@@ -92,7 +92,7 @@ Section headings are a good place for important actions relating to the content 
 <Canvas>
   <Story name="Section heading with badge and actions">
     {`
-      <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m-bottom u-border--bottom">
+      <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m-bottom u-border-gray-10-bottom">
         <div class="u-flex u-items-center">
           <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
           <span class="a-badge a-badge--brand-1 u-h6">New<span>

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -74,7 +74,7 @@ A vertical navbar that can make better use of screenspace in some circumstances,
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border--top">
+            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -148,7 +148,7 @@ A vertical navbar that can make better use of screenspace in some circumstances,
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border--top">
+            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -247,7 +247,7 @@ View this example in a small viewport.
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border--top">
+            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -321,7 +321,7 @@ View this example in a small viewport.
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border--top">
+            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -418,7 +418,7 @@ View this example in a small viewport.
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border--top u-relative u-flex u-flex--col">
+            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top u-relative u-flex u-flex--col">
               <button type="button" class="a-button a-button--nav-large" aria-controls="dropdown-3" aria-expanded="true">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -527,7 +527,7 @@ View this example in a small viewport.
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border--top">
+            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />

--- a/scss/bitstyles/utilities/border/_.scss
+++ b/scss/bitstyles/utilities/border/_.scss
@@ -2,7 +2,7 @@
 
 @each $breakpoint-alias in $bitstyles-border-breakpoints {
   @if $breakpoint-alias == 'base' {
-    @include output-directional-property(
+    @include output-directional-properties(
       $property-name: 'border',
       $classname-root: 'border',
       $values: $bitstyles-border-colors,
@@ -12,7 +12,7 @@
 
   @else {
     @include media-query($breakpoint-alias) {
-      @include output-directional-property(
+      @include output-directional-properties(
         $property-name: 'border',
         $classname-root: 'border',
         $values: $bitstyles-border-colors,

--- a/scss/bitstyles/utilities/border/_.scss
+++ b/scss/bitstyles/utilities/border/_.scss
@@ -1,7 +1,24 @@
-.#{$bitstyles-namespace}u-border--top {
-  border-top: 1px solid palette('gray', '70');
-}
+@import './settings';
 
-.#{$bitstyles-namespace}u-border--bottom {
-  border-bottom: 1px solid palette('gray', '10');
+@each $breakpoint-alias in $bitstyles-border-breakpoints {
+  @if $breakpoint-alias == 'base' {
+    @include output-directional-property(
+      $property-name: 'border',
+      $classname-root: 'border',
+      $values: $bitstyles-border-colors,
+      $directions: $bitstyles-border-directions
+    );
+  }
+
+  @else {
+    @include media-query($breakpoint-alias) {
+      @include output-directional-property(
+        $property-name: 'border',
+        $classname-root: 'border',
+        $values: $bitstyles-border-colors,
+        $directions: $bitstyles-border-directions,
+        $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+      );
+    }
+  }
 }

--- a/scss/bitstyles/utilities/border/border.stories.mdx
+++ b/scss/bitstyles/utilities/border/border.stories.mdx
@@ -9,6 +9,11 @@ Apply a border with the specified color and direction.
 ## Gray-10
 
 <Canvas>
+  <Story name="u-border-gray-10">
+    {`
+      <h3 class="u-border-gray-10">u-border-gray-10</h3>
+    `}
+  </Story>
   <Story name="u-border-gray-10-top">
     {`
       <h3 class="u-border-gray-10-top">u-border-gray-10-top</h3>
@@ -29,11 +34,26 @@ Apply a border with the specified color and direction.
       <h3 class="u-border-gray-10-left">u-border-gray-10-left</h3>
     `}
   </Story>
+  <Story name="u-border-gray-10-x">
+    {`
+      <h3 class="u-border-gray-10-x">u-border-gray-10-x</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-10-y">
+    {`
+      <h3 class="u-border-gray-10-y">u-border-gray-10-y</h3>
+    `}
+  </Story>
 </Canvas>
 
 ## Gray-70
 
 <Canvas>
+  <Story name="u-border-gray-70">
+    {`
+      <h3 class="u-border-gray-70">u-border-gray-70</h3>
+    `}
+  </Story>
   <Story name="u-border-gray-70-top">
     {`
       <h3 class="u-border-gray-70-top">u-border-gray-70-top</h3>
@@ -52,6 +72,16 @@ Apply a border with the specified color and direction.
   <Story name="u-border-gray-70-left">
     {`
       <h3 class="u-border-gray-70-left">u-border-gray-70-left</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-70-x">
+    {`
+      <h3 class="u-border-gray-70-x">u-border-gray-70-x</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-70-y">
+    {`
+      <h3 class="u-border-gray-70-y">u-border-gray-70-y</h3>
     `}
   </Story>
 </Canvas>

--- a/scss/bitstyles/utilities/border/border.stories.mdx
+++ b/scss/bitstyles/utilities/border/border.stories.mdx
@@ -4,12 +4,54 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Border
 
-Apply a standard border.
+Apply a border with the specified color and direction.
 
-<Canvas >
-  <Story name="Border--bottom">
+## Gray-10
+
+<Canvas>
+  <Story name="u-border-gray-10-top">
     {`
-      <h3 class="u-border-bottom">Recent bookings</h3>
+      <h3 class="u-border-gray-10-top">u-border-gray-10-top</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-10-right">
+    {`
+      <h3 class="u-border-gray-10-right">u-border-gray-10-right</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-10-bottom">
+    {`
+      <h3 class="u-border-gray-10-bottom">u-border-gray-10-bottom</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-10-left">
+    {`
+      <h3 class="u-border-gray-10-left">u-border-gray-10-left</h3>
+    `}
+  </Story>
+</Canvas>
+
+## Gray-70
+
+<Canvas>
+  <Story name="u-border-gray-70-top">
+    {`
+      <h3 class="u-border-gray-70-top">u-border-gray-70-top</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-70-right">
+    {`
+      <h3 class="u-border-gray-70-right">u-border-gray-70-right</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-70-bottom">
+    {`
+      <h3 class="u-border-gray-70-bottom">u-border-gray-70-bottom</h3>
+    `}
+  </Story>
+  <Story name="u-border-gray-70-left">
+    {`
+      <h3 class="u-border-gray-70-left">u-border-gray-70-left</h3>
     `}
   </Story>
 </Canvas>

--- a/scss/bitstyles/utilities/border/settings.scss
+++ b/scss/bitstyles/utilities/border/settings.scss
@@ -1,0 +1,11 @@
+$bitstyles-border-colors: (
+  'gray-70': 1px solid palette('gray', '70'),
+  'gray-10': 1px solid palette('gray', '10'),
+) !default;
+$bitstyles-border-breakpoints: ('base') !default;
+$bitstyles-border-directions: (
+  'top': ('top'),
+  'right': ('right'),
+  'bottom': ('bottom'),
+  'left': ('left'),
+) !default;

--- a/scss/bitstyles/utilities/border/settings.scss
+++ b/scss/bitstyles/utilities/border/settings.scss
@@ -4,8 +4,11 @@ $bitstyles-border-colors: (
 ) !default;
 $bitstyles-border-breakpoints: ('base') !default;
 $bitstyles-border-directions: (
+  '': null,
   'top': ('top'),
   'right': ('right'),
   'bottom': ('bottom'),
   'left': ('left'),
+  'x': ('left', 'right'),
+  'y': ('top', 'bottom')
 ) !default;


### PR DESCRIPTION
Fixes #486 


The following changes are contained in this pull request:
border classes are now generated:
    - all four directions by default
    - border-color is now part of the classname
    - uses the same generators as the margin/padding branch
    - available at breakpoints if needed, but that’s not specified by default
    - Adds stories for each of the border classes

Looks like:

<img width="1044" alt="Screenshot 2021-05-25 at 12 19 15" src="https://user-images.githubusercontent.com/2479422/119481943-94b8b400-bd53-11eb-8e8c-44a366068fcb.png">


Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
