### PR TITLE
[#497] Fix: checkboxes have little white dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Dropdown atom has a new variant `.a-dropdown--full-width` that causes the dropdown to span the full width of its nearest `position: relative` parent element. Combinable with `a-dropdown--top`
 - Gap sizes can now be specified, and the class suffixes named, using a Sass variable
 
+## Fixed
+
+- The checkbox checkmark is now correctly centered, and only rendered once
+
 ## Breaking
 
 - `.u-fixed-ratio` is renamed `.u-aspect-ratio`, and the double-dashes are replaced with single. Please rename all uses e.g. `.u-fixed-ratio--16-9` becomes `.u-aspect-ratio-16-9`

--- a/scss/bitstyles/tools/_input--checkbox.scss
+++ b/scss/bitstyles/tools/_input--checkbox.scss
@@ -19,6 +19,8 @@
     width: 100%;
     height: 100%;
     background-image: $bitstyles-checkbox-background-image-checked;
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
     background-size: 0.75em;
     content: '';
     opacity: 0;


### PR DESCRIPTION
Fixes #497

The following changes are contained in this pull request:
- Checkmark of checkboxes is now correctly centered, and only rendered once

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)

Looked like:
<img width="202" alt="Screenshot 2021-06-03 at 12 04 00" src="https://user-images.githubusercontent.com/2479422/120627957-785bfc00-c464-11eb-8338-8db301d2c11f.png">

Looks like:
<img width="202" alt="Screenshot 2021-06-03 at 12 08 43" src="https://user-images.githubusercontent.com/2479422/120627936-73974800-c464-11eb-8c10-047a989b6f55.png">

