### PR TITLE
[#538] Add utility: row-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 - Padding for `.a-card`s is specifiable with the `$bitstyles-card-sizes` Sass variable. By default there is a base size, and a large size
 - A new `.a-card__header` element allows edge-to-edge header sections for cards of all sizes
+- Adds row-start utility classes `.u-row-start-x` where `x` is a number, to specify which row an element should start in
 
 ### Fixed
 
 - `.u-col-span-` and `.u-col-start-` classes are available at `@l` breakpoint again. Fixes the complex form example
+- `$bitstyles-col-span-breakpoints` variable has been corrected to `$bitstyles-col-start-breakpoints`. If you were using this variable, you’ll need to rename it
 
 ### Breaking
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -159,6 +159,7 @@
 @use 'bitstyles/utilities/padding';
 @use 'bitstyles/utilities/relative';
 @use 'bitstyles/utilities/round';
+@use 'bitstyles/utilities/row-start';
 @use 'bitstyles/utilities/self';
 @use 'bitstyles/utilities/sr-only';
 @use 'bitstyles/utilities/text';

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -68,6 +68,7 @@
 @forward 'bitstyles/utilities/justify/settings' as justify-*;
 @forward 'bitstyles/utilities/margin/settings' as margin-*;
 @forward 'bitstyles/utilities/padding/settings' as padding-*;
+@forward 'bitstyles/utilities/row-start/settings' as row-start-*;
 @forward 'bitstyles/utilities/self/settings' as self-*;
 @forward 'bitstyles/utilities/sr-only/settings' as sr-only-*;
 @forward 'bitstyles/utilities/z-index/settings' as z-index-*;

--- a/scss/bitstyles/atoms/card/_card.scss
+++ b/scss/bitstyles/atoms/card/_card.scss
@@ -12,15 +12,17 @@
 }
 
 @mixin card__header($spacing) {
-  margin: (- $spacing) (- $spacing) $spacing;
   padding: math.div($spacing, 2) $spacing;
+  margin: (- $spacing) (- $spacing) $spacing;
   background-color: settings.$header-background-color;
 }
 
 @function modifier-name($name) {
   @if $name == 'base' {
     @return '';
-  } @else {
+  }
+
+  @else {
     @return '-#{$name}';
   }
 }

--- a/scss/bitstyles/utilities/row-start/_index.import.scss
+++ b/scss/bitstyles/utilities/row-start/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-row-start-*;
+@forward 'row-start';

--- a/scss/bitstyles/utilities/row-start/_index.scss
+++ b/scss/bitstyles/utilities/row-start/_index.scss
@@ -1,0 +1,2 @@
+@forward 'settings';
+@forward 'row-start';

