### PR TITLE
[#496] Add utility class: z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Border utility classes can now be available at breakpoints by overriding the `$bitstyles-border-breakpoints` variable
 - Default breakpoints now include `xl`, for ultra-widescreens
 - `.a-content` max-width and padding is now customisable using Sass variables, and by default now includes a 100% option
+- A new `.u-z` utility class for setting `z-index`
 
 ## Fixed
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -87,3 +87,4 @@
 @import 'bitstyles/utilities/text/';
 @import 'bitstyles/utilities/truncate/';
 @import 'bitstyles/utilities/typography/';
+@import 'bitstyles/utilities/z-index/';

--- a/scss/bitstyles/tools/_directional-properties.scss
+++ b/scss/bitstyles/tools/_directional-properties.scss
@@ -90,3 +90,34 @@
     }
   }
 }
+
+
+/*
+ * Outputs a classname with CSS properties, intended for CSS properties that do not have directional variants.
+ *
+ * @param $property-name The name of the CSS property to be specified e.g. `margin`
+ * @param $classname-root The root name to use for the class, normally matches the CSS property to avoid confusion e.g. `margin`
+ * @param $values A map of name/value pairs, where the name will form part of the classname, and the value will be output as the value for the current CSS property e.g. ('m': 1rem, 'l': 2rem)
+ * @param $breakpoint-suffix [optional] Pass the suffix to use in the classname to denote the breakpoint you’re outputting these classes for. If you’re using a character that needs to be escaped, remember to double-escape it e.g. `\\\@m`
+ */
+ @mixin output-properties(
+  $property-name,
+  $classname-root,
+  $values,
+  $breakpoint-suffix: ''
+) {
+  @each $alias, $value in $values {
+    $classname: get-classname(
+      (
+        $bitstyles-namespace,
+        'u',
+        $classname-root,
+        $alias
+      )
+    );
+
+    .#{$classname}#{$breakpoint-suffix} {
+      #{$property-name}: $value;
+    }
+  }
+}

--- a/scss/bitstyles/tools/_directional-properties.scss
+++ b/scss/bitstyles/tools/_directional-properties.scss
@@ -91,7 +91,6 @@
   }
 }
 
-
 /*
  * Outputs a classname with CSS properties, intended for CSS properties that do not have directional variants.
  *
@@ -100,7 +99,7 @@
  * @param $values A map of name/value pairs, where the name will form part of the classname, and the value will be output as the value for the current CSS property e.g. ('m': 1rem, 'l': 2rem)
  * @param $breakpoint-suffix [optional] Pass the suffix to use in the classname to denote the breakpoint you’re outputting these classes for. If you’re using a character that needs to be escaped, remember to double-escape it e.g. `\\\@m`
  */
- @mixin output-properties(
+@mixin output-properties(
   $property-name,
   $classname-root,
   $values,

--- a/scss/bitstyles/utilities/z-index/_.scss
+++ b/scss/bitstyles/utilities/z-index/_.scss
@@ -1,7 +1,22 @@
 @import './settings';
 
-@each $z-index-alias, $z-index-value in $bitstyles-z-index {
-  .#{$bitstyles-namespace}u-z-#{$z-index-alias} {
-    z-index: $z-index-value;
+@each $breakpoint-alias in $bitstyles-z-index-breakpoints {
+  @if $breakpoint-alias == 'base' {
+    @include output-properties(
+      $property-name: 'z-index',
+      $classname-root: 'z',
+      $values: $bitstyles-z-index
+    );
+  }
+
+  @else {
+    @include media-query($breakpoint-alias) {
+      @include output-properties(
+        $property-name: 'z-index',
+        $classname-root: 'z',
+        $values: $bitstyles-z-index,
+        $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+      );
+    }
   }
 }

--- a/scss/bitstyles/utilities/z-index/_.scss
+++ b/scss/bitstyles/utilities/z-index/_.scss
@@ -1,0 +1,7 @@
+@import './settings';
+
+@each $z-index-alias, $z-index-value in $bitstyles-z-index {
+  .#{$bitstyles-namespace}u-z-#{$z-index-alias} {
+    z-index: $z-index-value;
+  }
+}

--- a/scss/bitstyles/utilities/z-index/settings.scss
+++ b/scss/bitstyles/utilities/z-index/settings.scss
@@ -1,0 +1,3 @@
+$bitstyles-z-index: (
+  '1': 1
+) !default;

--- a/scss/bitstyles/utilities/z-index/settings.scss
+++ b/scss/bitstyles/utilities/z-index/settings.scss
@@ -1,3 +1,4 @@
 $bitstyles-z-index: (
   '1': 1
 ) !default;
+$bitstyles-z-index-breakpoints:('base') !default;

--- a/scss/bitstyles/utilities/z-index/z-index.stories.mdx
+++ b/scss/bitstyles/utilities/z-index/z-index.stories.mdx
@@ -1,0 +1,18 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/z" />
+
+# Z (z-index)
+
+Sets the z-index. By default, only `.u-z-1` is available. Note that you need to set a position other than the default `static` (probably either using `u-relative`, or by using component-level custom CSS to set `position: absolute`, `sticky`, or `fixed`).
+
+<Canvas>
+  <Story name="z">
+    {`
+      <div class="u-relative u-z-1">.u-z-1</div>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+

--- a/scss/bitstyles/utilities/z-index/z-index.stories.mdx
+++ b/scss/bitstyles/utilities/z-index/z-index.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Z (z-index)
 
-Sets the z-index. By default, only `.u-z-1` is available. Note that you need to set a position other than the default `static` (probably either using `u-relative`, or by using component-level custom CSS to set `position: absolute`, `sticky`, or `fixed`).
+Sets the z-index. By default, only `.u-z-1` is available. Note that you need to set a position other than the default `static` (probably either using `u-relative`, or by using component-level custom CSS to set `position: absolute`, `sticky`, or `fixed`), as otherwise CSS `z-index` has no effect.
 
 <Canvas>
   <Story name="z">
@@ -16,3 +16,17 @@ Sets the z-index. By default, only `.u-z-1` is available. Note that you need to 
 
 ## Customization
 
+The available z-indexes can be customized by overriding the `$bitstyles-z-index` variable:
+
+```scss
+$bitstyles-z-index: (
+  '1': 1,
+  'modal': 10
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-z-index-breakpoints` variable:
+
+ ```scss
+ $bitstyles-z-index-breakpoints: ('base', 's', 'm', 'xl');
+ ```


### PR DESCRIPTION
Fixes #496 

The following changes are contained in this pull request:

- Adds a z-index utility class
- Adds the generator for non-directional properties, uses it generate z-indexes
- Adds docs on customizing z-indexes

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
