### PR TITLE
[#527] Login form with errors wrong spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,19 @@
 
 ## Unreleased
 
-# Added
+### Added
 
 - The breakpoints at which `.a-card` is output can now be specified with the `$bitstyles-card-breakpoints` Sass variable. Default is at `m`, and `l` breakpoints
 - Padding for `.a-card`s is specifiable with the `$bitstyles-card-sizes` Sass variable. By default there is a base size, and a large size
 - A new `.a-card__header` element allows edge-to-edge header sections for cards of all sizes
 
-# Fixed
+### Fixed
 
 - `.u-col-span-` and `.u-col-start-` classes are available at `@l` breakpoint again. Fixes the complex form example
+
+### Breaking
+
+- As `.a-card` elements now set their own padding, remove any utility padding classes. If the padding does not match your requirements, it can be customized using the cards’ sass variables
 
 ## [[3.0.0-rc.2]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0-rc.2) - 2021-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Breaking
 
 - As `.a-card` elements now set their own padding, remove any utility padding classes. If the padding does not match your requirements, it can be customized using the cards’ sass variables
+- If you output any flashes or other content at the top of an `.a-card` element using negative-margin utility classes to cancel out the padding, these classes shuld now be replaced with the `.a-card__header` class
 
 ## [[3.0.0-rc.2]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0-rc.2) - 2021-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+# Added
+
+- The breakpoints at which `.a-card` is output can now be specified with the `$bitstyles-card-breakpoints` Sass variable. Default is at `m`, and `l` breakpoints
+- Padding for `.a-card`s is specifiable with the `$bitstyles-card-sizes` Sass variable. By default there is a base size, and a large size
+- A new `.a-card__header` element allows edge-to-edge header sections for cards of all sizes
+
+# Fixed
+
+- `.u-col-span-` and `.u-col-start-` classes are available at `@l` breakpoint again. Fixes the complex form example
+
 ## [[3.0.0-rc.2]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0-rc.2) - 2021-09-06
 
 ### Fixed
@@ -20,7 +32,6 @@
 
 ### Added
 
-- The breakpoints at which `.a-card` is output can now be specified with the `$bitstyles-card-breakpoints` Sass variable. Default is at `m`, and `l` breakpoints
 - Added `$bitstyles-grays-hint-color-mix` and `$bitstyles-grays-hint-color` variables to allow control over how the `gray` color palette is generated
 - Added `$bitstyles-color-mix-percentages` list variable, giving control over which percentage intervals are generated in each color’s palette
 - There’s now the `generate-palette($base-color, $mix-color, $percentages)` function to automate generating palettes of individual colors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Added
 
-- The breakpoints at which `.a-card` is output can now be specified with the `$bitstyles-card-breakpoints` Sass variable. Default is at `m`, and `l` breakpoints
 - Padding for `.a-card`s is specifiable with the `$bitstyles-card-sizes` Sass variable. By default there is a base size, and a large size
 - A new `.a-card__header` element allows edge-to-edge header sections for cards of all sizes
 
@@ -15,9 +14,13 @@
 ### Breaking
 
 - As `.a-card` elements now set their own padding, remove any utility padding classes. If the padding does not match your requirements, it can be customized using the cards’ sass variables
-- If you output any flashes or other content at the top of an `.a-card` element using negative-margin utility classes to cancel out the padding, these classes shuld now be replaced with the `.a-card__header` class
+- If you output any flashes or other content at the top of an `.a-card` element using negative-margin utility classes to cancel out the padding, these classes should now be replaced with the `.a-card__header` class
 
 ## [[3.0.0-rc.2]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0-rc.2) - 2021-09-06
+
+### Added
+
+- The breakpoints at which `.a-card` is output can now be specified with the `$bitstyles-card-breakpoints` Sass variable. Default is at `m`, and `l` breakpoints
 
 ### Fixed
 

--- a/scss/bitstyles/atoms/card/_card.scss
+++ b/scss/bitstyles/atoms/card/_card.scss
@@ -1,19 +1,50 @@
+@use 'sass:map';
+@use 'sass:math';
 @use './settings';
 @use '../../tools/directional-properties';
 @use '../../tools/media-query';
 
-@mixin card {
-  padding: settings.$padding;
+@mixin card($padding) {
+  padding: $padding;
   overflow: hidden;
   border-radius: settings.$border-radius;
   box-shadow: settings.$box-shadow;
+}
+
+@mixin card__header($spacing) {
+  margin: (- $spacing) (- $spacing) math.div($spacing, 2);
+  padding: math.div($spacing, 2) $spacing;
+  background-color: settings.$header-background-color;
 }
 
 @include directional-properties.output-block(
   $object-level: 'a',
   $classname-root: 'card'
 ) {
-  @include card;
+  @include card(map.get(settings.$sizes, 'base'));
+}
+
+@include directional-properties.output-block(
+  $object-level: 'a',
+  $classname-root: 'card__header'
+) {
+  @include card__header(map.get(settings.$sizes, 'base'));
+}
+
+@each $size-name, $padding-size in map.remove(settings.$sizes, 'base') {
+  @include directional-properties.output-block(
+    $object-level: 'a',
+    $classname-root: 'card--#{$size-name}'
+  ) {
+    @include card($padding-size);
+  }
+
+  @include directional-properties.output-block(
+    $object-level: 'a',
+    $classname-root: 'card--#{$size-name}__header'
+  ) {
+    @include card__header($padding-size);
+  }
 }
 
 @each $breakpoint-alias in settings.$breakpoints {
@@ -23,7 +54,32 @@
       $classname-root: 'card',
       $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
     ) {
-      @include card;
+      @include card(map.get(settings.$sizes, 'base'));
+    }
+
+    @include directional-properties.output-block(
+      $object-level: 'a',
+      $classname-root: 'card__header',
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    ) {
+      @include card__header(map.get(settings.$sizes, 'base'));
+    }
+    @each $size-name, $padding-size in settings.$sizes {
+      @include directional-properties.output-block(
+        $object-level: 'a',
+        $classname-root: 'card--#{$size-name}',
+        $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+      ) {
+        @include card($padding-size);
+      }
+
+      @include directional-properties.output-block(
+        $object-level: 'a',
+        $classname-root: 'card--#{$size-name}__header',
+        $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+      ) {
+        @include card__header($padding-size);
+      }
     }
   }
 }

