### PR TITLE
[#511] Responsive grid-gap classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Added
+
+- The `.u-gap` classes are now available at `m` and `xl` breakpoints
+
 # [[1.5.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v1.5.0) - 2021-06-28
 
 ## Added

--- a/scss/bitstyles/utilities/gap/_.scss
+++ b/scss/bitstyles/utilities/gap/_.scss
@@ -1,7 +1,22 @@
 @import './settings';
 
-@each $gap-size-alias, $gap-size in ($bitstyles-gap-sizes) {
-  .#{$bitstyles-namespace}u-gap-#{$gap-size-alias} {
-    gap: $gap-size;
+@each $breakpoint-alias in $bitstyles-gap-breakpoints {
+  @if $breakpoint-alias == 'base' {
+    @include output-properties(
+      $property-name: 'gap',
+      $classname-root: 'gap',
+      $values: $bitstyles-gap-sizes
+    );
+  }
+
+  @else {
+    @include media-query($breakpoint-alias) {
+      @include output-properties(
+        $property-name: 'gap',
+        $classname-root: 'gap',
+        $values: $bitstyles-gap-sizes,
+        $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+      );
+    }
   }
 }

--- a/scss/bitstyles/utilities/gap/gap.stories.mdx
+++ b/scss/bitstyles/utilities/gap/gap.stories.mdx
@@ -6,14 +6,6 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 The gap classes specify gaps on your grid elements — space between each grid item, but no space around them (you need to handle the space outside yourself).
 
-By default, `s`, `m`, and `l` sizes are available. This can be customized by overriding `$bitstyles-gap-sizes` e.g.
-
-```scss
-$bitstyles-gap-sizes: (
-  'my-gap-size': 5rem
-);
-```
-
 <Canvas>
   <Story name="u-gap-s">
     {`
@@ -52,3 +44,51 @@ $bitstyles-gap-sizes: (
     `}
   </Story>
 </Canvas>
+
+### Responsive gaps
+
+Gap classes are available at `m` and `xl` breakpoints using the suffix on the class e.g. `u-gap-l@m`.
+
+<Canvas isColumn>
+  <Story name="u-gap-s@m">
+    {`
+      <div class="u-grid u-padding-m u-gap-s@m u-bg--gray-10">
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 1</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 2</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 3</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 4</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 5</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 6</div>
+      </div>
+    `}
+  </Story>
+  <Story name="u-gap-s@xl">
+    {`
+      <div class="u-grid u-padding-m u-gap-s@xl u-bg--gray-10">
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 1</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 2</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 3</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 4</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 5</div>
+        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 6</div>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+Sizes `s`, `m`, and `l` are available by default. This can be customized by overriding `$bitstyles-gap-sizes` e.g.
+
+```scss
+$bitstyles-gap-sizes: (
+  'my-gap-size': 5rem
+);
+```
+
+The breakpoints these classes are available at can be customised too, by changing the named breakpoints:
+
+```scss
+$bitstyles-gap-breakpoints: ('base', 'm', 'xl');
+```
+

--- a/scss/bitstyles/utilities/gap/settings.scss
+++ b/scss/bitstyles/utilities/gap/settings.scss
@@ -3,3 +3,4 @@ $bitstyles-gap-sizes: (
   'm': spacing('l'),
   'l': spacing('xl')
 ) !default;
+$bitstyles-gap-breakpoints: ('base', 'm', 'xl') !default;


### PR DESCRIPTION
Fixes #511 

The following changes are contained in this pull request:

- Uses the generator to output gap classes, therefore adds breakpoints
- Updates the docs a little

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
