### PR TITLE
[#516] Specify input placeholder text style with…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Added
+
+- Inputs’ placeholder text font-weight and font-style can now be customized using `$bitstyles-input-placeholder-font-weight` and `$bitstyles-input-placeholder-font-style` variables respectively
+
 # [[1.5.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v1.5.0) - 2021-06-28
 
 ## Added

--- a/scss/bitstyles/base/forms/settings-input.scss
+++ b/scss/bitstyles/base/forms/settings-input.scss
@@ -3,6 +3,8 @@
 
 $bitstyles-input-padding: spacing('xs') !default;
 $bitstyles-input-border-radius: spacing('xs') !default;
+$bitstyles-input-placeholder-font-style: italic !default;
+$bitstyles-input-placeholder-font-weight: $bitstyles-font-weight-normal !default;
 $bitstyles-input-placeholder-color: palette('gray', '50') !default;
 $bitstyles-input-checkbox-size: spacing('m') !default;
 

--- a/scss/bitstyles/tools/_input.scss
+++ b/scss/bitstyles/tools/_input.scss
@@ -69,7 +69,8 @@
 
 @mixin input-placeholder {
   &::placeholder {
-    font-style: italic;
+    font-style: $bitstyles-input-placeholder-font-style;
+    font-weight: $bitstyles-input-placeholder-font-weight;
     color: $bitstyles-input-placeholder-color;
     opacity: 1;
   }


### PR DESCRIPTION
Fixes #516 

The following changes are contained in this pull request:
- adds sass variable to specify placeholder font-style
- adds sass variable to specify placeholder font-weight


Looks like:

|defaut|font-style: normal|font-weight: bold|
|--|--|--|
|![default](https://user-images.githubusercontent.com/2479422/124145479-202d0f80-da8d-11eb-9f59-3cc93e703519.png)|![font-style: normal](https://user-images.githubusercontent.com/2479422/124145572-333fdf80-da8d-11eb-8e47-3a86de30462b.png)|![font-weight: bold](https://user-images.githubusercontent.com/2479422/124145642-42bf2880-da8d-11eb-93ad-52e936b41257.png)|


Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