--- a/scss/bitstyles/atoms/card/_card.scss
+++ b/scss/bitstyles/atoms/card/_card.scss
@@ -4,8 +4,6 @@
 @use '../../tools/directional-properties';
 @use '../../tools/media-query';
 
-$reduced-card-sizes: map.remove($bitstyles-card-sizes, 'base');
-
 @mixin card($padding) {
   padding: $padding;
   overflow: hidden;
@@ -19,31 +17,27 @@ $reduced-card-sizes: map.remove($bitstyles-card-sizes, 'base');
   background-color: settings.$header-background-color;
 }
 
-@include directional-properties.output-block(
-  $object-level: 'a',
-  $classname-root: 'card'
-) {
-  @include card(map.get(settings.$sizes, 'base'));
+@function modifier-name($name) {
+  @if $name == 'base' {
+    @return '';
+  } @else {
+    @return '-#{$name}';
+  }
 }
 
-@include directional-properties.output-block(
-  $object-level: 'a',
-  $classname-root: 'card__header'
-) {
-  @include card__header(map.get(settings.$sizes, 'base'));
-}
+@each $size, $padding-size in settings.$sizes {
+  $size-name: modifier-name($size);
 
-@each $size-name, $padding-size in $reduced-card-sizes {
   @include directional-properties.output-block(
     $object-level: 'a',
-    $classname-root: 'card-#{$size-name}'
+    $classname-root: 'card#{$size-name}'
   ) {
     @include card($padding-size);
   }
 
   @include directional-properties.output-block(
     $object-level: 'a',
-    $classname-root: 'card-#{$size-name}__header'
+    $classname-root: 'card#{$size-name}__header'
   ) {
     @include card__header($padding-size);
   }
@@ -51,25 +45,12 @@ $reduced-card-sizes: map.remove($bitstyles-card-sizes, 'base');
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.media-query($breakpoint-alias) {
-    @include directional-properties.output-block(
-      $object-level: 'a',
-      $classname-root: 'card',
-      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
-    ) {
-      @include card(map.get(settings.$sizes, 'base'));
-    }
+    @each $size, $padding-size in settings.$sizes {
+      $size-name: modifier-name($size);
 
-    @include directional-properties.output-block(
-      $object-level: 'a',
-      $classname-root: 'card__header',
-      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
-    ) {
-      @include card__header(map.get(settings.$sizes, 'base'));
-    }
-    @each $size-name, $padding-size in $reduced-card-sizes {
       @include directional-properties.output-block(
         $object-level: 'a',
-        $classname-root: 'card-#{$size-name}',
+        $classname-root: 'card#{$size-name}',
         $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
       ) {
         @include card($padding-size);
@@ -77,7 +58,7 @@ $reduced-card-sizes: map.remove($bitstyles-card-sizes, 'base');
 
       @include directional-properties.output-block(
         $object-level: 'a',
-        $classname-root: 'card-#{$size-name}__header',
+        $classname-root: 'card#{$size-name}__header',
         $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
       ) {
         @include card__header($padding-size);

--- a/scss/bitstyles/atoms/card/_card.scss
+++ b/scss/bitstyles/atoms/card/_card.scss
@@ -12,7 +12,7 @@
 }
 
 @mixin card__header($spacing) {
-  margin: (- $spacing) (- $spacing) math.div($spacing, 2);
+  margin: (- $spacing) (- $spacing) $spacing;
   padding: math.div($spacing, 2) $spacing;
   background-color: settings.$header-background-color;
 }

--- a/scss/bitstyles/atoms/card/_card.scss
+++ b/scss/bitstyles/atoms/card/_card.scss
@@ -4,6 +4,8 @@
 @use '../../tools/directional-properties';
 @use '../../tools/media-query';
 
+$reduced-card-sizes: map.remove($bitstyles-card-sizes, 'base');
+
 @mixin card($padding) {
   padding: $padding;
   overflow: hidden;
@@ -31,17 +33,17 @@
   @include card__header(map.get(settings.$sizes, 'base'));
 }
 
-@each $size-name, $padding-size in map.remove(settings.$sizes, 'base') {
+@each $size-name, $padding-size in $reduced-card-sizes {
   @include directional-properties.output-block(
     $object-level: 'a',
-    $classname-root: 'card--#{$size-name}'
+    $classname-root: 'card-#{$size-name}'
   ) {
     @include card($padding-size);
   }
 
   @include directional-properties.output-block(
     $object-level: 'a',
-    $classname-root: 'card--#{$size-name}__header'
+    $classname-root: 'card-#{$size-name}__header'
   ) {
     @include card__header($padding-size);
   }
@@ -64,10 +66,10 @@
     ) {
       @include card__header(map.get(settings.$sizes, 'base'));
     }
-    @each $size-name, $padding-size in settings.$sizes {
+    @each $size-name, $padding-size in $reduced-card-sizes {
       @include directional-properties.output-block(
         $object-level: 'a',
-        $classname-root: 'card--#{$size-name}',
+        $classname-root: 'card-#{$size-name}',
         $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
       ) {
         @include card($padding-size);
@@ -75,7 +77,7 @@
 
       @include directional-properties.output-block(
         $object-level: 'a',
-        $classname-root: 'card--#{$size-name}__header',
+        $classname-root: 'card-#{$size-name}__header',
         $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
       ) {
         @include card__header($padding-size);

--- a/scss/bitstyles/atoms/card/_settings.scss
+++ b/scss/bitstyles/atoms/card/_settings.scss
@@ -1,10 +1,14 @@
 @use '../../tools/palette';
 @use '../../tools/size';
 
-$padding: size.get('m') !default;
+$sizes: (
+  'base': size.get('m'),
+  'l': size.get('xl'),
+) !default;
 $border-radius: size.get('m') !default;
 $box-shadow:
   0 size.get('xs') size.get('m') rgba(palette.get('brand-1', '100'), 0.1),
   0 size.get('xxxs') size.get('xxs') rgba(palette.get('gray', '90'), 0.04),
   0 0 size.get('xxs') rgba(palette.get('gray', '90'), 0.1) !default;
 $breakpoints: ('m', 'l') !default;
+$header-background-color: palette.get('gray', '1');

--- a/scss/bitstyles/atoms/card/_settings.scss
+++ b/scss/bitstyles/atoms/card/_settings.scss
@@ -11,4 +11,4 @@ $box-shadow:
   0 size.get('xxxs') size.get('xxs') rgba(palette.get('gray', '90'), 0.04),
   0 0 size.get('xxs') rgba(palette.get('gray', '90'), 0.1) !default;
 $breakpoints: ('m', 'l') !default;
-$header-background-color: palette.get('gray', '1');
+$header-background-color: palette.get('gray', '1') !default;

--- a/scss/bitstyles/atoms/card/card.stories.mdx
+++ b/scss/bitstyles/atoms/card/card.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Card
 
-A content wrapper that sections and subtly highlights a chunk of content. The default, small version is ideal for smaller chunks.
+A content wrapper that sections and subtly highlights a chunk of content. At larger screensizes, this element will get more padding to give the content space to breathe.
 
 <Canvas>
   <Story name="Card">
@@ -33,22 +33,24 @@ A content wrapper that sections and subtly highlights a chunk of content. The de
   </Story>
 </Canvas>
 
+## Fullbleed headers
 
-For larger blocks of content, use a padding utility class to give the content more space to breathe:
+It is common to present important content edge-to-edge, using `.a-card__header`:
 
 <Canvas>
-  <Story name="Card [padding-m]">
+  <Story name="a-card__header">
     {`
-      <article class="a-card u-padding-xl">
+    <div class="u-grid u-grid-cols-2@m u-gap-m">
+      <article class="a-card">
+        <div class="a-card__header a-flash a-flash--danger">
+          Something happened
+        </div>
         <h3>Recent activity</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
-          <li>User one changed title to “In progress” [8 mins ago]</li>
-          <li>User one changed date to 01.01.2021 [3 days ago]</li>
-          <li>User one changed date to 01.01.2021 [5 weeks ago]</li>
-          <li>User one changed date to 01.01.2021 [1 month ago]</li>
         </ul>
       </article>
+    </div>
     `}
   </Story>
 </Canvas>

--- a/scss/bitstyles/atoms/card/card.stories.mdx
+++ b/scss/bitstyles/atoms/card/card.stories.mdx
@@ -4,26 +4,44 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Card
 
-A content wrapper that sections and subtly highlights a chunk of content. At larger screensizes, this element will get more padding to give the content space to breathe.
+A content wrapper that sections and subtly highlights a chunk of content. For larger cards, use the larger `l` size to give the content space to breathe.
 
 <Canvas>
-  <Story name="Card">
+  <Story name="card">
     {`
     <div class="u-grid u-grid-cols-3@m u-gap-m">
       <article class="a-card">
-        <h3>Recent activity</h3>
+        <h3>Standard card</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
       <article class="a-card">
-        <h3>Recent activity</h3>
+        <h3>Standard card</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
       <article class="a-card">
-        <h3>Recent activity</h3>
+        <h3>Standard card</h3>
+        <ul class="a-list-reset">
+          <li>User one changed date to 01.01.2021 [5 mins ago]</li>
+        </ul>
+      </article>
+    </div>
+    `}
+  </Story>
+  <Story name="card--l">
+    {`
+    <div class="u-grid u-grid-cols-2@m u-gap-m">
+      <article class="a-card--l">
+        <h3>Large card</h3>
+        <ul class="a-list-reset">
+          <li>User one changed date to 01.01.2021 [5 mins ago]</li>
+        </ul>
+      </article>
+      <article class="a-card--l">
+        <h3>Large card</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
@@ -37,7 +55,7 @@ A content wrapper that sections and subtly highlights a chunk of content. At lar
 
 It is common to present important content edge-to-edge, using `.a-card__header`:
 
-<Canvas>
+<Canvas isColumn>
   <Story name="a-card__header">
     {`
     <div class="u-grid u-grid-cols-2@m u-gap-m">
@@ -45,12 +63,25 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
         <div class="a-card__header a-flash a-flash--danger">
           Something happened
         </div>
-        <h3>Recent activity</h3>
+        <h3>Card with header</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
     </div>
+    `}
+  </Story>
+  <Story name="a-card--l__header">
+    {`
+    <article class="a-card--l">
+      <div class="a-card--l__header a-flash a-flash--danger">
+        Something happened
+      </div>
+      <h3>Large card with header</h3>
+      <ul class="a-list-reset">
+        <li>User one changed date to 01.01.2021 [5 mins ago]</li>
+      </ul>
+    </article>
     `}
   </Story>
 </Canvas>

--- a/scss/bitstyles/atoms/card/card.stories.mdx
+++ b/scss/bitstyles/atoms/card/card.stories.mdx
@@ -7,7 +7,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 A content wrapper that sections and subtly highlights a chunk of content. For larger cards, use the larger `l` size to give the content space to breathe.
 
 <Canvas>
-  <Story name="card">
+  <Story name="Card">
     {`
     <div class="u-grid u-grid-cols-3@m u-gap-m">
       <article class="a-card">
@@ -31,16 +31,16 @@ A content wrapper that sections and subtly highlights a chunk of content. For la
     </div>
     `}
   </Story>
-  <Story name="card--l">
+  <Story name="Card-L">
     {`
     <div class="u-grid u-grid-cols-2@m u-gap-m">
-      <article class="a-card--l">
+      <article class="a-card-l">
         <h3>Large card</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
-      <article class="a-card--l">
+      <article class="a-card-l">
         <h3>Large card</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
@@ -56,7 +56,7 @@ A content wrapper that sections and subtly highlights a chunk of content. For la
 It is common to present important content edge-to-edge, using `.a-card__header`:
 
 <Canvas isColumn>
-  <Story name="a-card__header">
+  <Story name="Card header">
     {`
     <div class="u-grid u-grid-cols-2@m u-gap-m">
       <article class="a-card">
@@ -71,10 +71,10 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
     </div>
     `}
   </Story>
-  <Story name="a-card--l__header">
+  <Story name="Card-L header">
     {`
-    <article class="a-card--l">
-      <div class="a-card--l__header a-flash a-flash--danger">
+    <article class="a-card-l">
+      <div class="a-card-l__header a-flash a-flash--danger">
         Something happened
       </div>
       <h3>Large card with header</h3>
@@ -88,10 +88,10 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
 
 ## Responsive
 
-The `.a-card` classes are available at `m` and `l` breakpoints by default.
+The `.a-card` classes are available at `m` and `l` breakpoints by default, including all the sizes of card.
 
 <Canvas>
-  <Story name="a-card@m">
+  <Story name="Card [m breakpoint]">
     {`
       <article class="a-card@m">
         <h3>Recent activity (a-card@m)</h3>
@@ -101,9 +101,29 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default.
       </article>
     `}
   </Story>
-  <Story name="a-card@l">
+  <Story name="Card [l breakpoint]">
     {`
       <article class="a-card@l">
+        <h3>Recent activity (a-card@l)</h3>
+        <ul class="a-list-reset">
+          <li>User one changed date to 01.01.2021 [5 mins ago]</li>
+        </ul>
+      </article>
+    `}
+  </Story>
+  <Story name="Card-L [m breakpoint]">
+    {`
+      <article class="a-card-l@m">
+        <h3>Recent activity (a-card@m)</h3>
+        <ul class="a-list-reset">
+          <li>User one changed date to 01.01.2021 [5 mins ago]</li>
+        </ul>
+      </article>
+    `}
+  </Story>
+  <Story name="Card-L [l breakpoint]">
+    {`
+      <article class="a-card-l@l">
         <h3>Recent activity (a-card@l)</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
@@ -118,7 +138,10 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default.
 Card appearance can be customized by overriding the following variables:
 
 ```scss
-$bitstyles-card-padding: spacing('m');
+$bitstyles-card-sizes: (
+  'base': spacing('m'),
+  'l': spacing('xl'),
+);
 $bitstyles-card-border-radius: spacing('m');
 $bitstyles-card-box-shadow:
   0 spacing('xs') spacing('m') rgba(palette('brand-1', '100'), 0.1),

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -37,7 +37,7 @@ Here are some examples using the grid utility classes to create common form layo
   <Story name="Login form">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card--l@m u-bg--white" method="POST" action="">
+        <form class="a-card-l@m u-bg--white" method="POST" action="">
           <h2>Login</h2>
           <ul class="a-list-reset u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
@@ -80,8 +80,8 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
   <Story name="Login form with errors">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card--l@m u-bg--white" method="POST" action="">
-          <div class="a-card--l__header@m a-flash a-flash--warning" role="alert">
+        <form class="a-card-l@m u-bg--white" method="POST" action="">
+          <div class="a-card-l__header@m a-flash a-flash--warning" role="alert">
             <div class="u-flex u-items-center">
               <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-exclamation"></use>
@@ -126,7 +126,7 @@ This form has the commonly-required fields for creating an account. Note the wor
   <Story name="Sign up form">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card--l@m u-bg--white" method="POST" action="">
+        <form class="a-card-l@m u-bg--white" method="POST" action="">
           <h2>Create an account</h2>
           <ul class="a-list-reset u-margin-xl-bottom">
             <li class="u-margin-m-bottom">

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -80,9 +80,9 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
   <Story name="Login form with errors">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card@m u-padding-xl@m" method="POST" action="">
-          <div class="u-padding-l-y u-margin-neg-m u-margin-neg-xl@m u-margin-l-bottom@m a-flash a-flash--warning" role="alert">
-            <div class="a-content u-flex u-items-center">
+        <form class="a-card--l@m" method="POST" action="">
+          <div class="a-card--l__header@m a-flash a-flash--warning" role="alert">
+            <div class="u-flex u-items-center">
               <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-exclamation"></use>
               </svg>

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -37,8 +37,8 @@ Here are some examples using the grid utility classes to create common form layo
   <Story name="Login form">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card@m u-padding-xl@m" method="POST" action="">
-          <h3>Login</h3>
+        <form class="a-card--l@m u-bg--white" method="POST" action="">
+          <h2>Login</h2>
           <ul class="a-list-reset u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
               <label for="email">Email</label>
@@ -80,7 +80,7 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
   <Story name="Login form with errors">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card--l@m" method="POST" action="">
+        <form class="a-card--l@m u-bg--white" method="POST" action="">
           <div class="a-card--l__header@m a-flash a-flash--warning" role="alert">
             <div class="u-flex u-items-center">
               <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -89,7 +89,7 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
               There was a problem logging in
             </div>
           </div>
-          <h3>Login</h3>
+          <h2>Login</h2>
           <ul class="a-list-reset u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
               <label for="email">Email</label>
@@ -126,8 +126,8 @@ This form has the commonly-required fields for creating an account. Note the wor
   <Story name="Sign up form">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card@m u-padding-xl@m" method="POST" action="">
-          <h3>Create an account</h3>
+        <form class="a-card--l@m u-bg--white" method="POST" action="">
+          <h2>Create an account</h2>
           <ul class="a-list-reset u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
               <label for="email">Email</label>

--- a/scss/bitstyles/utilities/col-span/_settings.scss
+++ b/scss/bitstyles/utilities/col-span/_settings.scss
@@ -6,4 +6,4 @@ $values: (
   '5': span 5 / span 5,
   '6': span 6 / span 6
 ) !default;
-$breakpoints: ('s', 'm', 'xl') !default;
+$breakpoints: ('s', 'm', 'l', 'xl') !default;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1156,6 +1156,23 @@ table {
   box-shadow: 0 5rem 10rem rgba(0, 0, 0, 0.1),
     0 1.25rem 2.5rem rgba(0, 0, 0, 0.04), 0 0 2.5rem rgba(0, 0, 0, 0.1);
 }
+.bs-a-card__header {
+  margin: -10rem -10rem 10rem;
+  padding: 5rem 10rem;
+  background-color: #000;
+}
+.bs-a-card-s {
+  padding: 20rem;
+  overflow: hidden;
+  border-radius: 10rem;
+  box-shadow: 0 5rem 10rem rgba(0, 0, 0, 0.1),
+    0 1.25rem 2.5rem rgba(0, 0, 0, 0.04), 0 0 2.5rem rgba(0, 0, 0, 0.1);
+}
+.bs-a-card-s__header {
+  margin: -20rem -20rem 20rem;
+  padding: 10rem 20rem;
+  background-color: #000;
+}
 @media screen and (min-width: 30em) {
   .bs-a-card\@m {
     padding: 10rem;
@@ -1163,6 +1180,23 @@ table {
     border-radius: 10rem;
     box-shadow: 0 5rem 10rem rgba(0, 0, 0, 0.1),
       0 1.25rem 2.5rem rgba(0, 0, 0, 0.04), 0 0 2.5rem rgba(0, 0, 0, 0.1);
+  }
+  .bs-a-card__header\@m {
+    margin: -10rem -10rem 10rem;
+    padding: 5rem 10rem;
+    background-color: #000;
+  }
+  .bs-a-card-s\@m {
+    padding: 20rem;
+    overflow: hidden;
+    border-radius: 10rem;
+    box-shadow: 0 5rem 10rem rgba(0, 0, 0, 0.1),
+      0 1.25rem 2.5rem rgba(0, 0, 0, 0.04), 0 0 2.5rem rgba(0, 0, 0, 0.1);
+  }
+  .bs-a-card-s__header\@m {
+    margin: -20rem -20rem 20rem;
+    padding: 10rem 20rem;
+    background-color: #000;
   }
 }
 @media screen and (min-width: 55em) {
@@ -1172,6 +1206,23 @@ table {
     border-radius: 10rem;
     box-shadow: 0 5rem 10rem rgba(0, 0, 0, 0.1),
       0 1.25rem 2.5rem rgba(0, 0, 0, 0.04), 0 0 2.5rem rgba(0, 0, 0, 0.1);
+  }
+  .bs-a-card__header\@l {
+    margin: -10rem -10rem 10rem;
+    padding: 5rem 10rem;
+    background-color: #000;
+  }
+  .bs-a-card-s\@l {
+    padding: 20rem;
+    overflow: hidden;
+    border-radius: 10rem;
+    box-shadow: 0 5rem 10rem rgba(0, 0, 0, 0.1),
+      0 1.25rem 2.5rem rgba(0, 0, 0, 0.04), 0 0 2.5rem rgba(0, 0, 0, 0.1);
+  }
+  .bs-a-card-s__header\@l {
+    margin: -20rem -20rem 20rem;
+    padding: 10rem 20rem;
+    background-color: #000;
   }
 }
 .bsa-content {
@@ -1671,6 +1722,26 @@ table {
     grid-column: span 5 / span 5;
   }
   .bs-u-col-span-6\@m {
+    grid-column: span 6 / span 6;
+  }
+}
+@media screen and (min-width: 55em) {
+  .bs-u-col-span-1\@l {
+    grid-column: span 1 / span 1;
+  }
+  .bs-u-col-span-2\@l {
+    grid-column: span 2 / span 2;
+  }
+  .bs-u-col-span-3\@l {
+    grid-column: span 3 / span 3;
+  }
+  .bs-u-col-span-4\@l {
+    grid-column: span 4 / span 4;
+  }
+  .bs-u-col-span-5\@l {
+    grid-column: span 5 / span 5;
+  }
+  .bs-u-col-span-6\@l {
     grid-column: span 6 / span 6;
   }
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -1166,7 +1166,24 @@ table {
   box-shadow: 0 0.4rem 0.8rem rgba(0, 13, 255, 0.1),
     0 0.1rem 0.2rem rgba(23, 25, 49, 0.04), 0 0 0.2rem rgba(23, 25, 49, 0.1);
 }
-@media screen and (min-width: 30em) {
+.a-card__header {
+  margin: -0.8rem -0.8rem 0.8rem;
+  padding: 0.4rem 0.8rem;
+  background-color: #e3e4fc;
+}
+.a-card-l {
+  padding: 1.6rem;
+  overflow: hidden;
+  border-radius: 0.8rem;
+  box-shadow: 0 0.4rem 0.8rem rgba(0, 13, 255, 0.1),
+    0 0.1rem 0.2rem rgba(23, 25, 49, 0.04), 0 0 0.2rem rgba(23, 25, 49, 0.1);
+}
+.a-card-l__header {
+  margin: -1.6rem -1.6rem 1.6rem;
+  padding: 0.8rem 1.6rem;
+  background-color: #e3e4fc;
+}
+@media screen and (min-width:30em) {
   .a-card\@m {
     padding: 0.8rem;
     overflow: hidden;
@@ -1174,14 +1191,48 @@ table {
     box-shadow: 0 0.4rem 0.8rem rgba(0, 13, 255, 0.1),
       0 0.1rem 0.2rem rgba(23, 25, 49, 0.04), 0 0 0.2rem rgba(23, 25, 49, 0.1);
   }
+  .a-card__header\@m {
+    margin: -0.8rem -0.8rem 0.8rem;
+    padding: 0.4rem 0.8rem;
+    background-color: #e3e4fc;
+  }
+  .a-card-l\@m {
+    padding: 1.6rem;
+    overflow: hidden;
+    border-radius: 0.8rem;
+    box-shadow: 0 0.4rem 0.8rem rgba(0, 13, 255, 0.1),
+      0 0.1rem 0.2rem rgba(23, 25, 49, 0.04), 0 0 0.2rem rgba(23, 25, 49, 0.1);
+  }
+  .a-card-l__header\@m {
+    margin: -1.6rem -1.6rem 1.6rem;
+    padding: 0.8rem 1.6rem;
+    background-color: #e3e4fc;
+  }
 }
-@media screen and (min-width: 55em) {
+@media screen and (min-width:55em) {
   .a-card\@l {
     padding: 0.8rem;
     overflow: hidden;
     border-radius: 0.8rem;
     box-shadow: 0 0.4rem 0.8rem rgba(0, 13, 255, 0.1),
       0 0.1rem 0.2rem rgba(23, 25, 49, 0.04), 0 0 0.2rem rgba(23, 25, 49, 0.1);
+  }
+  .a-card__header\@l {
+    margin: -0.8rem -0.8rem 0.8rem;
+    padding: 0.4rem 0.8rem;
+    background-color: #e3e4fc;
+  }
+  .a-card-l\@l {
+    padding: 1.6rem;
+    overflow: hidden;
+    border-radius: 0.8rem;
+    box-shadow: 0 0.4rem 0.8rem rgba(0, 13, 255, 0.1),
+      0 0.1rem 0.2rem rgba(23, 25, 49, 0.04), 0 0 0.2rem rgba(23, 25, 49, 0.1);
+  }
+  .a-card-l__header\@l {
+    margin: -1.6rem -1.6rem 1.6rem;
+    padding: 0.8rem 1.6rem;
+    background-color: #e3e4fc;
   }
 }
 .a-content {
@@ -1690,6 +1741,26 @@ table {
     grid-column: span 5 / span 5;
   }
   .u-col-span-6\@m {
+    grid-column: span 6 / span 6;
+  }
+}
+@media screen and (min-width: 55em) {
+  .u-col-span-1\@l {
+    grid-column: span 1 / span 1;
+  }
+  .u-col-span-2\@l {
+    grid-column: span 2 / span 2;
+  }
+  .u-col-span-3\@l {
+    grid-column: span 3 / span 3;
+  }
+  .u-col-span-4\@l {
+    grid-column: span 4 / span 4;
+  }
+  .u-col-span-5\@l {
+    grid-column: span 5 / span 5;
+  }
+  .u-col-span-6\@l {
     grid-column: span 6 / span 6;
   }
 }

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -96,7 +96,7 @@ $bitstyles-button-nav-large-color-hover: #000;
 $bitstyles-button-small-padding-vertical: 10rem;
 $bitstyles-button-tab-color-hover: #000;
 $bitstyles-button-ui-color-hover: #000;
-$bitstyles-card-padding: 10rem;
+$bitstyles-card-sizes: ('base': 10rem, 's': 20rem);
 $bitstyles-content-max-width-base: 'full';
 $bitstyles-dropdown-max-height: 1rem;
 $bitstyles-flash-color: '10';

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -96,7 +96,7 @@ $bitstyles-button-nav-large-color-hover: #000;
 $bitstyles-button-small-padding-vertical: 10rem;
 $bitstyles-button-tab-color-hover: #000;
 $bitstyles-button-ui-color-hover: #000;
-$bitstyles-card-padding: 10rem;
+$bitstyles-card-sizes: ('base': 10rem, 's': 20rem);
 $bitstyles-content-max-width-base: 'full';
 $bitstyles-dropdown-max-height: 1rem;
 $bitstyles-flash-color: '10';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -90,7 +90,7 @@
   $button-small-padding-vertical: 10rem,
   $button-tab-color-hover: #000,
   $button-ui-color-hover: #000,
-  $card-padding: 10rem,
+  $card-sizes: ('base': 10rem, 's': 20rem),
   $content-max-width-base: 'full',
   $dropdown-max-height: 1rem,
   $flash-color: '10',

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -160,7 +160,7 @@
   $color-hover: #000
 );
 @use '../../scss/bitstyles/atoms/card' with (
-  $padding: 10rem
+  $sizes: ('base': 10rem, 's': 20rem)
 );
 @use '../../scss/bitstyles/atoms/content' with (
   $max-width-base: 'full'


### PR DESCRIPTION
Fixes #527

The following changes are contained in this pull request:

- padding of cards is now handled inside the atom, instead of using padding utility classes
- so there are now multiple sizes of card — each applies a different padding
- added a `a-card__header` class that’s used in combination with those paddings to ensure an edge-to-edge subsection
- all is customizable with Sass variables

🚑 drive-by: grid-related classes are available at `l` breakpoint again (fixes the more complex form next to the login form example)

|Before|After|
|--|--|
|![before](https://user-images.githubusercontent.com/2479422/126310064-a231d534-cd5f-48a0-98e2-a1026d72f2e4.png)|![after2](https://user-images.githubusercontent.com/2479422/126309817-19764634-80d7-4a6c-8e7f-7cc5b4b18681.png)|

And:
![after1](https://user-images.githubusercontent.com/2479422/126309814-364c0dbb-1807-442b-bc15-5cb41f241e67.png)


Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
