### PR TITLE
[#440] Select styles break without postcss?

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -34,6 +34,16 @@ module.exports = {
         }
       },
       {
+        loader: "postcss-loader",
+        options: {
+          postcssOptions: {
+            plugins: [
+              ["autoprefixer"],
+            ],
+          },
+        }
+      },
+      {
         loader: "sass-loader"
       }],
       include: path.resolve(__dirname, '../scss'),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The `.u-align`, `.u-self`, and `.u-justify` sets of utility classes are now all available at `m` breakpoint. The available breakpoints can be customized
 - The various `.u-flex-` classes are now available at the `m` breakpoint. The available breakpoints can be customized by overriding `$bitstyles-flex-breakpoints`
 - Adds `.u-flex-nowrap` and `.u-flex-row` classes
+- Adds `url-encode-color` function to our color tools, to encode hex colors correctly
 
 ## Changed
 
@@ -21,6 +22,10 @@
 ## Docs
 
 - Adds a `Design Tokens` section to the storybook, and lists all available colors
+
+## Fixed
+
+- Selects now correctly display the icon specified as a background in Sass, even when postcss isn’t being used (note that you’ll have to deal with the prefixing of the `appearance` property, prefereably using autoprefixer)
 
 ## Breaking
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-react-hooks": "^1.7.0",
     "postcss": "^8",
     "postcss-cli": "^7.1.1",
+    "postcss-loader": "^4",
     "prettier": "^1.18.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/scss/bitstyles/base/forms/settings-checkbox.scss
+++ b/scss/bitstyles/base/forms/settings-checkbox.scss
@@ -1,3 +1,4 @@
+@use '../../tools/color';
 //
 // Base styles ////////////////////////////////////////
 $bitstyles-checkbox-border-radius: spacing('xxs') !default;
@@ -20,7 +21,7 @@ $bitstyles-checkbox-border-color-hover: palette('brand-1') !default;
 $bitstyles-checkbox-color-checked: palette('white') !default;
 $bitstyles-checkbox-background-color-checked: palette('brand-1') !default;
 $bitstyles-checkbox-border-color-checked: palette('brand-1') !default;
-$bitstyles-checkbox-background-image-checked: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='#ffffff' d='m83.07 11.71-44.41 44.59-21.73-21.81-15.93 15.99 37.65 37.81 60.35-60.59z'/%3E%3C/svg%3E") !default;
+$bitstyles-checkbox-background-image-checked: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='#{color.url-encode-color(#ffffff)}' d='m83.07 11.71-44.41 44.59-21.73-21.81-15.93 15.99 37.65 37.81 60.35-60.59z'/%3E%3C/svg%3E") !default;
 
 //
 // Disabled colors ////////////////////////////////////////

--- a/scss/bitstyles/base/forms/settings-select.scss
+++ b/scss/bitstyles/base/forms/settings-select.scss
@@ -1,3 +1,4 @@
+@use '../../tools/color';
 //
 // Base styles ////////////////////////////////////////
 $bitstyles-select-padding-vertical: spacing('xs') !default;
@@ -10,32 +11,32 @@ $bitstyles-select-color: palette('gray', '60') !default;
 $bitstyles-select-border-width: spacing('xxxs');
 $bitstyles-select-border-color: palette('gray', '10') !default;
 $bitstyles-select-background-color: palette('white') !default;
-$bitstyles-select-background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '60')}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{color.url-encode-color(palette('gray', '60'))}' d='M6.64 34.23a5.57 5.57 0 0 1 7.87-7.89L49.92 61.91 85.49 26.34a5.57 5.57 0 0 1 7.87 7.89L53.94 73.66a5.58 5.58 0 0 1-7.88 0Z'/%3E%3C/svg%3E") !default;
 
 //
 // Hover styles ////////////////////////////////////////
 $bitstyles-select-color-hover: palette('gray', '80') !default;
 $bitstyles-select-border-color-hover: palette('gray', '60') !default;
 $bitstyles-select-background-color-hover: palette('gray', '1') !default;
-$bitstyles-select-background-image-hover: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{$bitstyles-select-color-hover}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-image-hover: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{color.url-encode-color($bitstyles-select-color-hover)}' d='M6.64 34.23a5.57 5.57 0 0 1 7.87-7.89L49.92 61.91 85.49 26.34a5.57 5.57 0 0 1 7.87 7.89L53.94 73.66a5.58 5.58 0 0 1-7.88 0Z'/%3E%3C/svg%3E") !default;
 
 //
 // Active styles ////////////////////////////////////////
 $bitstyles-select-color-active: palette('gray', '80') !default;
 $bitstyles-select-border-color-active: palette('gray', '80') !default;
 $bitstyles-select-background-color-active: transparent !default;
-$bitstyles-select-background-image-active: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '80')}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-image-active: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{color.url-encode-color(palette('gray', '80'))}' d='M6.64 34.23a5.57 5.57 0 0 1 7.87-7.89L49.92 61.91 85.49 26.34a5.57 5.57 0 0 1 7.87 7.89L53.94 73.66a5.58 5.58 0 0 1-7.88 0Z'/%3E%3C/svg%3E") !default;
 
 //
 // Invalid styles ////////////////////////////////////////
 $bitstyles-select-color-invalid: palette('warning') !default;
 $bitstyles-select-border-color-invalid: palette('warning') !default;
 $bitstyles-select-background-color-invalid: palette('white') !default;
