### PR TITLE
[#503] Add utility: margin-auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default breakpoints now include `xl`, for ultra-widescreens
 - `.a-content` max-width and padding is now customisable using Sass variables, and by default now includes a 100% option
 - A new `.u-z` utility class for setting `z-index`
+- Margin utility classes now include `auto` as a size
 
 ## Fixed
 

--- a/scss/bitstyles/utilities/margin/margin.stories.mdx
+++ b/scss/bitstyles/utilities/margin/margin.stories.mdx
@@ -17,7 +17,8 @@ $bitstyles-margin-sizes: (
     's': spacing('s'),
     'm': spacing('m'),
     'l': spacing('l'),
-    'xl': spacing('xl')
+    'xl': spacing('xl'),
+    'auto': auto
   ),
   'negative': (
     'xxs': -#{spacing('xxs')},
@@ -79,6 +80,13 @@ $bitstyles-margin-sizes: (
     {`
       <div class="u-bg--brand-2 u-padding-m">
         <div class="u-bg--background u-margin-xl">u-margin-xl</div>
+      </div>
+    `}
+  </Story>
+  <Story name="margin-auto">
+    {`
+      <div class="u-bg--brand-2 u-padding-m">
+        <div class="u-bg--background u-margin-auto">u-margin-auto</div>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/margin/settings.scss
+++ b/scss/bitstyles/utilities/margin/settings.scss
@@ -6,7 +6,8 @@ $bitstyles-margin-sizes: (
     's': spacing('s'),
     'm': spacing('m'),
     'l': spacing('l'),
-    'xl': spacing('xl')
+    'xl': spacing('xl'),
+    'auto': auto
   ),
   'negative': (
     'xxs': -#{spacing('xxs')},


### PR DESCRIPTION
Fixes #503 

The following changes are contained in this pull request:
- Adds `auto` to the available margin sizes
- Adds a story for it

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