--- a/scss/bitstyles/utilities/row-start/_row-start.scss
+++ b/scss/bitstyles/utilities/row-start/_row-start.scss
@@ -1,0 +1,20 @@
+@use './settings.scss';
+@use '../../tools/directional-properties';
+@use '../../tools/media-query';
+
+@include directional-properties.output-properties(
+  $property-name: 'grid-row-start',
+  $classname-root: 'row-start',
+  $values: settings.$values
+);
+
+@each $breakpoint-alias in settings.$breakpoints {
+  @include media-query.media-query($breakpoint-alias) {
+    @include directional-properties.output-properties(
+      $property-name: 'grid-row-start',
+      $classname-root: 'row-start',
+      $values: settings.$values,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+  }
+}

--- a/scss/bitstyles/utilities/row-start/_settings.scss
+++ b/scss/bitstyles/utilities/row-start/_settings.scss
@@ -1,0 +1,9 @@
+$values: (
+  '1': 1,
+  '2': 2,
+  '3': 3,
+  '4': 4,
+  '5': 5,
+  '6': 6
+) !default;
+$breakpoints: ('s', 'm', 'xl') !default;

--- a/scss/bitstyles/utilities/row-start/row-start.stories.mdx
+++ b/scss/bitstyles/utilities/row-start/row-start.stories.mdx
@@ -1,82 +1,80 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Utilities/col-start" />
+<Meta title="Utilities/row-start" />
 
-# Col-start
+# Row-start
 
-Use these classes to specify which column an element should start in.
+Use these classes to specify which row an element should start in.
 
-Manually placing items in a grid normally results in unwanted gaps, as the following automatically-placed grid children continue from where you placed it. You could avoid this by applying other col-start classes to every grid child to manually place each one in the grid.
-
-It’s common to use `.u-col-start-1` to force an element to start a new row — the following grid children will continue afterwards.
+It’s common to use `.u-row-start-1` to force an element to be placed in the first row even if it follows another grid-item that’s been placed at the end of that row (so they are both placed in the first row despite their source-order).
 
 <Canvas isColumn>
-  <Story name="u-col-start-1">
+  <Story name="u-row-start-1">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-1">6-column grid, child 3, col-start-1</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-1">6-column grid, child 3, row-start-1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-col-start-2">
+  <Story name="u-row-start-2">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-2">6-column grid, child 3, col-start-2</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-2">6-column grid, child 3, row-start-2</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-col-start-3">
+  <Story name="u-row-start-3">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 3</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-3">6-column grid, child 4, col-start-3</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-3">6-column grid, child 4, row-start-3</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-col-start-4">
+  <Story name="u-row-start-4">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-4">6-column grid, child 3, col-start-4</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-4">6-column grid, child 3, row-start-4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-col-start-5">
+  <Story name="u-row-start-5">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-5">6-column grid, child 3, col-start-5</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-5">6-column grid, child 3, row-start-5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-col-start-6">
+  <Story name="u-row-start-6">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-6">6-column grid, child 3, col-start-6</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-6">6-column grid, child 3, row-start-6</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
@@ -85,41 +83,41 @@ It’s common to use `.u-col-start-1` to force an element to start a new row —
   </Story>
 </Canvas>
 
-## Responsive col-start
+## Responsive row-start
 
-The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by default.
+The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by default.
 
 <Canvas isColumn>
-  <Story name="u-col-start-1@s">
+  <Story name="u-row-start-1@s">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-1@s">6-column grid, child 3, col-start-1@s</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-1@s">6-column grid, child 3, row-start-1@s</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-col-start-1@m">
+  <Story name="u-row-start-1@m">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-1@m">6-column grid, child 3, col-start-1@m</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-1@m">6-column grid, child 3, row-start-1@m</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-col-start-1@xl">
+  <Story name="u-row-start-1@xl">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-1@xl">6-column grid, child 3, col-start-1@xl</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-1@xl">6-column grid, child 3, row-start-1@xl</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
@@ -130,10 +128,10 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 
 ## Customization
 
-The available start columns can be customized by overriding the `$bitstyles-col-start` Sass variable:
+The available start rows can be customized by overriding the `$bitstyles-row-start` Sass variable:
 
 ```scss
-$bitstyles-col-start: (
+$bitstyles-row-start: (
   '1': 1,
   '2': 2,
   '3': 3,
@@ -143,8 +141,8 @@ $bitstyles-col-start: (
 );
 ```
 
-The breakpoints these classes are available at can be customized by overriding the `$bitstyles-col-start-breakpoints` variable:
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-row-start-breakpoints` variable:
 
 ```scss
-$bitstyles-col-start-breakpoints: ('s', 'm', 'xl');
+$bitstyles-row-start-breakpoints: ('s', 'm', 'xl');
 ```

--- a/scss/bitstyles/utilities/row-start/row-start.stories.mdx
+++ b/scss/bitstyles/utilities/row-start/row-start.stories.mdx
@@ -88,36 +88,36 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
 The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by default.
 
 <Canvas isColumn>
-  <Story name="u-row-start-1@s">
+  <Story name="u-row-start-2@s">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-1@s">6-column grid, child 3, row-start-1@s</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-2@s">6-column grid, child 3, row-start-1@s</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-row-start-1@m">
+  <Story name="u-row-start-2@m">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-1@m">6-column grid, child 3, row-start-1@m</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-2@m">6-column grid, child 3, row-start-1@m</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
-  <Story name="u-row-start-1@xl">
+  <Story name="u-row-start-2@xl">
     {`
       <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-1@xl">6-column grid, child 3, row-start-1@xl</li>
+        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-2@xl">6-column grid, child 3, row-start-1@xl</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
         <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -3719,6 +3719,36 @@ table {
 .bsu-round-0--tl {
   border-top-left-radius: 0;
 }
+.bs-u-row-start-100 {
+  grid-row-start: 100;
+}
+.bs-u-row-start-200 {
+  grid-row-start: 200;
+}
+@media screen and (max-width: 20em) {
+  .bs-u-row-start-100\@s {
+    grid-row-start: 100;
+  }
+  .bs-u-row-start-200\@s {
+    grid-row-start: 200;
+  }
+}
+@media screen and (min-width: 30em) {
+  .bs-u-row-start-100\@m {
+    grid-row-start: 100;
+  }
+  .bs-u-row-start-200\@m {
+    grid-row-start: 200;
+  }
+}
+@media screen and (min-width: 95em) {
+  .bs-u-row-start-100\@xl {
+    grid-row-start: 100;
+  }
+  .bs-u-row-start-200\@xl {
+    grid-row-start: 200;
+  }
+}
 .bs-u-self-end {
   align-self: flex-end;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -3738,6 +3738,84 @@ table {
 .u-round-0--tl {
   border-top-left-radius: 0;
 }
+.u-row-start-1 {
+  grid-row-start: 1;
+}
+.u-row-start-2 {
+  grid-row-start: 2;
+}
+.u-row-start-3 {
+  grid-row-start: 3;
+}
+.u-row-start-4 {
+  grid-row-start: 4;
+}
+.u-row-start-5 {
+  grid-row-start: 5;
+}
+.u-row-start-6 {
+  grid-row-start: 6;
+}
+@media screen and (max-width: 29.9375em) {
+  .u-row-start-1\@s {
+    grid-row-start: 1;
+  }
+  .u-row-start-2\@s {
+    grid-row-start: 2;
+  }
+  .u-row-start-3\@s {
+    grid-row-start: 3;
+  }
+  .u-row-start-4\@s {
+    grid-row-start: 4;
+  }
+  .u-row-start-5\@s {
+    grid-row-start: 5;
+  }
+  .u-row-start-6\@s {
+    grid-row-start: 6;
+  }
+}
+@media screen and (min-width: 30em) {
+  .u-row-start-1\@m {
+    grid-row-start: 1;
+  }
+  .u-row-start-2\@m {
+    grid-row-start: 2;
+  }
+  .u-row-start-3\@m {
+    grid-row-start: 3;
+  }
+  .u-row-start-4\@m {
+    grid-row-start: 4;
+  }
+  .u-row-start-5\@m {
+    grid-row-start: 5;
+  }
+  .u-row-start-6\@m {
+    grid-row-start: 6;
+  }
+}
+@media screen and (min-width: 95em) {
+  .u-row-start-1\@xl {
+    grid-row-start: 1;
+  }
+  .u-row-start-2\@xl {
+    grid-row-start: 2;
+  }
+  .u-row-start-3\@xl {
+    grid-row-start: 3;
+  }
+  .u-row-start-4\@xl {
+    grid-row-start: 4;
+  }
+  .u-row-start-5\@xl {
+    grid-row-start: 5;
+  }
+  .u-row-start-6\@xl {
+    grid-row-start: 6;
+  }
+}
 .u-self-end {
   align-self: flex-end;
 }

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -116,5 +116,9 @@ $bitstyles-ui-group-border-radius: 10rem;
 // Utilities settings /////////////////////////////////////
 
 $bitstyles-margin-breakpoints: ('xl', 's');
+$bitstyles-row-start-values: (
+  '100': 100,
+  '200': 200
+);
 
 @import '../../scss/bitstyles';

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -116,6 +116,10 @@ $bitstyles-ui-group-border-radius: 10rem;
 // Utilities settings /////////////////////////////////////
 
 $bitstyles-margin-breakpoints: ('xl', 's');
+$bitstyles-row-start-values: (
+  '100': 100,
+  '200': 200
+);
 
 @import '../../scss/bitstyles/settings/animation';
 @import '../../scss/bitstyles/settings/breakpoints';
@@ -212,6 +216,7 @@ $bitstyles-margin-breakpoints: ('xl', 's');
 @import '../../scss/bitstyles/utilities/padding';
 @import '../../scss/bitstyles/utilities/relative';
 @import '../../scss/bitstyles/utilities/round';
+@import '../../scss/bitstyles/utilities/row-start';
 @import '../../scss/bitstyles/utilities/self';
 @import '../../scss/bitstyles/utilities/sr-only';
 @import '../../scss/bitstyles/utilities/text';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -103,5 +103,6 @@
   $table-color-th: #f00,
   $ui-group-border-radius: 10rem,
   // utilities
-  $margin-breakpoints: ('xl', 's')
+  $margin-breakpoints: ('xl', 's'),
+  $row-start-values: ('100': 100, '200': 200),
 );

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -232,6 +232,12 @@
 @use '../../scss/bitstyles/utilities/padding';
 @use '../../scss/bitstyles/utilities/relative';
 @use '../../scss/bitstyles/utilities/round';
+@use '../../scss/bitstyles/utilities/row-start' with (
+  $values: (
+    '100': 100,
+    '200': 200
+  )
+);
 @use '../../scss/bitstyles/utilities/self';
 @use '../../scss/bitstyles/utilities/sr-only';
 @use '../../scss/bitstyles/utilities/text';


### PR DESCRIPTION
Fixes #538 

## Changes

- Adds row-start utility classes

## Looks like

<img width="1135" alt="Screenshot 2021-08-13 at 17 27 13" src="https://user-images.githubusercontent.com/2479422/129382386-3841ac5f-6ec5-4d51-81ff-5116b974316c.png">

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