-$bitstyles-select-background-image-invalid: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('warning')}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-image-invalid: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{color.url-encode-color(palette('warning'))}' d='M6.64 34.23a5.57 5.57 0 0 1 7.87-7.89L49.92 61.91 85.49 26.34a5.57 5.57 0 0 1 7.87 7.89L53.94 73.66a5.58 5.58 0 0 1-7.88 0Z'/%3E%3C/svg%3E") !default;
 
 //
 // Disabled styles ////////////////////////////////////////
 $bitstyles-select-color-disabled: palette('text') !default;
 $bitstyles-select-border-color-disabled: palette('black', '20') !default;
 $bitstyles-select-background-color-disabled: palette('black', '10') !default;
-$bitstyles-select-background-image-disabled: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{palette('gray', '50')}' d='M6.64,34.23a5.57,5.57,0,0,1,7.87-7.89L49.92,61.91,85.49,26.34a5.57,5.57,0,0,1,7.87,7.89L53.94,73.66a5.58,5.58,0,0,1-7.88,0Z'/%3E%3C/svg%3E") !default;
+$bitstyles-select-background-image-disabled: url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='#{color.url-encode-color(palette('gray', '50'))}' d='M6.64 34.23a5.57 5.57 0 0 1 7.87-7.89L49.92 61.91 85.49 26.34a5.57 5.57 0 0 1 7.87 7.89L53.94 73.66a5.58 5.58 0 0 1-7.88 0Z'/%3E%3C/svg%3E") !default;

--- a/scss/bitstyles/tools/_color.scss
+++ b/scss/bitstyles/tools/_color.scss
@@ -1,5 +1,8 @@
-@use "sass:map";
-@use "sass:math";
+@use 'sass:color';
+@use 'sass:map';
+@use 'sass:math';
+@use 'sass:meta';
+@use 'sass:string';
 
 // Generate palette
 //
@@ -15,7 +18,7 @@
   $color-map: ();
 
   @each $percentage in $percentages {
-    $color-map: map.merge($color-map, ('#{$percentage}': mix($mix-color, $base-color, 100% - percentage(math.div($percentage, 100)))));
+    $color-map: map.merge($color-map, ('#{$percentage}': color.mix($mix-color, $base-color, 100% - math.percentage(math.div($percentage, 100)))));
   }
 
   @return $color-map;
@@ -33,11 +36,11 @@
 
 // stylelint-disable at-rule-no-unknown
 @function palette($color, $percent: '100') {
-  @if map-has-key($bitstyles-color-palette, $color) {
-    $palette: map-get($bitstyles-color-palette, $color);
+  @if map.has-key($bitstyles-color-palette, $color) {
+    $palette: map.get($bitstyles-color-palette, $color);
 
-    @if map-has-key($palette, $percent) {
-      @return map-get($palette, $percent);
+    @if map.has-key($palette, $percent) {
+      @return map.get($palette, $percent);
     }
 
     @else {
@@ -50,3 +53,11 @@
   }
 }
 // stylelint-enable at-rule-no-unknown
+
+@function url-encode-color($color) {
+  @if meta.type-of($color) == 'color' and string.index(#{$color}, '#') == 1 {
+    @return '%23' + string.unquote('#{string.slice(#{$color}, 2)}');
+  }
+
+  @return $string;
+}

--- a/scss/bitstyles/tools/_select.scss
+++ b/scss/bitstyles/tools/_select.scss
@@ -45,7 +45,7 @@
     color: $bitstyles-select-color-invalid;
     background-color: $bitstyles-select-background-color-invalid;
     background-image: $bitstyles-select-background-image-invalid;
-    border: $bitstyles-select-border-color-invalid;
+    border-color: $bitstyles-select-border-color-invalid;
   }
 
   &[disabled] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9432,7 +9432,7 @@ postcss-load-config@^2.0.0:
     cosmiconfig "^5.0.0"
     import-cwd "^2.0.0"
 
-postcss-loader@^4.2.0:
+postcss-loader@^4, postcss-loader@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-4.3.0.tgz#2c4de9657cd4f07af5ab42bd60a673004da1b8cc"
   integrity sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==


### PR DESCRIPTION
Fixes #440 

The following changes are contained in this pull request:

- Adds postcss-loader so we can use autoprefixer (it should be included in every project for browser-compatibility)
- Adds a function to tools.color to URL-encode hex colors
- Uses it to fix the URL-encoded SVGs used for the `<select>` arrows, and for checkboxes’ ✔
- All our color functions now use namespaced sass functions

Now even when post-css is not being used to build bitstyles, the select icons are visible, so the bug is fixed.

⚠️ without post-css (and therefore autoprefixer), the `appearance` property isn’t prefixed to `-webkit-appearance`, and therefore the browser’s built-in icon and ui-chrome may be visible next to ours, as shown here:

|Before|After|
|--|--|
|![before](https://user-images.githubusercontent.com/2479422/125269473-04d1c800-e309-11eb-81f1-d7b8e6547eb9.png)|![after](https://user-images.githubusercontent.com/2479422/125268607-254d5280-e308-11eb-9588-e87fe3e12176.png)|


Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
