### PR TITLE
[#515] Make flex utility classes available at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Inputs’ placeholder text font-weight and font-style can now be customized using `$bitstyles-input-placeholder-font-weight` and `$bitstyles-input-placeholder-font-style` variables respectively
 - The `.u-gap` classes are now available at `m` and `xl` breakpoints
 - The `.u-align`, `.u-self`, and `.u-justify` sets of utility classes are now all  available at `m` breakpoint. The available breakpoints can be customized
-- The various `u-flex-` classes are now available at the `m` breakpoint. the available breakpoints can be customized by overriding `$bitstyles-flex-breakpoints`
+- The various `.u-flex-` classes are now available at the `m` breakpoint. the available breakpoints can be customized by overriding `$bitstyles-flex-breakpoints`
+- Adds `.u-flex-nowrap` and `.u-flex-row` classes
 
 ## Changed
 
@@ -27,6 +28,8 @@
 - Renamed `u-flex__shrink-1` to `u-flex-shrink-1`
 - Renamed `u-flex-grow-0` to `u-flex-grow-0`
 - Renamed `u-flex-grow-1` to `u-flex-grow-1`
+- Renamed `u-flex--wrap` to `u-flex-wrap`
+- Renamed `u-flex-col` to `u-flex-col`
 
 # [[1.5.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v1.5.0) - 2021-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 - Added `$bitstyles-grays-hint-color-mix` and `$bitstyles-grays-hint-color` variables to allow control over how the `gray` color palette is generated
 - Added `$bitstyles-color-mix-percentages` list variable, giving control over which percentage intervals are generated in each color’s palette
 - There’s now the `generate-palette($base-color, $mix-color, $percentages)` function to automate generating palettes of individual colors
-- Color scales based on the semantic colors (`brand-1`, `warning` etc.)  are now available in shades as well as tints (`brand-1-shades`, `warning-shades` etc.)
+- Color scales based on the semantic colors (`brand-1`, `warning` etc.) are now available in shades as well as tints (`brand-1-shades`, `warning-shades` etc.)
 - Inputs’ placeholder text font-weight and font-style can now be customized using `$bitstyles-input-placeholder-font-weight` and `$bitstyles-input-placeholder-font-style` variables respectively
 - The `.u-gap` classes are now available at `m` and `xl` breakpoints
-- The `.u-align`, `.u-self`, and `.u-justify` sets of utility classes are now all  available at `m` breakpoint. The available breakpoints can be customized
-- The various `.u-flex-` classes are now available at the `m` breakpoint. the available breakpoints can be customized by overriding `$bitstyles-flex-breakpoints`
+- The `.u-align`, `.u-self`, and `.u-justify` sets of utility classes are now all available at `m` breakpoint. The available breakpoints can be customized
+- The various `.u-flex-` classes are now available at the `m` breakpoint. The available breakpoints can be customized by overriding `$bitstyles-flex-breakpoints`
 - Adds `.u-flex-nowrap` and `.u-flex-row` classes
 
 ## Changed
@@ -24,10 +24,8 @@
 
 ## Breaking
 
-- Renamed `u-flex-shrink-0` to `u-flex-shrink-0`
-- Renamed `u-flex__shrink-1` to `u-flex-shrink-1`
-- Renamed `u-flex-grow-0` to `u-flex-grow-0`
-- Renamed `u-flex-grow-1` to `u-flex-grow-1`
+- Renamed `u-flex__shrink-x` (where `x` is a number) to `u-flex-shrink-x`
+- Renamed `u-flex__grow-x` (where `x` is a number) to `u-flex-grow-x`
 - Renamed `u-flex--wrap` to `u-flex-wrap`
 - Renamed `u-flex--col` to `u-flex-col`
 
@@ -104,7 +102,7 @@
 
 ## Changed
 
-- Sidebar examples now include the closed state, so that it can be seen on  small-viewports
+- Sidebar examples now include the closed state, so that it can be seen on small-viewports
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Renamed `u-flex-grow-0` to `u-flex-grow-0`
 - Renamed `u-flex-grow-1` to `u-flex-grow-1`
 - Renamed `u-flex--wrap` to `u-flex-wrap`
-- Renamed `u-flex-col` to `u-flex-col`
+- Renamed `u-flex--col` to `u-flex-col`
 
 # [[1.5.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v1.5.0) - 2021-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Color scales based on the semantic colors (`brand-1`, `warning` etc.)  are now available in shades as well as tints (`brand-1-shades`, `warning-shades` etc.)
 - Inputs’ placeholder text font-weight and font-style can now be customized using `$bitstyles-input-placeholder-font-weight` and `$bitstyles-input-placeholder-font-style` variables respectively
 - The `.u-gap` classes are now available at `m` and `xl` breakpoints
+- The `.u-align`, `.u-self`, and `.u-justify` sets of utility classes are now all  available at `m` breakpoint. The available breakpoints can be customized
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Inputs’ placeholder text font-weight and font-style can now be customized using `$bitstyles-input-placeholder-font-weight` and `$bitstyles-input-placeholder-font-style` variables respectively
 - The `.u-gap` classes are now available at `m` and `xl` breakpoints
 - The `.u-align`, `.u-self`, and `.u-justify` sets of utility classes are now all  available at `m` breakpoint. The available breakpoints can be customized
+- The various `u-flex-` classes are now available at the `m` breakpoint. the available breakpoints can be customized by overriding `$bitstyles-flex-breakpoints`
 
 ## Changed
 
@@ -19,6 +20,13 @@
 ## Docs
 
 - Adds a `Design Tokens` section to the storybook, and lists all available colors
+
+## Breaking
+
+- Renamed `u-flex-shrink-0` to `u-flex-shrink-0`
+- Renamed `u-flex__shrink-1` to `u-flex-shrink-1`
+- Renamed `u-flex-grow-0` to `u-flex-grow-0`
+- Renamed `u-flex-grow-1` to `u-flex-grow-1`
 
 # [[1.5.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v1.5.0) - 2021-06-28
 

--- a/scss/bitstyles/atoms/button--nav-large/button--nav-large.stories.mdx
+++ b/scss/bitstyles/atoms/button--nav-large/button--nav-large.stories.mdx
@@ -61,7 +61,7 @@ It’s rare to have only one link, so here’s how it looks with multiple:
 <Canvas isColumn>
   <Story name="Nav-large list">
     {`
-      <ul class="a-list-reset u-flex u-flex--col">
+      <ul class="a-list-reset u-flex u-flex-col">
         <li class="u-margin-s-bottom">
           <a href="/" class="a-button a-button--nav-large">
             Dashboard
@@ -82,7 +82,7 @@ It’s rare to have only one link, so here’s how it looks with multiple:
   </Story>
   <Story name="Nav-large list current page">
     {`
-      <ul class="a-list-reset u-flex u-flex--col">
+      <ul class="a-list-reset u-flex u-flex-col">
         <li class="u-margin-s-bottom">
           <a href="/" class="a-button a-button--nav-large" aria-current="page">
             Dashboard

--- a/scss/bitstyles/organisms/modal/modal.stories.mdx
+++ b/scss/bitstyles/organisms/modal/modal.stories.mdx
@@ -29,8 +29,8 @@ You may use a modal to inform the user of the outcome of an action, give a littl
       </main>
       <div class="o-modal" data-a11y-dialog="dialog_1" aria-hidden="true" aria-labelledby="dialog-title">
         <div class="o-modal__overlay" data-a11y-dialog-hide title="Close modal"></div>
-        <div class="a-content a-content--s o-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex--col" role="document">
-          <header class="u-flex u-flex--col u-items-center">
+        <div class="a-content a-content--s o-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex-col" role="document">
+          <header class="u-flex u-flex-col u-items-center">
             <div class="a-badge a-badge--positive u-padding-m u-margin-s-bottom">
               <svg width="18" height="18" class="a-icon a-icon--xl" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-check"></use>
@@ -66,8 +66,8 @@ If you have multiple options for the user, present them with any information the
     </main>
     <div class="o-modal" data-a11y-dialog="dialog_1" aria-hidden="true" aria-labelledby="dialog-title">
       <div class="o-modal__overlay" tabindex="-1" title="Close modal" data-a11y-dialog-hide></div>
-      <div class="a-content a-content--s o-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex--col" role="document">
-        <header class="u-flex u-flex--col u-items-center">
+      <div class="a-content a-content--s o-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex-col" role="document">
+        <header class="u-flex u-flex-col u-items-center">
           <div class="a-badge a-badge--brand-1 u-padding-m u-margin-s-bottom">
             <svg width="18" height="18" class="a-icon a-icon--xl" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-mail"></use>
@@ -79,10 +79,10 @@ If you have multiple options for the user, present them with any information the
           <p>The previous email we sent to email@example.com will no longer be valid.</p>
         </div>
         <ul class="a-list-reset u-grid u-grid-cols-2@m u-gap-m u-items-center u-margin-l-top">
-          <li class="u-flex u-flex--col">
+          <li class="u-flex u-flex-col">
             <button class="a-button a-button--ui" type="button" data-a11y-dialog-hide>Cancel</button>
           </li>
-          <li class="u-flex u-flex--col">
+          <li class="u-flex u-flex-col">
             <button class="a-button" type="button">Send</button>
           </li>
         </ul>
@@ -108,8 +108,8 @@ Sometimes you just need to show the user a load of text, such as for legal docum
     </main>
     <div class="o-modal" data-a11y-dialog="dialog_1" aria-hidden="true" aria-labelledby="dialog-title">
       <div class="o-modal__overlay" tabindex="-1" title="Close modal" data-a11y-dialog-hide></div>
-      <div class="a-content a-content--m o-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex--col" role="document">
-        <header class="u-flex u-flex--col u-items-center">
+      <div class="a-content a-content--m o-modal__content a-card u-padding-xl@m u-padding-l u-flex u-flex-col" role="document">
+        <header class="u-flex u-flex-col u-items-center">
           <div class="a-badge a-badge--brand-1 u-padding-m u-margin-s-bottom">
             <svg width="18" height="18" class="a-icon a-icon--xl" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-mail"></use>

--- a/scss/bitstyles/organisms/modal/modal.stories.mdx
+++ b/scss/bitstyles/organisms/modal/modal.stories.mdx
@@ -36,12 +36,12 @@ You may use a modal to inform the user of the outcome of an action, give a littl
                 <use xlink:href="${icons}#icon-check"></use>
               </svg>
             </div>
-            <h1 class="u-flex__shrink-0 u-h2" id="dialog-title" tabindex="0">Confirmation email sent</h1>
+            <h1 class="u-flex-shrink-0 u-h2" id="dialog-title" tabindex="0">Confirmation email sent</h1>
           </header>
-          <div class="u-flex__grow-1 u-overflow--y u-fg--gray-50 u-text--center">
+          <div class="u-flex-grow-1 u-overflow--y u-fg--gray-50 u-text--center">
             <p>We sent the email to your primary email address. If you do not receive it shortly, please contact your admin.</p>
           </div>
-          <button class="u-flex__shrink-0 u-margin-l-top a-button" type="button" data-a11y-dialog-hide>
+          <button class="u-flex-shrink-0 u-margin-l-top a-button" type="button" data-a11y-dialog-hide>
             Got it
           </button>
         </div>
@@ -73,9 +73,9 @@ If you have multiple options for the user, present them with any information the
               <use xlink:href="${icons}#icon-mail"></use>
             </svg>
           </div>
-          <h1 class="u-flex__shrink-0 u-h2" id="dialog-title" tabindex="0">Send confirmation email?</h1>
+          <h1 class="u-flex-shrink-0 u-h2" id="dialog-title" tabindex="0">Send confirmation email?</h1>
         </header>
-        <div class="u-flex__grow-1 u-overflow--y u-fg--gray-50 u-text--center">
+        <div class="u-flex-grow-1 u-overflow--y u-fg--gray-50 u-text--center">
           <p>The previous email we sent to email@example.com will no longer be valid.</p>
         </div>
         <ul class="a-list-reset u-grid u-grid-cols-2@m u-gap-m u-items-center u-margin-l-top">
@@ -115,16 +115,16 @@ Sometimes you just need to show the user a load of text, such as for legal docum
               <use xlink:href="${icons}#icon-mail"></use>
             </svg>
           </div>
-          <h1 class="u-flex__shrink-0 u-h2 u-margin-0" id="dialog-title" tabindex="0">The legal stuff</h1>
+          <h1 class="u-flex-shrink-0 u-h2 u-margin-0" id="dialog-title" tabindex="0">The legal stuff</h1>
           <p class="u-h3">Please read and accept</p>
         </header>
-        <div class="u-flex__grow-1 u-overflow--y u-fg--gray-50">
+        <div class="u-flex-grow-1 u-overflow--y u-fg--gray-50">
           <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
           <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
           <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
           <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
         </div>
-        <button class="u-flex__shrink-0 u-margin-l-top u-margin-xl-top@m a-button" type="button" data-a11y-dialog-hide>
+        <button class="u-flex-shrink-0 u-margin-l-top u-margin-xl-top@m a-button" type="button" data-a11y-dialog-hide>
           I accept
         </button>
       </div>

--- a/scss/bitstyles/organisms/navbar/navbar.stories.mdx
+++ b/scss/bitstyles/organisms/navbar/navbar.stories.mdx
@@ -14,7 +14,7 @@ A top-level navigation container, this organism is only responsible for the layo
     {`
       <div style="min-height:25rem;">
         <div class="u-relative">
-          <ul class="u-flex u-flex--col a-list-reset o-navbar u-padding-s u-bg--gray-80" id="navbar-1">
+          <ul class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg--gray-80" id="navbar-1">
             <li class="u-margin-s-bottom">
               <a href="/" class="a-button a-button--nav-large" aria-current="page">Team</a>
             </li>

--- a/scss/bitstyles/organisms/notification-center/notification-center.stories.mdx
+++ b/scss/bitstyles/organisms/notification-center/notification-center.stories.mdx
@@ -15,7 +15,7 @@ Commonly, this layout is used for buttons.
       <div style="position: relative; z-index:0; transform: translate3d(0,0,0); min-height: 15rem">
         <div class="o-notification-center a-content a-content--s u-margin-0" aria-live="polite">
           <article class="a-card u-padding-l u-flex u-items-start">
-            <div class="u-flex__shrink-0 a-badge a-badge--positive u-padding-s u-margin-m-right">
+            <div class="u-flex-shrink-0 a-badge a-badge--positive u-padding-s u-margin-m-right">
               <svg class="a-icon a-icon--xl" viewBox="0 0 100 100" width="18" height="18" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
                 <use xlink:href="${icons}#icon-mail"></use>
               </svg>

--- a/scss/bitstyles/ui/Colors.stories.js
+++ b/scss/bitstyles/ui/Colors.stories.js
@@ -51,7 +51,7 @@ const ColorItem = (label, color) =>
 
 const ColorRow = ({ palette }) =>
   `
-    <ul class="u-flex__grow-1 u-grid a-list-reset" style="grid-template-columns: repeat(${
+    <ul class="u-flex-grow-1 u-grid a-list-reset" style="grid-template-columns: repeat(${
       Object.keys(palette).length
     }, 1fr)">
       ${Object.keys(palette)

--- a/scss/bitstyles/ui/app-layouts.stories.mdx
+++ b/scss/bitstyles/ui/app-layouts.stories.mdx
@@ -14,11 +14,11 @@ Sidebar, header, and content that uses all available space.
     {`
       <div class="u-flex u-height-100vh">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex__shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
-            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex__grow-1 u-flex__shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
+            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-home"></use>
                   </svg>
@@ -26,7 +26,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1" aria-current="page">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1" aria-current="page">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-filter"></use>
                   </svg>
@@ -34,7 +34,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-mail"></use>
                   </svg>
@@ -42,7 +42,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-check"></use>
                   </svg>
@@ -50,7 +50,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-pencil"></use>
                   </svg>
@@ -58,7 +58,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-bin"></use>
                   </svg>
@@ -66,7 +66,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-search"></use>
                   </svg>
@@ -74,7 +74,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
+            <div class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -84,15 +84,15 @@ Sidebar, header, and content that uses all available space.
             </div>
           </div>
           <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex--col u-hidden@l">
-            <button class="u-flex__shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
+            <button class="u-flex-shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
               <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
                 <use xlink:href="${icons}#icon-cross"></use>
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex__grow-1 u-flex__shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-home"></use>
                   </svg>
@@ -100,7 +100,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1" aria-current="page">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1" aria-current="page">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-filter"></use>
                   </svg>
@@ -108,7 +108,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-mail"></use>
                   </svg>
@@ -116,7 +116,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-check"></use>
                   </svg>
@@ -124,7 +124,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-pencil"></use>
                   </svg>
@@ -132,7 +132,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-bin"></use>
                   </svg>
@@ -140,7 +140,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-search"></use>
                   </svg>
@@ -148,7 +148,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
+            <div class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -158,8 +158,8 @@ Sidebar, header, and content that uses all available space.
             </div>
           </div>
         </nav>
-        <main class="u-flex__grow-1 u-flex u-flex--col">
-          <header class="u-bg--gray-5 u-padding-l-top u-flex__shrink-0">
+        <main class="u-flex-grow-1 u-flex u-flex--col">
+          <header class="u-bg--gray-5 u-padding-l-top u-flex-shrink-0">
             <div class="a-content a-content--full">
               <div class="u-padding-xl-bottom">
                 <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
@@ -185,7 +185,7 @@ Sidebar, header, and content that uses all available space.
                 <div class="u-flex u-justify-between u-flex--wrap u-items-center">
                   <div class="u-flex u-flex--wrap u-items-center">
                     <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
-                    <div class="u-flex__shrink-0 u-margin-m-bottom">
+                    <div class="u-flex-shrink-0 u-margin-m-bottom">
                       <span class="a-badge a-badge--gray u-font--medium">Published</span>
                     </div>
                   </div>
@@ -223,7 +223,7 @@ Sidebar, header, and content that uses all available space.
               </ul>
             </div>
           </header>
-          <div class="a-content a-content--full u-padding-l-y u-flex__grow-1 u-overflow--y">
+          <div class="a-content a-content--full u-padding-l-y u-flex-grow-1 u-overflow--y">
             <h2 class="u-sr-only">Users</h2>
             <form action="" method="POST" role="search" class="u-margin-m-bottom u-flex">
               <h3 class="u-sr-only">Filter results</h3>
@@ -267,11 +267,11 @@ Sidebar, header, and content that uses all available space.
     {`
       <div class="u-flex u-height-100vh">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex__shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
-            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex__grow-1 u-flex__shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
+            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-home"></use>
                   </svg>
@@ -279,7 +279,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1" aria-current="page">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1" aria-current="page">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-filter"></use>
                   </svg>
@@ -287,7 +287,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-mail"></use>
                   </svg>
@@ -295,7 +295,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-check"></use>
                   </svg>
@@ -303,7 +303,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-pencil"></use>
                   </svg>
@@ -311,7 +311,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-bin"></use>
                   </svg>
@@ -319,7 +319,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-search"></use>
                   </svg>
@@ -327,7 +327,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
+            <div class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -337,15 +337,15 @@ Sidebar, header, and content that uses all available space.
             </div>
           </div>
           <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex--col u-hidden@l">
-            <button class="u-flex__shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
+            <button class="u-flex-shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
               <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
                 <use xlink:href="${icons}#icon-cross"></use>
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex__grow-1 u-flex__shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-home"></use>
                   </svg>
@@ -353,7 +353,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1" aria-current="page">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1" aria-current="page">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-filter"></use>
                   </svg>
@@ -361,7 +361,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-mail"></use>
                   </svg>
@@ -369,7 +369,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-check"></use>
                   </svg>
@@ -377,7 +377,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-pencil"></use>
                   </svg>
@@ -385,7 +385,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-bin"></use>
                   </svg>
@@ -393,7 +393,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-search"></use>
                   </svg>
@@ -401,7 +401,7 @@ Sidebar, header, and content that uses all available space.
                 </a>
               </li>
             </ul>
-            <div class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
+            <div class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top">
               <a href="/" class="a-button a-button--nav-large">
                 <div class="a-button__icon a-avatar">
                   <img src="https://placekitten.com/100/150" width="36" height="54" alt="Username’s avatar" class="a-avatar" />
@@ -411,8 +411,8 @@ Sidebar, header, and content that uses all available space.
             </div>
           </div>
         </nav>
-        <main class="u-flex__grow-1 u-flex u-flex--col">
-          <header class="u-bg--gray-5 u-padding-l-top u-flex__shrink-0">
+        <main class="u-flex-grow-1 u-flex u-flex--col">
+          <header class="u-bg--gray-5 u-padding-l-top u-flex-shrink-0">
             <div class="a-content a-content--full">
               <div class="u-padding-xl-bottom">
                 <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
@@ -438,7 +438,7 @@ Sidebar, header, and content that uses all available space.
                 <div class="u-flex u-justify-between u-flex--wrap u-items-center">
                   <div class="u-flex u-flex--wrap u-items-center">
                     <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
-                    <div class="u-flex__shrink-0 u-margin-m-bottom">
+                    <div class="u-flex-shrink-0 u-margin-m-bottom">
                       <span class="a-badge a-badge--gray u-font--medium">Published</span>
                     </div>
                   </div>
@@ -476,7 +476,7 @@ Sidebar, header, and content that uses all available space.
               </ul>
             </div>
           </header>
-          <div class="u-flex__grow-1 u-overflow--y u-grid u-gap-l u-grid-cols-2@xl a-content a-content--full u-margin-0">
+          <div class="u-flex-grow-1 u-overflow--y u-grid u-gap-l u-grid-cols-2@xl a-content a-content--full u-margin-0">
             <div class="u-padding-l-y">
               <form action="" method="POST" role="search" class="u-margin-m-bottom u-flex">
                 <h3 class="u-sr-only">Filter results</h3>

--- a/scss/bitstyles/ui/app-layouts.stories.mdx
+++ b/scss/bitstyles/ui/app-layouts.stories.mdx
@@ -14,9 +14,9 @@ Sidebar, header, and content that uses all available space.
     {`
       <div class="u-flex u-height-100vh">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
@@ -83,14 +83,14 @@ Sidebar, header, and content that uses all available space.
               </a>
             </div>
           </div>
-          <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex--col u-hidden@l">
+          <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex-col u-hidden@l">
             <button class="u-flex-shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
               <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
                 <use xlink:href="${icons}#icon-cross"></use>
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
@@ -158,11 +158,11 @@ Sidebar, header, and content that uses all available space.
             </div>
           </div>
         </nav>
-        <main class="u-flex-grow-1 u-flex u-flex--col">
+        <main class="u-flex-grow-1 u-flex u-flex-col">
           <header class="u-bg--gray-5 u-padding-l-top u-flex-shrink-0">
             <div class="a-content a-content--full">
               <div class="u-padding-xl-bottom">
-                <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
+                <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Main section</a>
                     <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -182,14 +182,14 @@ Sidebar, header, and content that uses all available space.
                     </svg>
                   </li>
                 </ol>
-                <div class="u-flex u-justify-between u-flex--wrap u-items-center">
-                  <div class="u-flex u-flex--wrap u-items-center">
+                <div class="u-flex u-justify-between u-flex-wrap u-items-center">
+                  <div class="u-flex u-flex-wrap u-items-center">
                     <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                     <div class="u-flex-shrink-0 u-margin-m-bottom">
                       <span class="a-badge a-badge--gray u-font--medium">Published</span>
                     </div>
                   </div>
-                  <ul class="a-list-reset u-flex u-flex--wrap">
+                  <ul class="a-list-reset u-flex u-flex-wrap">
                     <li class="u-margin-s-right u-margin-m-bottom u-relative@m">
                       <button type="button" class="a-button a-button--ui" aria-controls="dropdown-1" aria-expanded="false">
                         <span class="a-button__label">Move</span>
@@ -267,9 +267,9 @@ Sidebar, header, and content that uses all available space.
     {`
       <div class="u-flex u-height-100vh">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
@@ -336,14 +336,14 @@ Sidebar, header, and content that uses all available space.
               </a>
             </div>
           </div>
-          <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex--col u-hidden@l">
+          <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex-col u-hidden@l">
             <button class="u-flex-shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
               <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
                 <use xlink:href="${icons}#icon-cross"></use>
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
@@ -411,11 +411,11 @@ Sidebar, header, and content that uses all available space.
             </div>
           </div>
         </nav>
-        <main class="u-flex-grow-1 u-flex u-flex--col">
+        <main class="u-flex-grow-1 u-flex u-flex-col">
           <header class="u-bg--gray-5 u-padding-l-top u-flex-shrink-0">
             <div class="a-content a-content--full">
               <div class="u-padding-xl-bottom">
-                <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
+                <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Main section</a>
                     <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -435,14 +435,14 @@ Sidebar, header, and content that uses all available space.
                     </svg>
                   </li>
                 </ol>
-                <div class="u-flex u-justify-between u-flex--wrap u-items-center">
-                  <div class="u-flex u-flex--wrap u-items-center">
+                <div class="u-flex u-justify-between u-flex-wrap u-items-center">
+                  <div class="u-flex u-flex-wrap u-items-center">
                     <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                     <div class="u-flex-shrink-0 u-margin-m-bottom">
                       <span class="a-badge a-badge--gray u-font--medium">Published</span>
                     </div>
                   </div>
-                  <ul class="a-list-reset u-flex u-flex--wrap">
+                  <ul class="a-list-reset u-flex u-flex-wrap">
                     <li class="u-margin-s-right u-margin-m-bottom u-relative@m">
                       <button type="button" class="a-button a-button--ui" aria-controls="dropdown-1" aria-expanded="false">
                         <span class="a-button__label">Move</span>

--- a/scss/bitstyles/ui/breadcrumbs.stories.mdx
+++ b/scss/bitstyles/ui/breadcrumbs.stories.mdx
@@ -25,7 +25,7 @@ A list of links charting the user’s place in the site structure. The title of 
   <Story name="Breadcrumbs">
     {`
       <nav aria-label="breadcrumbs">
-        <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
+        <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/">Main section</a>
             <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -56,7 +56,7 @@ Using the same structure, your root page might be represented with an icon, for 
   <Story name="Breadcrumbs with icon">
     {`
       <nav aria-label="breadcrumbs">
-        <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center u-line-height--min">
+        <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center u-line-height--min">
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/" class="u-margin-xs-right u-flex u-items-center">
               <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" class="a-icon a-icon--l" viewBox="0 0 100 100">

--- a/scss/bitstyles/ui/button-groups.stories.mdx
+++ b/scss/bitstyles/ui/button-groups.stories.mdx
@@ -23,7 +23,7 @@ A group of buttons aligned horizontally, collapsing onto a new row when there’
 <Canvas>
   <Story name="Button group">
     {`
-      <ul class="a-list-reset u-flex u-flex--wrap u-items-center">
+      <ul class="a-list-reset u-flex u-flex-wrap u-items-center">
         <li class="u-margin-xs-right">
           <button class="a-button u-h6" type="button">Show</button>
         </li>
@@ -41,7 +41,7 @@ A group of buttons aligned horizontally, collapsing onto a new row when there’
 <Canvas>
   <Story name="Button group with icons">
     {`
-      <ul class="a-list-reset u-flex u-flex--wrap u-items-center">
+      <ul class="a-list-reset u-flex u-flex-wrap u-items-center">
         <li class="u-flex u-margin-xs-right">
           <button class="a-button u-h6" type="button">
             <svg width="14" height="14" class="a-button__icon a-icon a-icon-m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">

--- a/scss/bitstyles/ui/dropdown-menu.stories.mdx
+++ b/scss/bitstyles/ui/dropdown-menu.stories.mdx
@@ -142,7 +142,7 @@ These examples show various contents for the dropdown menus — what you put in 
                 <div class="a-button__avatar a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="a-button__label u-flex u-flex--col u-items-start">
+                <div class="a-button__label u-flex u-flex-col u-items-start">
                   <span>Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -209,7 +209,7 @@ These examples show various contents for the dropdown menus — what you put in 
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -287,7 +287,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -322,7 +322,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
   </Story>
   <Story name="dropdown--top">
     {`
-      <div style="height: 15rem" class="u-flex u-flex--col>
+      <div style="height: 15rem" class="u-flex u-flex-col>
         <div class="u-flex-grow-1"></div>
         <div class="u-relative" x-data="{ dropdownOpen: false }">
           <button
@@ -355,7 +355,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -390,7 +390,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
   </Story>
   <Story name="dropdown--full-width">
     {`
-      <div style="height: 15rem; width: 20rem" class="u-flex u-flex--col">
+      <div style="height: 15rem; width: 20rem" class="u-flex u-flex-col">
         <div class="u-relative u-flex u-justify-end" x-data="{ dropdownOpen: false }">
           <button
             type="button"
@@ -422,7 +422,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -462,7 +462,7 @@ The directions can be combined.
 <Canvas>
   <Story name="dropdown--top dropdown--right">
     {`
-      <div style="height: 15rem; width: 12rem;" class="u-flex u-flex--col">
+      <div style="height: 15rem; width: 12rem;" class="u-flex u-flex-col">
         <div class="u-flex-grow-1"></div>
         <div class="u-relative u-flex u-justify-end" x-data="{ dropdownOpen: false }">
           <button
@@ -495,7 +495,7 @@ The directions can be combined.
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -530,7 +530,7 @@ The directions can be combined.
   </Story>
   <Story name="dropdown--full-width dropdown--top">
     {`
-      <div style="height: 20rem" class="u-flex u-flex--col">
+      <div style="height: 20rem" class="u-flex u-flex-col">
         <div class="u-flex-grow-1"></div>
         <div class="u-relative u-flex u-justify-end" x-data="{ dropdownOpen: false }">
           <button
@@ -563,7 +563,7 @@ The directions can be combined.
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>

--- a/scss/bitstyles/ui/dropdown-menu.stories.mdx
+++ b/scss/bitstyles/ui/dropdown-menu.stories.mdx
@@ -139,7 +139,7 @@ These examples show various contents for the dropdown menus — what you put in 
           >
             <li>
               <a href="/" class="a-button a-button--menu u-h6">
-                <div class="a-button__avatar a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center">
+                <div class="a-button__avatar a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
                 <div class="a-button__label u-flex u-flex--col u-items-start">
@@ -206,10 +206,10 @@ These examples show various contents for the dropdown menus — what you put in 
           >
             <li>
               <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
-                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s-right">
+                <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -284,10 +284,10 @@ The default dropdowns are aligned to the left edge of their relative parent, und
           >
             <li>
               <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
-                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s-right">
+                <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -323,7 +323,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
   <Story name="dropdown--top">
     {`
       <div style="height: 15rem" class="u-flex u-flex--col>
-        <div class="u-flex__grow-1"></div>
+        <div class="u-flex-grow-1"></div>
         <div class="u-relative" x-data="{ dropdownOpen: false }">
           <button
             type="button"
@@ -352,10 +352,10 @@ The default dropdowns are aligned to the left edge of their relative parent, und
           >
             <li>
               <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
-                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s-right">
+                <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -419,10 +419,10 @@ The default dropdowns are aligned to the left edge of their relative parent, und
           >
             <li>
               <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
-                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s-right">
+                <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -463,7 +463,7 @@ The directions can be combined.
   <Story name="dropdown--top dropdown--right">
     {`
       <div style="height: 15rem; width: 12rem;" class="u-flex u-flex--col">
-        <div class="u-flex__grow-1"></div>
+        <div class="u-flex-grow-1"></div>
         <div class="u-relative u-flex u-justify-end" x-data="{ dropdownOpen: false }">
           <button
             type="button"
@@ -492,10 +492,10 @@ The directions can be combined.
           >
             <li>
               <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
-                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s-right">
+                <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
@@ -531,7 +531,7 @@ The directions can be combined.
   <Story name="dropdown--full-width dropdown--top">
     {`
       <div style="height: 20rem" class="u-flex u-flex--col">
-        <div class="u-flex__grow-1"></div>
+        <div class="u-flex-grow-1"></div>
         <div class="u-relative u-flex u-justify-end" x-data="{ dropdownOpen: false }">
           <button
             type="button"
@@ -560,10 +560,10 @@ The directions can be combined.
           >
             <li>
               <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
-                <div class="a-avatar a-avatar--l u-flex__shrink-0 u-flex u-items-center u-margin-s-right">
+                <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
-                <div class="u-flex__shrink-0 u-flex u-flex--col u-items-start">
+                <div class="u-flex-shrink-0 u-flex u-flex--col u-items-start">
                   <span class="u-fg--gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>

--- a/scss/bitstyles/ui/flashes.stories.mdx
+++ b/scss/bitstyles/ui/flashes.stories.mdx
@@ -27,7 +27,7 @@ Inform the user of a global or important event, such as may happen after a page 
       <div aria-live="polite">
         <div class="u-padding-l-y a-flash--brand-1">
           <div class="a-content u-flex u-items-center u-font--medium">
-            <svg width="14" height="14" class="a-icon a-icon--l u-flex__shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-info-circle"></use>
             </svg>
             Something you may be interested to hear
@@ -41,7 +41,7 @@ Inform the user of a global or important event, such as may happen after a page 
       <div aria-live="polite">
         <div class="u-padding-l-y a-flash--positive" aria-live="polite">
           <div class="a-content u-flex u-items-center u-font--medium">
-            <svg width="14" height="14" class="a-icon a-icon--l u-flex__shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-check-circle"></use>
             </svg>
             Changes successfully saved
@@ -55,7 +55,7 @@ Inform the user of a global or important event, such as may happen after a page 
       <div aria-live="polite">
         <div class="u-padding-l-y a-flash--warning" aria-live="polite">
           <div class="a-content u-flex u-items-center u-font--medium">
-            <svg width="14" height="14" class="a-icon a-icon--l u-flex__shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-question-circle"></use>
             </svg>
             Login not successful, please try that again
@@ -69,7 +69,7 @@ Inform the user of a global or important event, such as may happen after a page 
       <div aria-live="polite">
         <div class="u-padding-l-y a-flash--danger" role="alert">
           <div class="a-content u-flex u-items-center u-font--medium">
-            <svg width="14" height="14" class="a-icon a-icon--l u-flex__shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-exclamation"></use>
             </svg>
             An error occured, please contact an admin

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -44,7 +44,7 @@ Here are some examples using the grid utility classes to create common form layo
               <label for="email">Email</label>
               <input id="email" type="email" autocomplete="email" />
             </li>
-            <li class="u-margin-m-bottom u-flex u-flex--col">
+            <li class="u-margin-m-bottom u-flex u-flex-col">
               <label for="password">Password</label>
               <input id="password" type="password" autocomplete="current-password" />
               <div class="u-flex u-justify-end u-margin-xs-top">
@@ -96,7 +96,7 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
               <input id="email" type="email" autocomplete="email" aria-invalid="true" aria-describedby="email-help-text" />
               <span id="email-help-text" class="u-fg--warning u-margin-xs-top">Missing email address</span>
             </li>
-            <li class="u-margin-m-bottom u-flex u-flex--col">
+            <li class="u-margin-m-bottom u-flex u-flex-col">
               <label for="password">Password</label>
               <input id="password" type="password" autocomplete="current-password" />
               <div class="u-flex u-justify-end u-margin-xs-top">

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -83,7 +83,7 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
         <form class="a-card@m u-padding-xl@m" method="POST" action="">
           <div class="u-padding-l-y u-margin-neg-m u-margin-neg-xl@m u-margin-l-bottom@m a-flash a-flash--warning" role="alert">
             <div class="a-content u-flex u-items-center">
-              <svg width="14" height="14" class="a-icon a-icon--l u-flex__shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-exclamation"></use>
               </svg>
               There was a problem logging in
@@ -283,7 +283,7 @@ The `role="search"` attribute highlights this functionality for screenreader use
     {`
     <form role="search" action="" method="POST" class="u-flex o-ui-group">
       <label for="search" class="u-sr-only">Search users</label>
-      <input type="search" id="search" placeholder="Username or email…" class="u-flex__grow-1 u-round-0--tr u-round-0--br o-ui-group__item" />
+      <input type="search" id="search" placeholder="Username or email…" class="u-flex-grow-1 u-round-0--tr u-round-0--br o-ui-group__item" />
       <button type="submit" class="a-button a-button--ui o-ui-group__item o-ui-group__last u-round-0--tl u-round-0--bl">Search</button>
     </form>
     `}
@@ -295,7 +295,7 @@ The `role="search"` attribute highlights this functionality for screenreader use
     {`
     <form role="search" action="" method="POST" class="u-flex o-ui-group">
       <label for="search" class="u-sr-only">Search users</label>
-      <input type="search" id="search" placeholder="Username or email…" class="u-flex__grow-1 o-ui-group__item u-round-0--tr u-round-0--br" />
+      <input type="search" id="search" placeholder="Username or email…" class="u-flex-grow-1 o-ui-group__item u-round-0--tr u-round-0--br" />
       <button type="submit" class="a-button a-button--ui o-ui-group__item o-ui-group__last u-round-0--tl u-round-0--bl" title="Search users">
         <svg width="18" height="18" class="a-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
           <use xlink:href="${icons}#icon-search"></use>

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -41,7 +41,7 @@ Give the active link the `aria-current="page"` attribute.
   <Story name="Navbar" inline={false} height="80vh">
     {`
       <nav class="u-bg--gray-80 u-padding-s-top u-padding-s-bottom u-relative">
-        <div class="u-padding-m-x u-flex u-justify-between u-items-center u-flex--wrap">
+        <div class="u-padding-m-x u-flex u-justify-between u-items-center u-flex-wrap">
           <div class="u-flex-shrink-1 u-flex u-items-center">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden u-block@l" />
             <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden@l" />
@@ -81,7 +81,7 @@ Give the active link the `aria-current="page"` attribute.
               <span class="u-sr-only">Toggle menu</span>
             </button>
             <ul
-              class="u-flex u-flex--col a-list-reset o-navbar u-padding-s u-bg--gray-80"
+              class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg--gray-80"
               id="navbar-1"
               x-show="navbarOpen"
               @click.away="navbarOpen = false"
@@ -178,7 +178,7 @@ This navbar is only intended to hold a few link to the main sections of your sit
               <span class="u-sr-only">Toggle menu</span>
             </button>
             <ul
-              class="u-flex u-flex--col a-list-reset o-navbar u-padding-s u-bg--gray-80"
+              class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg--gray-80"
               id="navbar-1"
               x-show="navbarOpen"
               @click.away="navbarOpen = false"

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -42,10 +42,10 @@ Give the active link the `aria-current="page"` attribute.
     {`
       <nav class="u-bg--gray-80 u-padding-s-top u-padding-s-bottom u-relative">
         <div class="u-padding-m-x u-flex u-justify-between u-items-center u-flex--wrap">
-          <div class="u-flex__shrink-1 u-flex u-items-center">
-            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-l-right u-hidden u-block@l" />
-            <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-l-right u-hidden@l" />
-            <div class="u-hidden u-block@l u-flex__shrink-1 u-overflow--x">
+          <div class="u-flex-shrink-1 u-flex u-items-center">
+            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden u-block@l" />
+            <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden@l" />
+            <div class="u-hidden u-block@l u-flex-shrink-1 u-overflow--x">
               <ul class="u-flex a-list-reset">
                 <li class="u-margin-m-right">
                   <a href="/" class="a-button a-button--nav" aria-current="page">Team</a>
@@ -127,10 +127,10 @@ This navbar is only intended to hold a few link to the main sections of your sit
     {`
       <nav class="u-bg--gray-80 u-padding-s-top u-padding-s-bottom u-relative">
         <div class="u-padding-m-x u-flex u-justify-between u-items-center">
-          <div class="u-flex__shrink-1 u-flex u-items-center">
-            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-l-right u-hidden u-block@l" />
-            <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-l-right u-hidden@l" />
-            <div class="u-hidden u-block@l u-flex__shrink-1 u-overflow--x">
+          <div class="u-flex-shrink-1 u-flex u-items-center">
+            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden u-block@l" />
+            <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden@l" />
+            <div class="u-hidden u-block@l u-flex-shrink-1 u-overflow--x">
               <ul class="u-flex a-list-reset">
                 <li class="u-margin-m-right">
                   <a href="/" class="a-button a-button--nav" aria-current="page">Team</a>
@@ -156,7 +156,7 @@ This navbar is only intended to hold a few link to the main sections of your sit
               </ul>
             </div>
           </div>
-          <div class="u-hidden u-block@l u-flex__shrink-0">
+          <div class="u-hidden u-block@l u-flex-shrink-0">
             <a href="/" class="a-button a-button--nav">
               <span class="a-button__label">Jane Dobermann</span>
               <div class="a-button__icon a-avatar">

--- a/scss/bitstyles/ui/notifications.stories.mdx
+++ b/scss/bitstyles/ui/notifications.stories.mdx
@@ -38,7 +38,7 @@ Some notifications may require or enable further actions by the user — add but
      <div style="position: relative; z-index:0; transform: translate3d(0,0,0); min-height: 15rem">
         <div class="o-notification-center a-content a-content--s u-margin-0" aria-live="polite">
           <article class="a-card u-padding-l u-flex u-items-start">
-            <div class="u-flex__shrink-0 a-badge a-badge--positive u-padding-s u-margin-m-right">
+            <div class="u-flex-shrink-0 a-badge a-badge--positive u-padding-s u-margin-m-right">
               <svg width="18" height="18" class="a-icon a-icon--xl" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-mail"></use>
               </svg>

--- a/scss/bitstyles/ui/page-header.stories.mdx
+++ b/scss/bitstyles/ui/page-header.stories.mdx
@@ -48,7 +48,7 @@ This first example shows a header with all these slots filled:
         <header class="u-bg--gray-5 u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
-              <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
+              <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
                   <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -68,14 +68,14 @@ This first example shows a header with all these slots filled:
                   </svg>
                 </li>
               </ol>
-              <div class="u-flex u-justify-between u-flex--wrap u-items-center">
-                <div class="u-flex u-flex--wrap u-items-center">
+              <div class="u-flex u-justify-between u-flex-wrap u-items-center">
+                <div class="u-flex u-flex-wrap u-items-center">
                   <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                   <div class="u-flex-shrink-0 u-margin-m-bottom">
                     <span class="a-badge a-badge--gray u-font--medium">Published</span>
                   </div>
                 </div>
-                <ul class="a-list-reset u-flex u-flex--wrap">
+                <ul class="a-list-reset u-flex u-flex-wrap">
                   <li class="u-margin-s-right u-margin-m-bottom u-relative@m" x-data="{ dropdownOpen: false }">
                     <button
                       type="button"
@@ -176,7 +176,7 @@ It’s also common to not need tabs — if the content is not large and varied e
         <header class="u-bg--gray-5 u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
-              <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
+              <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
                   <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -196,14 +196,14 @@ It’s also common to not need tabs — if the content is not large and varied e
                   </svg>
                 </li>
               </ol>
-              <div class="u-flex u-justify-between u-flex--wrap u-items-center">
-                <div class="u-flex u-flex--wrap u-items-center">
+              <div class="u-flex u-justify-between u-flex-wrap u-items-center">
+                <div class="u-flex u-flex-wrap u-items-center">
                   <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                   <div class="u-flex-shrink-0 u-margin-m-bottom">
                     <span class="a-badge a-badge--gray u-font--medium">Published</span>
                   </div>
                 </div>
-                <ul class="a-list-reset u-flex u-flex--wrap">
+                <ul class="a-list-reset u-flex u-flex-wrap">
                   <li class="u-margin-s-right u-margin-m-bottom u-relative@m" x-data="{ dropdownOpen: false }">
                     <button
                       type="button"
@@ -287,7 +287,7 @@ This is a minimal example, with only breadcrumbs and a heading.
         <header class="u-bg--gray-5 u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
-              <ol class="u-h6 a-list-reset u-flex u-flex--wrap u-items-center">
+              <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
                   <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -307,8 +307,8 @@ This is a minimal example, with only breadcrumbs and a heading.
                   </svg>
                 </li>
               </ol>
-              <div class="u-flex u-justify-between u-flex--wrap u-items-center">
-                <div class="u-flex u-flex--wrap u-items-center">
+              <div class="u-flex u-justify-between u-flex-wrap u-items-center">
+                <div class="u-flex u-flex-wrap u-items-center">
                   <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                 </div>
               </div>

--- a/scss/bitstyles/ui/page-header.stories.mdx
+++ b/scss/bitstyles/ui/page-header.stories.mdx
@@ -71,7 +71,7 @@ This first example shows a header with all these slots filled:
               <div class="u-flex u-justify-between u-flex--wrap u-items-center">
                 <div class="u-flex u-flex--wrap u-items-center">
                   <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
-                  <div class="u-flex__shrink-0 u-margin-m-bottom">
+                  <div class="u-flex-shrink-0 u-margin-m-bottom">
                     <span class="a-badge a-badge--gray u-font--medium">Published</span>
                   </div>
                 </div>
@@ -199,7 +199,7 @@ It’s also common to not need tabs — if the content is not large and varied e
               <div class="u-flex u-justify-between u-flex--wrap u-items-center">
                 <div class="u-flex u-flex--wrap u-items-center">
                   <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
-                  <div class="u-flex__shrink-0 u-margin-m-bottom">
+                  <div class="u-flex-shrink-0 u-margin-m-bottom">
                     <span class="a-badge a-badge--gray u-font--medium">Published</span>
                   </div>
                 </div>

--- a/scss/bitstyles/ui/section-heading.stories.mdx
+++ b/scss/bitstyles/ui/section-heading.stories.mdx
@@ -76,7 +76,7 @@ Section headings are a good place for important actions relating to the content 
     {`
       <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m-bottom u-border-gray-10-bottom">
         <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
-        <ul class="a-list-reset u-flex u-flex--wrap u-flex__shrink-0">
+        <ul class="a-list-reset u-flex u-flex--wrap u-flex-shrink-0">
           <li class="u-margin-s-right">
             <button type="button" class="a-button a-button--ui">Edit</button>
           </li>
@@ -97,7 +97,7 @@ Section headings are a good place for important actions relating to the content 
           <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
           <span class="a-badge a-badge--brand-1 u-h6">New<span>
         </div>
-        <ul class="a-list-reset u-flex u-flex--wrap u-flex__shrink-0">
+        <ul class="a-list-reset u-flex u-flex--wrap u-flex-shrink-0">
           <li class="u-margin-s-right">
             <button type="button" class="a-button a-button--ui">Edit</button>
           </li>

--- a/scss/bitstyles/ui/section-heading.stories.mdx
+++ b/scss/bitstyles/ui/section-heading.stories.mdx
@@ -74,9 +74,9 @@ Section headings are a good place for important actions relating to the content 
 <Canvas>
   <Story name="Section heading with actions">
     {`
-      <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m-bottom u-border-gray-10-bottom">
+      <div class="u-flex u-flex-wrap u-items-center u-justify-between u-padding-m-bottom u-border-gray-10-bottom">
         <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
-        <ul class="a-list-reset u-flex u-flex--wrap u-flex-shrink-0">
+        <ul class="a-list-reset u-flex u-flex-wrap u-flex-shrink-0">
           <li class="u-margin-s-right">
             <button type="button" class="a-button a-button--ui">Edit</button>
           </li>
@@ -92,12 +92,12 @@ Section headings are a good place for important actions relating to the content 
 <Canvas>
   <Story name="Section heading with badge and actions">
     {`
-      <div class="u-flex u-flex--wrap u-items-center u-justify-between u-padding-m-bottom u-border-gray-10-bottom">
+      <div class="u-flex u-flex-wrap u-items-center u-justify-between u-padding-m-bottom u-border-gray-10-bottom">
         <div class="u-flex u-items-center">
           <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
           <span class="a-badge a-badge--brand-1 u-h6">New<span>
         </div>
-        <ul class="a-list-reset u-flex u-flex--wrap u-flex-shrink-0">
+        <ul class="a-list-reset u-flex u-flex-wrap u-flex-shrink-0">
           <li class="u-margin-s-right">
             <button type="button" class="a-button a-button--ui">Edit</button>
           </li>

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -43,11 +43,11 @@ Uses a fullwidth dropdown to fit with no overlap.
     {`
       <div class="u-flex u-height-100vh" x-data="{ sidebarOpen: false }">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex__shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
-            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex__shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex__grow-1 u-flex__shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
+            <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-home"></use>
                   </svg>
@@ -55,7 +55,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1" aria-current="page">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1" aria-current="page">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-filter"></use>
                   </svg>
@@ -63,7 +63,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-mail"></use>
                   </svg>
@@ -71,7 +71,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-check"></use>
                   </svg>
@@ -79,7 +79,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-pencil"></use>
                   </svg>
@@ -87,7 +87,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-bin"></use>
                   </svg>
@@ -95,7 +95,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-search"></use>
                   </svg>
@@ -104,7 +104,7 @@ Uses a fullwidth dropdown to fit with no overlap.
               </li>
             </ul>
             <div
-              class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top u-relative u-flex u-flex--col"
+              class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top u-relative u-flex u-flex--col"
               x-data="{ dropdownOpen: false }"
             >
               <button
@@ -168,7 +168,7 @@ Uses a fullwidth dropdown to fit with no overlap.
             x-transition:leave-end="is-off-screen"
           >
             <button
-              class="u-flex__shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left"
+              class="u-flex-shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left"
               title="Close menu"
               aria-controls="navbar-1"
               aria-expanded="sidebarOpen"
@@ -179,9 +179,9 @@ Uses a fullwidth dropdown to fit with no overlap.
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex__grow-1 u-flex__shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-home"></use>
                   </svg>
@@ -189,7 +189,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1" aria-current="page">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1" aria-current="page">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-filter"></use>
                   </svg>
@@ -197,7 +197,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-mail"></use>
                   </svg>
@@ -205,7 +205,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-check"></use>
                   </svg>
@@ -213,7 +213,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-pencil"></use>
                   </svg>
@@ -221,7 +221,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-bin"></use>
                   </svg>
@@ -229,7 +229,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 </a>
               </li>
               <li class="u-margin-xs-bottom u-flex">
-                <a href="/" class="a-button a-button--nav u-flex__grow-1">
+                <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
                     <use xlink:href="${icons}#icon-search"></use>
                   </svg>
@@ -238,7 +238,7 @@ Uses a fullwidth dropdown to fit with no overlap.
               </li>
             </ul>
             <div
-              class="u-flex__shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top u-relative"
+              class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top u-relative"
               x-data="{ dropdownOpen: false }"
             >
               <button
@@ -285,10 +285,10 @@ Uses a fullwidth dropdown to fit with no overlap.
             </div>
           </div>
         </nav>
-        <main class="u-flex__grow-1 u-padding-xxl-left@l u-padding-xl-right@l u-padding-xl-bottom u-padding-m u-overflow--y">
+        <main class="u-flex-grow-1 u-padding-xxl-left@l u-padding-xl-right@l u-padding-xl-bottom u-padding-m u-overflow--y">
           <div class="u-flex u-items-center u-margin-m-bottom">
             <button
-              class="u-flex__shrink-0 u-margin-neg-m-left a-button a-button--icon a-button--icon-reversed u-margin-xs-right u-hidden@l"
+              class="u-flex-shrink-0 u-margin-neg-m-left a-button a-button--icon a-button--icon-reversed u-margin-xs-right u-hidden@l"
               title="Open menu"
               aria-controls="navbar-1"
               aria-expanded="sidebarOpen"

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -43,9 +43,9 @@ Uses a fullwidth dropdown to fit with no overlap.
     {`
       <div class="u-flex u-height-100vh" x-data="{ sidebarOpen: false }">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex--col">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
@@ -104,7 +104,7 @@ Uses a fullwidth dropdown to fit with no overlap.
               </li>
             </ul>
             <div
-              class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top u-relative u-flex u-flex--col"
+              class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-border-gray-70-top u-relative u-flex u-flex-col"
               x-data="{ dropdownOpen: false }"
             >
               <button
@@ -157,7 +157,7 @@ Uses a fullwidth dropdown to fit with no overlap.
             </div>
           </div>
           <div
-            class="o-sidebar--small u-bg--gray-80 u-flex u-flex--col u-hidden@l"
+            class="o-sidebar--small u-bg--gray-80 u-flex u-flex-col u-hidden@l"
             x-show="sidebarOpen"
             @click.away="sidebarOpen = false"
             x-transition:enter="is-transitioning"
@@ -179,7 +179,7 @@ Uses a fullwidth dropdown to fit with no overlap.
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex--col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">

--- a/scss/bitstyles/ui/tabs.stories.mdx
+++ b/scss/bitstyles/ui/tabs.stories.mdx
@@ -31,7 +31,7 @@ Also note the differences in attributes of selected/deselected tabs (`aria-selec
     {`
       <div class="u-bg--gray-5 u-padding-xl-top">
         <div class="a-content">
-          <ul class="a-list-reset u-flex u-flex--wrap u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
+          <ul class="a-list-reset u-flex u-flex-wrap u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
             <li class="u-margin-s-right">
               <button class="a-button a-button--tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">
                 Personal details

--- a/scss/bitstyles/utilities/flex/_.scss
+++ b/scss/bitstyles/utilities/flex/_.scss
@@ -1,20 +1,54 @@
-.#{$bitstyles-namespace}u-flex--wrap {
-  flex-wrap: wrap;
-}
+@import 'settings';
 
-.#{$bitstyles-namespace}u-flex--col {
-  flex-direction: column;
-}
+@include output-properties(
+  $property-name: 'flex-wrap',
+  $classname-root: 'flex',
+  $values: $bitstyles-flex-wrap
+);
 
-.#{$bitstyles-namespace}u-flex__grow-1 {
-  flex-grow: 1;
-}
+@include output-properties(
+  $property-name: 'flex-direction',
+  $classname-root: 'flex',
+  $values: $bitstyles-flex-direction
+);
 
-.#{$bitstyles-namespace}u-flex__shrink-0 {
-  flex-shrink: 0;
-}
+@include output-properties(
+  $property-name: 'flex-grow',
+  $classname-root: 'flex-grow',
+  $values: $bitstyles-flex-grow
+);
 
-.#{$bitstyles-namespace}u-flex__shrink-1 {
-  flex-shrink: 1;
-  min-width: 0;
+@include output-properties(
+  $property-name: 'flex-shrink',
+  $classname-root: 'flex-shrink',
+  $values: $bitstyles-flex-shrink
+);
+
+@each $breakpoint-alias in $bitstyles-flex-breakpoints {
+  @include media-query($breakpoint-alias) {
+    @include output-properties(
+      $property-name: 'flex-wrap',
+      $classname-root: 'flex',
+      $values: $bitstyles-flex-wrap,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+    @include output-properties(
+      $property-name: 'flex-direction',
+      $classname-root: 'flex',
+      $values: $bitstyles-flex-direction,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+    @include output-properties(
+      $property-name: 'flex-grow',
+      $classname-root: 'flex-grow',
+      $values: $bitstyles-flex-grow,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+    @include output-properties(
+      $property-name: 'flex-shrink',
+      $classname-root: 'flex-shrink',
+      $values: $bitstyles-flex-shrink,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+  }
 }

--- a/scss/bitstyles/utilities/flex/_.scss
+++ b/scss/bitstyles/utilities/flex/_.scss
@@ -5,19 +5,16 @@
   $classname-root: 'flex',
   $values: $bitstyles-flex-wrap
 );
-
 @include output-properties(
   $property-name: 'flex-direction',
   $classname-root: 'flex',
   $values: $bitstyles-flex-direction
 );
-
 @include output-properties(
   $property-name: 'flex-grow',
   $classname-root: 'flex-grow',
   $values: $bitstyles-flex-grow
 );
-
 @include output-properties(
   $property-name: 'flex-shrink',
   $classname-root: 'flex-shrink',

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -14,11 +14,11 @@ Flex has become the prefered method for laying out app UI, and in many cases als
 
 Apply `.u-flex` to an element to make its children share the available width e.g. a list of links in a menu.
 
-These examples show how that base flex layout behaves with different content. The second of each of the example blocks shows the same layout, but with one of the children being given the `u-flex__grow-1` class, and the third shows one given `.u-flex__shrink-0`.
+These examples show how that base flex layout behaves with different content. The second of each of the example blocks shows the same layout, but with one of the children being given the `u-flex-grow-1` class, and the third shows one given `.u-flex-shrink-0`.
 
-Make one of the children `.u-flex__grow-1` to make it take any available space that’s left over. If there is no space left over, it becomes the same size as its siblings.
+Make one of the children `.u-flex-grow-1` to make it take any available space that’s left over. If there is no space left over, it becomes the same size as its siblings.
 
-Apply `.u-flex__shrink-0` to a flex-child to stop it being crushed when there is not enough space for it and its siblings. This is useful with elements which have intrinsic size (e.g. images, icons), or that need to remain fully-sized (e.g. buttons).
+Apply `.u-flex-shrink-0` to a flex-child to stop it being crushed when there is not enough space for it and its siblings. This is useful with elements which have intrinsic size (e.g. images, icons), or that need to remain fully-sized (e.g. buttons).
 
 ### Little text content
 
@@ -29,7 +29,7 @@ These first examples show the layouts with a small amount of text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>List item one</li>
-        <li class="u-flex__grow-1 u-bg--brand-2">Important content here</li>
+        <li class="u-flex-grow-1 u-bg--brand-2">Important content here</li>
         <li>List item three</li>
         <li>List item four</li>
       </ul>
@@ -39,7 +39,7 @@ These first examples show the layouts with a small amount of text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>List item one</li>
-        <li class="u-flex__shrink-0"><button type="button">Don’t shrink me</button></li>
+        <li class="u-flex-shrink-0"><button type="button">Don’t shrink me</button></li>
         <li>List item three</li>
         <li>List item four</li>
       </ul>
@@ -66,7 +66,7 @@ These next examples show how the same layouts behave with long text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex__grow-1 u-bg--brand-2">Important content here. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-grow-1 u-bg--brand-2">Important content here. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -76,7 +76,7 @@ These next examples show how the same layouts behave with long text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex__shrink-0 u-bg--brand-2">Important content here. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-shrink-0 u-bg--brand-2">Important content here. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -113,7 +113,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li>
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-flex__grow-1 u-bg--brand-2">
+        <li class="u-flex-grow-1 u-bg--brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
         <li>
@@ -131,7 +131,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li>
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-flex__shrink-0 u-bg--brand-2">
+        <li class="u-flex-shrink-0 u-bg--brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
         <li>
@@ -156,7 +156,7 @@ Note this layout may not be so useful with elements that take all available spac
     {`
       <ul class="u-flex u-flex--wrap a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex__grow-1 u-bg--brand-2">Important content here - Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-grow-1 u-bg--brand-2">Important content here - Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -166,7 +166,7 @@ Note this layout may not be so useful with elements that take all available spac
     {`
       <ul class="u-flex u-flex--wrap a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
-        <li class="u-flex__grow-1 u-bg--brand-2">Important content here</li>
+        <li class="u-flex-grow-1 u-bg--brand-2">Important content here</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
       </ul>

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -6,7 +6,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 **Resize your viewport** to best view these examples, or view the examples in the canvas instead of here in the docs.
 
-**Some of these examples will cause horizontal scrollbars** at some viewport widths. That’s deliberate and important — your approach to dealing with that issue will depend on your content, but probably `.u-flex--wrap` will be among the first places to look (see below).
+**Some of these examples will cause horizontal scrollbars** at some viewport widths. That’s deliberate and important — your approach to dealing with that issue will depend on your content, but probably `.u-flex-wrap` will be among the first places to look (see below).
 
 Flex has become the prefered method for laying out app UI, and in many cases also for content in an article/content context. Probably the only instance that’s not true is when you can assume browser support for CSS Grid, which gives developers control over layout in two axis. These flex layout classes cover the most common usecases, they should be extended as needed.
 
@@ -62,7 +62,7 @@ These next examples show how the same layouts behave with long text content.
       </ul>
     `}
   </Story>
-  <Story name="Flex with long content, with primary child">
+  <Story name="Flex with long content, with grow-1 child">
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -72,7 +72,7 @@ These next examples show how the same layouts behave with long text content.
       </ul>
     `}
   </Story>
-  <Story name="Flex with long content, with no-shrink child">
+  <Story name="Flex with long content, with shrink-0 child">
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -107,7 +107,7 @@ And this time the same layouts, with images as content (any element with intrins
       </ul>
     `}
   </Story>
-  <Story name="Flex with intrinsic-width content, with primary child">
+  <Story name="Flex with intrinsic-width content, with grow-1 child">
     {`
       <ul class="u-flex a-list-reset">
         <li>
@@ -125,7 +125,7 @@ And this time the same layouts, with images as content (any element with intrins
       </ul>
     `}
   </Story>
-  <Story name="Flex with intrinsic-width content, with no-shrink child">
+  <Story name="Flex with intrinsic-width content, with shrink-0 child">
     {`
       <ul class="u-flex a-list-reset">
         <li>
@@ -147,14 +147,14 @@ And this time the same layouts, with images as content (any element with intrins
 
 ## Flex wrap
 
-Give the flex parent `.u-flex--wrap` too, if you want the children to wrap onto a new line when they run of space. This can be a good thing to do when you have a list of elements with intrinsic or fixed size e.g. a list of buttons, icons, or images. The result will mean the elements are allowed to flow onto the next line when there’s not enough space for them to be adjacent.
+Give the flex parent `.u-flex-wrap` too, if you want the children to wrap onto a new line when they run of space. This can be a good thing to do when you have a list of elements with intrinsic or fixed size e.g. a list of buttons, icons, or images. The result will mean the elements are allowed to flow onto the next line when there’s not enough space for them to be adjacent.
 
 Note this layout may not be so useful with elements that take all available space, like long paragraphs of text. It’s often great for buttons and images though.
 
 <Canvas isColumn>
   <Story name="Flex wrap with long content">
     {`
-      <ul class="u-flex u-flex--wrap a-list-reset">
+      <ul class="u-flex u-flex-wrap a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-flex-grow-1 u-bg--brand-2">Important content here - Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -164,7 +164,7 @@ Note this layout may not be so useful with elements that take all available spac
   </Story>
   <Story name="Flex wrap with intrinsic-width content">
     {`
-      <ul class="u-flex u-flex--wrap a-list-reset">
+      <ul class="u-flex u-flex-wrap a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li class="u-flex-grow-1 u-bg--brand-2">Important content here</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
@@ -181,7 +181,7 @@ This flex layout is ideal for laying out buttons in a row — perhaps actions at
 <Canvas>
   <Story name="Flex wrap for buttons">
     {`
-      <ul class="u-flex u-flex--wrap a-list-reset">
+      <ul class="u-flex u-flex-wrap a-list-reset">
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">An action</button></li>
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">Another action</button></li>
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">A longer-named action</button></li>
@@ -193,12 +193,12 @@ This flex layout is ideal for laying out buttons in a row — perhaps actions at
 
 ## Flex column
 
-Flex defaults to laying out children in horizontal rows. To layout items vertically in columns, use `.u-flex--col`.
+Flex defaults to laying out children in horizontal rows. To layout items vertically in columns, use `.u-flex-col`.
 
 <Canvas>
   <Story name="Flex col">
     {`
-      <ul class="u-flex u-flex--col a-list-reset">
+      <ul class="u-flex u-flex-col a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li>Text content here</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
@@ -210,12 +210,12 @@ Flex defaults to laying out children in horizontal rows. To layout items vertica
 
 ## Flex column with align-center
 
-The flex classes can be combined: use `.u-items-center` with `.u-flex--col` to get a centered column.
+The flex classes can be combined: use `.u-items-center` with `.u-flex-col` to get a centered column.
 
 <Canvas>
   <Story name="Flex col with align center">
     {`
-      <ul class="u-flex u-flex--col u-items-center a-list-reset">
+      <ul class="u-flex u-flex-col u-items-center a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li>Text content here</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -20,26 +20,44 @@ Make one of the children `.u-flex-grow-1` to make it take any available space th
 
 Apply `.u-flex-shrink-0` to a flex-child to stop it being crushed when there is not enough space for it and its siblings. This is useful with elements which have intrinsic size (e.g. images, icons), or that need to remain fully-sized (e.g. buttons).
 
-### Little text content
-
 These first examples show the layouts with a small amount of text content.
 
 <Canvas isColumn>
-  <Story name="Flex, with grow-1 child">
+  <Story name="u-flex-grow-0">
     {`
       <ul class="u-flex a-list-reset">
         <li>List item one</li>
-        <li class="u-flex-grow-1 u-bg--brand-2">Important content here</li>
+        <li class="u-flex-grow-0 u-bg--brand-2">u-flex-grow-0</li>
         <li>List item three</li>
         <li>List item four</li>
       </ul>
     `}
   </Story>
-  <Story name="Flex, with no-shrink child">
+  <Story name="u-flex-grow-1">
     {`
       <ul class="u-flex a-list-reset">
         <li>List item one</li>
-        <li class="u-flex-shrink-0"><button type="button">Don’t shrink me</button></li>
+        <li class="u-flex-grow-1 u-bg--brand-2">u-flex-grow-1</li>
+        <li>List item three</li>
+        <li>List item four</li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-shrink-0">
+    {`
+      <ul class="u-flex a-list-reset">
+        <li>List item one</li>
+        <li class="u-flex-shrink-0 u-bg--brand-2">u-flex-shrink-0</li>
+        <li>List item three</li>
+        <li>List item four</li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-shrink-1">
+    {`
+      <ul class="u-flex a-list-reset">
+        <li>List item one</li>
+        <li class="u-flex-shrink-1 u-bg--brand-2">u-flex-shrink-1</li>
         <li>List item three</li>
         <li>List item four</li>
       </ul>
@@ -47,36 +65,44 @@ These first examples show the layouts with a small amount of text content.
   </Story>
 </Canvas>
 
-### Lots of text content
-
 These next examples show how the same layouts behave with long text content.
 
 <Canvas isColumn>
-  <Story name="Flex with long content">
+  <Story name="u-flex-grow-0, long content">
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-grow-0 u-bg--brand-2">u-flex-grow-0. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
     `}
   </Story>
-  <Story name="Flex with long content, with grow-1 child">
+  <Story name="u-flex-grow-1, long content">
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex-grow-1 u-bg--brand-2">Important content here. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-grow-1 u-bg--brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
     `}
   </Story>
-  <Story name="Flex with long content, with shrink-0 child">
+  <Story name="u-flex-shrink-0, long content">
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex-shrink-0 u-bg--brand-2">Important content here. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-shrink-0 u-bg--brand-2">u-flex-shrink-0. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-shrink-1, long content">
+    {`
+      <ul class="u-flex a-list-reset">
+        <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-shrink-1 u-bg--brand-2">u-flex-shrink-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -89,55 +115,158 @@ These next examples show how the same layouts behave with long text content.
 And this time the same layouts, with images as content (any element with intrinsic width will behave in this way).
 
 <Canvas isColumn>
-  <Story name="Flex with intrinsic-width content">
+  <Story name="u-flex-grow-0, intrinsic-width content">
     {`
       <ul class="u-flex a-list-reset">
-        <li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li>
+        <li class="u-padding-m u-flex-grow-0 u-bg--brand-2">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+          u-flex-grow-0
+        </li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li>
-          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
-        </li>
-        <li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
       </ul>
     `}
   </Story>
-  <Story name="Flex with intrinsic-width content, with grow-1 child">
+  <Story name="u-flex-grow-1, intrinsic-width content">
     {`
       <ul class="u-flex a-list-reset">
-        <li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-flex-grow-1 u-bg--brand-2">
+        <li class="u-padding-m u-flex-grow-1 u-bg--brand-2">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+          u-flex-grow-1
+        </li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li>
-          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
-        </li>
-        <li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
       </ul>
     `}
   </Story>
-  <Story name="Flex with intrinsic-width content, with shrink-0 child">
+  <Story name="u-flex-shrink-0, intrinsic-width content">
     {`
       <ul class="u-flex a-list-reset">
-        <li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-flex-shrink-0 u-bg--brand-2">
+        <li class="u-padding-m u-flex-shrink-0 u-bg--brand-2">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+          u-flex-shrink-0
+        </li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-shrink-1, intrinsic-width content">
+    {`
+      <ul class="u-flex a-list-reset">
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m u-flex-shrink-1 u-bg--brand-2">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+          u-flex-shrink-1
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+      </ul>
+    `}
+  </Story>
+</Canvas>
+
+#### Responsiveness
+
+<Canvas isColumn>
+  <Story name="u-flex-grow-0@m, intrinsic-width content">
+    {`
+      <ul class="u-flex a-list-reset">
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m u-flex-grow-0@m u-bg--brand-2">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+          u-flex-grow-0@m
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-grow-1@m, intrinsic-width content">
+    {`
+      <ul class="u-flex a-list-reset">
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m u-flex-grow-1@m u-bg--brand-2">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+          u-flex-grow-1@m
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-shrink-0@m, intrinsic-width content">
+    {`
+      <ul class="u-flex a-list-reset">
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m u-flex-shrink-0@m u-bg--brand-2">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+          u-flex-shrink-0@m
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-shrink-1@m, intrinsic-width content">
+    {`
+      <ul class="u-flex a-list-reset">
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m u-flex-shrink-1@m u-bg--brand-2">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+          u-flex-shrink-1@m
+        </li>
+        <li class="u-padding-m">
+          <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
+        </li>
+        <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
       </ul>
@@ -147,26 +276,46 @@ And this time the same layouts, with images as content (any element with intrins
 
 ## Flex wrap
 
-Give the flex parent `.u-flex-wrap` too, if you want the children to wrap onto a new line when they run of space. This can be a good thing to do when you have a list of elements with intrinsic or fixed size e.g. a list of buttons, icons, or images. The result will mean the elements are allowed to flow onto the next line when there’s not enough space for them to be adjacent.
+Give the flex parent `.u-flex-wrap`if you want the children to wrap onto a new line when they run of space. This can be a good thing to do when you have a list of elements with intrinsic or fixed size e.g. a list of buttons, icons, or images. The elements will flow onto the next line when there’s not enough space for them to be adjacent.
 
 Note this layout may not be so useful with elements that take all available space, like long paragraphs of text. It’s often great for buttons and images though.
 
 <Canvas isColumn>
-  <Story name="Flex wrap with long content">
+  <Story name="u-flex-wrap">
     {`
       <ul class="u-flex u-flex-wrap a-list-reset">
-        <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex-grow-1 u-bg--brand-2">Important content here - Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m u-flex-grow-1 u-bg--brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
     `}
   </Story>
-  <Story name="Flex wrap with intrinsic-width content">
+  <Story name="u-flex-wrap@m">
+    {`
+      <ul class="u-flex u-flex-wrap@m a-list-reset">
+        <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m u-flex-grow-1 u-bg--brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-wrap, intrinsic-width content">
     {`
       <ul class="u-flex u-flex-wrap a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
-        <li class="u-flex-grow-1 u-bg--brand-2">Important content here</li>
+        <li class="u-flex-grow-1 u-bg--brand-2 u-padding-m">u-flex-grow-1</li>
+        <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
+        <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-wrap@m, intrinsic-width content">
+    {`
+      <ul class="u-flex u-flex-wrap@m a-list-reset">
+        <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
+        <li class="u-flex-grow-1 u-bg--brand-2 u-padding-m">u-flex-grow-1</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
       </ul>
@@ -178,10 +327,20 @@ Note this layout may not be so useful with elements that take all available spac
 
 This flex layout is ideal for laying out buttons in a row — perhaps actions at the end of a table row, or a row of buttons above a list. When combined with some margins, you get a horizontal group of buttons that collapses to a stack when the container width is too small.
 
-<Canvas>
-  <Story name="Flex wrap for buttons">
+<Canvas isColumn>
+  <Story name="u-flex-wrap, buttons">
     {`
       <ul class="u-flex u-flex-wrap a-list-reset">
+        <li class="u-margin-m-right u-margin-m-bottom"><button type="button">An action</button></li>
+        <li class="u-margin-m-right u-margin-m-bottom"><button type="button">Another action</button></li>
+        <li class="u-margin-m-right u-margin-m-bottom"><button type="button">A longer-named action</button></li>
+        <li class="u-margin-m-right u-margin-m-bottom"><button type="button">Action</button></li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-flex-wrap@m, buttons">
+    {`
+      <ul class="u-flex u-flex-wrap@m a-list-reset">
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">An action</button></li>
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">Another action</button></li>
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">A longer-named action</button></li>
@@ -195,8 +354,8 @@ This flex layout is ideal for laying out buttons in a row — perhaps actions at
 
 Flex defaults to laying out children in horizontal rows. To layout items vertically in columns, use `.u-flex-col`.
 
-<Canvas>
-  <Story name="Flex col">
+<Canvas isColumn>
+  <Story name="u-flex-col">
     {`
       <ul class="u-flex u-flex-col a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
@@ -206,16 +365,9 @@ Flex defaults to laying out children in horizontal rows. To layout items vertica
       </ul>
     `}
   </Story>
-</Canvas>
-
-## Flex column with align-center
-
-The flex classes can be combined: use `.u-items-center` with `.u-flex-col` to get a centered column.
-
-<Canvas>
-  <Story name="Flex col with align center">
+  <Story name="u-flex-col@m">
     {`
-      <ul class="u-flex u-flex-col u-items-center a-list-reset">
+      <ul class="u-flex u-flex-col@m a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li>Text content here</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
@@ -224,3 +376,4 @@ The flex classes can be combined: use `.u-items-center` with `.u-flex-col` to ge
     `}
   </Story>
 </Canvas>
+

--- a/scss/bitstyles/utilities/flex/settings.scss
+++ b/scss/bitstyles/utilities/flex/settings.scss
@@ -1,0 +1,17 @@
+$bitstyles-flex-direction: (
+  'col': column,
+  'row': row
+) !default;
+$bitstyles-flex-wrap: (
+  'wrap': wrap,
+  'nowrap': nowrap
+) !default;
+$bitstyles-flex-grow: (
+  '0': 0,
+  '1': 1
+) !default;
+$bitstyles-flex-shrink: (
+  '0': 0,
+  '1': 1
+) !default;
+$bitstyles-flex-breakpoints: ('m') !default;

--- a/scss/bitstyles/utilities/items/_.scss
+++ b/scss/bitstyles/utilities/items/_.scss
@@ -1,25 +1,18 @@
-.#{$bitstyles-namespace}u-items-center {
-  align-items: center;
-}
+@import 'settings';
 
-.#{$bitstyles-namespace}u-items-start {
-  align-items: flex-start;
-}
+@include output-properties(
+  $property-name: 'align-items',
+  $classname-root: 'items',
+  $values: $bitstyles-items
+);
 
-.#{$bitstyles-namespace}u-items-end {
-  align-items: flex-end;
-}
-
-.#{$bitstyles-namespace}u-items-stretch {
-  align-items: stretch;
-}
-
-.#{$bitstyles-namespace}u-items-baseline {
-  align-items: baseline;
-}
-
-@include media-query('m') {
-  .#{$bitstyles-namespace}u-items-center\@m {
-    align-items: center;
+@each $breakpoint-alias in $bitstyles-items-breakpoints {
+  @include media-query($breakpoint-alias) {
+    @include output-properties(
+      $property-name: 'align-items',
+      $classname-root: 'items',
+      $values: $bitstyles-items,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
   }
 }

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -1,118 +1,189 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Utilities/align-items" />
+<Meta title="Utilities/items" />
 
 # Align-items
 
 Flex and Grid share many alignment properties. These will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
 
-## Center
+Set `align-items` to center to align each flex child to the respective side(s) of the main axis:
 
-Set `align-items` to center to align each flex child to their vertical center:
-
-<Canvas>
+<Canvas isColumn>
   <Story name="items-center">
     {`
       <ul class="a-list-reset u-flex u-items-center u-fg--white">
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
-          Elements of different height.
+          u-items-center
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
-          Elements of different height.
+          u-items-center
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
-          Elements of different height.
+          u-items-center
         </li>
       </ul>
     `}
   </Story>
-</Canvas>
-
-
-## End
-
-Set `align-items` to end to align each flex child to their vertical end:
-
-<Canvas>
   <Story name="items-end">
     {`
       <ul class="a-list-reset u-flex u-items-end u-fg--white">
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
-          Elements of different height.
+          u-items-end
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
-          Elements of different height.
+          u-items-end
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
-          Elements of different height.
+          u-items-end
         </li>
       </ul>
     `}
   </Story>
-</Canvas>
-
-## Start
-
-Set `align-items` to start to align each flex child to their vertical start:
-
-<Canvas>
   <Story name="items-start">
     {`
       <ul class="a-list-reset u-flex u-items-start u-fg--white">
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
-          Elements of different height.
+          u-items-start
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
-          Elements of different height.
+          u-items-start
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
-          Elements of different height.
+          u-items-start
         </li>
       </ul>
     `}
   </Story>
-</Canvas>
-
-## Stretch
-
-Set `align-items` to stretch each flex child on their vertical axis:
-
-<Canvas>
   <Story name="items-stretch">
     {`
       <ul class="a-list-reset u-flex u-items-stretch u-fg--white" style="min-height: 10rem;">
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
-          Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o.
+          u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o.
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
-          Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o. Danish sesame snaps chocolate cake chocolate bar croissant liquorice jelly topping.
+          u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o. Danish sesame snaps chocolate cake chocolate bar croissant liquorice jelly topping.
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
-          Elements with different amounts of content.
+          u-items-stretch. Elements with different amounts of content.
         </li>
       </ul>
     `}
   </Story>
-</Canvas>
-
-## BASELINE
-
-Set `align-items` to align each flex child to the baseline:
-
-<Canvas>
   <Story name="items-baseline">
     {`
       <ul class="a-list-reset u-flex u-items-baseline u-fg--white">
         <li class="u-margin-m u-padding-m u-bg--gray-20">
-          Elements with different padding top & bottom.
+          u-items-baseline. Elements with different padding top & bottom.
         </li>
         <li class="u-margin-m u-padding-m u-padding-xl-y u-bg--gray-20">
-          Elements with different padding top & bottom.
+          u-items-baseline. Elements with different padding top & bottom.
         </li>
         <li class="u-margin-m u-padding-m-left u-padding-m-right u-padding-xl-bottom u-bg--gray-20">
-          Elements with different padding top & bottom.
+          u-items-baseline. Elements with different padding top & bottom.
         </li>
       </ul>
     `}
   </Story>
 </Canvas>
+
+## Responsive
+
+These classes are all available at the `m` breakpoint.
+
+<Canvas isColumn>
+  <Story name="items-center@m">
+    {`
+      <ul class="a-list-reset u-flex u-items-center@m u-fg--white">
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+          u-items-center
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+          u-items-center
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+          u-items-center
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="items-end@m">
+    {`
+      <ul class="a-list-reset u-flex u-items-end@m u-fg--white">
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+          u-items-end
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+          u-items-end
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+          u-items-end
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="items-start@m">
+    {`
+      <ul class="a-list-reset u-flex u-items-start@m u-fg--white">
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+          u-items-start
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+          u-items-start
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+          u-items-start
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="items-stretch@m">
+    {`
+      <ul class="a-list-reset u-flex u-items-stretch@m u-fg--white" style="min-height: 10rem;">
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+          u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o.
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+          u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o. Danish sesame snaps chocolate cake chocolate bar croissant liquorice jelly topping.
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+          u-items-stretch. Elements with different amounts of content.
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="items-baseline@m">
+    {`
+      <ul class="a-list-reset u-flex u-items-baseline@m u-fg--white">
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          u-items-baseline. Elements with different padding top & bottom.
+        </li>
+        <li class="u-margin-m u-padding-m u-padding-xl-y u-bg--gray-20">
+          u-items-baseline. Elements with different padding top & bottom.
+        </li>
+        <li class="u-margin-m u-padding-m-left u-padding-m-right u-padding-xl-bottom u-bg--gray-20">
+          u-items-baseline. Elements with different padding top & bottom.
+        </li>
+      </ul>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+The available align-items values can be customized by overriding the `$bitstyles-items` Sass variable:
+
+```scss
+$bitstyles-items: (
+  'center': center,
+  'end': flex-end,
+  'start': flex-start,
+  'stretch': stretch,
+  'baseline': baseline,
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-items-breakpoints` variable:
+
+```scss
+$bitstyles-items-breakpoints: ('m');
+```

--- a/scss/bitstyles/utilities/items/settings.scss
+++ b/scss/bitstyles/utilities/items/settings.scss
@@ -1,0 +1,8 @@
+$bitstyles-items: (
+  'center': center,
+  'end': flex-end,
+  'start': flex-start,
+  'stretch': stretch,
+  'baseline': baseline,
+) !default;
+$bitstyles-items-breakpoints: ('m') !default;

--- a/scss/bitstyles/utilities/justify/_.scss
+++ b/scss/bitstyles/utilities/justify/_.scss
@@ -1,13 +1,18 @@
-.#{$bitstyles-namespace}u-justify-between {
-  justify-content: space-between;
-}
+@import 'settings';
 
-.#{$bitstyles-namespace}u-justify-end {
-  justify-content: flex-end;
-}
+@include output-properties(
+  $property-name: 'justify-content',
+  $classname-root: 'justify',
+  $values: $bitstyles-justify
+);
 
-@include media-query('m') {
-  .#{$bitstyles-namespace}u-justify-between\@m {
-    justify-content: space-between;
+@each $breakpoint-alias in $bitstyles-justify-breakpoints {
+  @include media-query($breakpoint-alias) {
+    @include output-properties(
+      $property-name: 'justify-content',
+      $classname-root: 'justify',
+      $values: $bitstyles-justify,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
   }
 }

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -1,45 +1,109 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Utilities/justify-items" />
+<Meta title="Utilities/justify" />
 
-# Justify-items
+# Justify
 
 Flex and Grid share many alignment properties. These will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
 
-### Between
+Set `justify-content` to align flex children to the respecitve different edges on the cross-axis. This only affects layout when the combined elements are smaller than the available cross-axis:
 
-Set `justify-content` to align flex children to the edges on the cross-axis. This only affects layout when the elements are less wide than the available width:
-
-<Canvas>
+<Canvas isColumn>
   <Story name="justify-between">
     {`
       <ul class="a-list-reset u-flex u-justify-between u-fg--white" style="min-height:10rem;">
         <li class="u-margin-m u-padding-m u-bg--gray-20">
-          Elements which leave space.
+          Between
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20">
-          Elements which leave space.
+          Between
         </li>
       </ul>
     `}
   </Story>
-</Canvas>
-
-### End
-
-Set `justify-content` to align flex children to the end on the cross-axis. This only affects layout when the elements are less wide than the available width:
-
-<Canvas>
+  <Story name="justify-start">
+    {`
+      <ul class="a-list-reset u-flex u-justify-start u-fg--white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          Start
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          Start
+        </li>
+      </ul>
+    `}
+  </Story>
   <Story name="justify-end">
     {`
       <ul class="a-list-reset u-flex u-justify-end u-fg--white" style="min-height:10rem;">
         <li class="u-margin-m u-padding-m u-bg--gray-20">
-          Elements which leave space.
+          End
         </li>
         <li class="u-margin-m u-padding-m u-bg--gray-20">
-          Elements which leave space.
+          End
         </li>
       </ul>
     `}
   </Story>
 </Canvas>
+
+## Responsiveness
+
+These classes are available at the `m` breakpoint.
+
+<Canvas isColumn>
+  <Story name="justify-between@m">
+    {`
+      <ul class="a-list-reset u-flex u-justify-between@m u-fg--white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          Between
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          Between
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="justify-start@m">
+    {`
+      <ul class="a-list-reset u-flex u-justify-start@m u-fg--white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          Start
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          Start
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="justify-end@m">
+    {`
+      <ul class="a-list-reset u-flex u-justify-end@m u-fg--white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          End
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20">
+          End
+        </li>
+      </ul>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+The available justify-content values can be customized by overriding the `$bitstyles-justify` Sass variable:
+
+```scss
+$bitstyles-justify: (
+  'between': space-between,
+  'end': flex-end,
+  'start': flex-start,
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-justify-breakpoints` variable:
+
+```scss
+$bitstyles-justify-breakpoints: ('m');
+```

--- a/scss/bitstyles/utilities/justify/settings.scss
+++ b/scss/bitstyles/utilities/justify/settings.scss
@@ -1,0 +1,6 @@
+$bitstyles-justify: (
+  'between': space-between,
+  'end': flex-end,
+  'start': flex-start,
+) !default;
+$bitstyles-justify-breakpoints: ('m') !default;

--- a/scss/bitstyles/utilities/self/_.scss
+++ b/scss/bitstyles/utilities/self/_.scss
@@ -1,3 +1,18 @@
-.#{$bitstyles-namespace}u-self-end {
-  align-self: flex-end;
+@import 'settings';
+
+@include output-properties(
+  $property-name: 'align-self',
+  $classname-root: 'self',
+  $values: $bitstyles-self
+);
+
+@each $breakpoint-alias in $bitstyles-self-breakpoints {
+  @include media-query($breakpoint-alias) {
+    @include output-properties(
+      $property-name: 'align-self',
+      $classname-root: 'self',
+      $values: $bitstyles-self,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+  }
 }

--- a/scss/bitstyles/utilities/self/self.stories.mdx
+++ b/scss/bitstyles/utilities/self/self.stories.mdx
@@ -23,10 +23,52 @@ Set `align-self` to align a flex child to the flex end:
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
           Elements of different height.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20 u-self-end" style="height: 10rem;">
-          Elements of different height.
+        <li class="u-margin-m u-padding-m u-bg--brand-2 u-self-end" style="height: 10rem;">
+          u-self-end. Elements of different height.
         </li>
       </ul>
     `}
   </Story>
 </Canvas>
+
+## Responsiveness
+
+The classes are available at the `m` breakpoint.
+
+<Canvas>
+  <Story name="self-end@m">
+    {`
+      <ul class="a-list-reset u-flex u-items-start u-fg--white">
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+          Elements of different height.
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+          Elements of different height.
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+          Elements of different height.
+        </li>
+        <li class="u-margin-m u-padding-m u-bg--brand-2 u-self-end@m" style="height: 10rem;">
+          u-self-end@m. Elements of different height.
+        </li>
+      </ul>
+    `}
+  </Story>
+</Canvas>
+
+
+## Customization
+
+The available align-self values can be customized by overriding the `$bitstyles-self` Sass variable:
+
+```scss
+$bitstyles-self: (
+  'end': flex-end,
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-self-breakpoints` variable:
+
+```scss
+$bitstyles-self-breakpoints: ('m');
+```

--- a/scss/bitstyles/utilities/self/settings.scss
+++ b/scss/bitstyles/utilities/self/settings.scss
@@ -1,0 +1,4 @@
+$bitstyles-self: (
+  'end': flex-end,
+) !default;
+$bitstyles-self-breakpoints: ('m') !default;


### PR DESCRIPTION
Fixes #515 

The following changes are contained in this pull request:
- `.u-flex-`, `.u-items-`, `u-self-`, and `u-justify-` utility classes are all now generated, and consistently available at `m` breakpoint
- Updates docs & examples for flex, justify, items, and self utility classes
- Renames changed flex classnames (dropping the `__` notation

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
