### PR TITLE
[#493] Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,7 +2,7 @@
   "extends": "stylelint-config-bitcrowd",
   "rules": {
     "at-rule-no-unknown": [ true, {
-      "ignoreAtRules": ["else", "include", "mixin", "if", "each", "function", "return", "error", "for", "warn"]
+      "ignoreAtRules": ["else", "include", "mixin", "if", "each", "function", "return", "error", "for", "warn", "use"]
     }]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `.u-fixed-ratio` is renamed `.u-aspect-ratio`, and the double-dashes are replaced with single. Please rename all uses e.g. `.u-fixed-ratio--16-9` becomes `.u-aspect-ratio-16-9`
 - `.u-fixed-ratio__inner` has been removed, and is no longer necessary. To migrate, move other classes that may be on that element to the `.u-fixed-ratio` element, and remove the `.u-fixed-ratio__inner` element
+- Now requires version `^1.34.0` of `dart-sass`, in order to use the new `Math.div` function, and remove all the division using `/` characters.
 
 # [[1.2.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v1.2.0) - 2021-05-04
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-dom": "^17.0.1",
     "react-is": "^17.0.1",
     "rimraf": "^3.0.0",
-    "sass": "^1.32.7",
+    "sass": "^1.34.0",
     "specificity-graph": "^0.1.7",
     "stylelint": "^13.13.1",
     "stylelint-config-bitcrowd": "^4.0.0",

--- a/scss/bitstyles/atoms/button--nav/_.scss
+++ b/scss/bitstyles/atoms/button--nav/_.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import './settings';
 
 .#{$bitstyles-namespace}a-button--nav {
@@ -47,5 +49,5 @@
 
 .#{$bitstyles-namespace}a-button-nav__icon {
   margin-right: $bitstyles-button-nav-padding-horizontal;
-  margin-left: -#{$bitstyles-button-nav-padding-horizontal / 4};
+  margin-left: -#{math.div($bitstyles-button-nav-padding-horizontal, 4)};
 }

--- a/scss/bitstyles/atoms/button--small/_.scss
+++ b/scss/bitstyles/atoms/button--small/_.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import './settings';
 
 .#{$bitstyles-namespace}a-button--small {
@@ -5,7 +7,7 @@
   padding: $bitstyles-button-small-padding-vertical $bitstyles-button-small-padding-horizontal;
 
   &.#{$bitstyles-namespace}a-button--icon {
-    padding: $bitstyles-button-small-padding-horizontal / 2;
+    padding: math.div($bitstyles-button-small-padding-horizontal, 2);
     border-radius: $bitstyles-button-small-border-radius;
   }
 }

--- a/scss/bitstyles/atoms/button/_.scss
+++ b/scss/bitstyles/atoms/button/_.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import './settings';
 
 .#{$bitstyles-namespace}a-button {
@@ -62,10 +64,10 @@
 .#{$bitstyles-namespace}a-button__avatar,
 .#{$bitstyles-namespace}a-button__icon {
   margin-right: $bitstyles-button-icon-spacing;
-  margin-left: -$bitstyles-button-icon-spacing / 4;
+  margin-left: math.div(-$bitstyles-button-icon-spacing, 4);
 }
 
 .#{$bitstyles-namespace}a-button__label + .#{$bitstyles-namespace}a-button__icon {
-  margin-right: -$bitstyles-button-icon-spacing / 4;
+  margin-right: math.div(-$bitstyles-button-icon-spacing, 4);
   margin-left: $bitstyles-button-icon-spacing;
 }

--- a/scss/bitstyles/settings/_layout.scss
+++ b/scss/bitstyles/settings/_layout.scss
@@ -1,15 +1,17 @@
+@use "sass:math";
+
 $bitstyles-global-z: topbar !default;
 $bitstyles-border-radius-round: 9999rem !default;
 
 $bitstyles-spacing-base: 0.8rem !default;
 $bitstyles-spacing-sizes: (
   '0': 0,
-  'xxxs': $bitstyles-spacing-base / 8,
-  'xxs': $bitstyles-spacing-base / 4,
-  'xs': $bitstyles-spacing-base / 2,
-  's': $bitstyles-spacing-base - ($bitstyles-spacing-base / 4),
+  'xxxs': math.div($bitstyles-spacing-base, 8),
+  'xxs': math.div($bitstyles-spacing-base, 4),
+  'xs': math.div($bitstyles-spacing-base, 2),
+  's': $bitstyles-spacing-base - math.div($bitstyles-spacing-base, 4),
   'm': $bitstyles-spacing-base,
-  'l': $bitstyles-spacing-base + ($bitstyles-spacing-base / 4),
+  'l': $bitstyles-spacing-base + math.div($bitstyles-spacing-base, 4),
   'xl': $bitstyles-spacing-base * 2,
   'xxl': $bitstyles-spacing-base * 4,
   'xxxl': $bitstyles-spacing-base * 8

--- a/scss/bitstyles/tools/_aspect-ratio.scss
+++ b/scss/bitstyles/tools/_aspect-ratio.scss
@@ -1,3 +1,6 @@
+@use "sass:list";
+@use "sass:math";
+
 // Aspect Ratio
 //
 // **Enforces an aspect ratio on this element and its contents**.
@@ -24,12 +27,12 @@
 //
 
 @mixin aspect-ratio($width, $height) {
-  aspect-ratio: #{$width} / #{$height};
+  aspect-ratio: list.slash($width, $height);
 
-  @supports not (aspect-ratio: #{$width} / #{$height}) {
+  @supports not (aspect-ratio: list.slash($width, $height)) {
     &::before {
       float: left;
-      padding-top: percentage($height / $width);
+      padding-top: percentage(math.div($height, $width));
       content: '';
     }
 

--- a/scss/bitstyles/tools/_input--checkbox.scss
+++ b/scss/bitstyles/tools/_input--checkbox.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @mixin input--checkbox {
   color: $bitstyles-checkbox-color;
   background-color: $bitstyles-checkbox-background-color;
@@ -22,8 +24,8 @@
     opacity: 0;
     transform: scale(0.7);
     transition:
-      opacity ($bitstyles-transition-duration / 2) $bitstyles-transition-duration $bitstyles-transition-easing,
-      transform ($bitstyles-transition-duration / 2) $bitstyles-transition-duration $bitstyles-transition-easing;
+      opacity math.div($bitstyles-transition-duration, 2) $bitstyles-transition-duration $bitstyles-transition-easing,
+      transform math.div($bitstyles-transition-duration, 2) $bitstyles-transition-duration $bitstyles-transition-easing;
   }
 
   &:checked {

--- a/scss/bitstyles/tools/_input.scss
+++ b/scss/bitstyles/tools/_input.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @mixin input {
   transition:
     color $bitstyles-transition-duration $bitstyles-transition-easing,
@@ -23,7 +25,7 @@
   @include input;
 
   width: 100%;
-  padding: ($bitstyles-input-padding - $bitstyles-input-border-width / 2) $bitstyles-input-padding;
+  padding: ($bitstyles-input-padding - math.div($bitstyles-input-border-width, 2)) $bitstyles-input-padding;
   font: inherit;
   line-height: $bitstyles-line-height-min;
   color: $bitstyles-input-color;

--- a/scss/bitstyles/tools/_typography-conversions.scss
+++ b/scss/bitstyles/tools/_typography-conversions.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Px to Rem sizing
 //
 // **Converts pixels to rems**.
@@ -10,7 +12,7 @@
 //
 
 @function px-to-rem($pixel-size, $root-size: $bitstyles-font-size-base-small) {
-  @return ($pixel-size / $root-size) * 1rem;
+  @return math.div($pixel-size, $root-size) * 1rem;
 }
 
 // Px to em sizing
@@ -25,5 +27,5 @@
 //
 
 @function px-to-em($pixel-size, $root-size: $bitstyles-font-size-base-small) {
-  @return ($pixel-size / $root-size) + 0em; // stylelint-disable-line length-zero-no-unit
+  @return math.div($pixel-size, $root-size) + 0em; // stylelint-disable-line length-zero-no-unit
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10328,10 +10328,10 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-sass@^1.32.7:
-  version "1.32.12"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.12.tgz#a2a47ad0f1c168222db5206444a30c12457abb9f"
-  integrity sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==
+sass@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.34.0.tgz#e46d5932d8b0ecc4feb846d861f26a578f7f7172"
+  integrity sha512-rHEN0BscqjUYuomUEaqq3BMgsXqQfkcMVR7UhscsAVub0/spUrZGBMxQXFS2kfiDsPLZw5yuU9iJEFNC2x38Qw==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
Fixes #493 

Migrating away from using the `/` as division, as Sass is doing so to avoid clashing with the meaning of the symbol in CSS (it’s increasingly being used there). See https://sass-lang.com/documentation/breaking-changes/slash-div

The following changes are contained in this pull request:

- Updates Sass to latest version, to allow the use of `Math.div`
- Uses the automatic migration tool to change all division to new method
- Updates the `input` mixin to use the new division method (was missed by automated migration)

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
