### PR TITLE
[#544] Update remaining utility classes to using single-dash naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `u-bg` classes can now be made available at different breakpoints by overriding the `$bitstyles-bg-breakpoints` variable
+- `u-fg` classes can now be made available at different breakpoints by overriding the `$bitstyles-fg-breakpoints` variable
+- Default settings for `u-fg` classes now include `white` as an option
+- `u-font` classes can now be customized by overriding the `$bitstyles-font-weight-values` and `$bitstyles-font-style-values` variables. They can be made available at different breakpoints by overriding the `$bitstyles-font-weight-breakpoints` and `$bitstyles-font-style-breakpoints` variables
+- `u-text` classes can now be customized by overriding the `$bitstyles-text-values` variable. They can be made available at different breakpoints by overriding the `$bitstyles-text-breakpoints` variable
+
+### Breaking
+
+- All utility classes which had a double dash in their classname (`--`) now only have a single dash. You’ll need to rename all these classes to use single dashes e.g. `.u-bg--brand-1` becomes `.u-bg-brand-1`
+- Values for the display classes (`u-block`, `u-flex` etc.) will now need to be set unquoted. If you previously were overriding the `$bitstyles-display-values` variable, make sure all the values on the right hand side are unquoted CSS values e.g. `'block': block` instead of `'block': 'block'`, as was previously possible
+
 ## [[3.1.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0) - 2021-12-20
 
 ### Added
@@ -44,6 +59,19 @@
 
 - As `.a-card` elements now set their own padding, remove any utility padding classes. If the padding does not match your requirements, it can be customized using the cards’ sass variables
 - If you output any flashes or other content at the top of an `.a-card` element using negative-margin utility classes to cancel out the padding, these classes should now be replaced with the `.a-card__header` class
+
+## [[3.0.0-rc.2]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0-rc.2) - 2021-09-06
+
+### Added
+
+- The breakpoints at which `.a-card` is output can now be specified with the `$bitstyles-card-breakpoints` Sass variable. Default is at `m`, and `l` breakpoints
+
+### Fixed
+
+- All of the variables can now be overridden by users
+
+### Breaking
+
 - Removes `settings/color-base`, and merges its variables into `settings/color-palette`. If you’re already using the Sass module system, you’ll need to rename all variables containing `color-base` to `color-palette`
 
 ## [[2.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v2.0.0) - 2021-07-22

--- a/scss/bitstyles/atoms/badge/badge.stories.mdx
+++ b/scss/bitstyles/atoms/badge/badge.stories.mdx
@@ -10,7 +10,7 @@ Display tags and other filters or categorization.
 <Canvas>
   <Story name="Badge">
     {`
-      <span class="a-badge a-badge--gray u-h6 u-font--medium">badge</span>
+      <span class="a-badge a-badge--gray u-h6 u-font-medium">badge</span>
     `}
   </Story>
 </Canvas>
@@ -22,16 +22,16 @@ Various colours are available, based on the colors you specify in your palette. 
     {`
       <ul class="a-list-reset u-flex">
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--gray u-h6 u-font--medium">badge</span>
+          <span class="a-badge a-badge--gray u-h6 u-font-medium">badge</span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--brand-1 u-h6 u-font--medium">badge</span>
+          <span class="a-badge a-badge--brand-1 u-h6 u-font-medium">badge</span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--brand-2 u-h6 u-font--medium">badge</span>
+          <span class="a-badge a-badge--brand-2 u-h6 u-font-medium">badge</span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--danger u-h6 u-font--medium">badge</span>
+          <span class="a-badge a-badge--danger u-h6 u-font-medium">badge</span>
         </li>
       </ul>
     `}
@@ -45,7 +45,7 @@ When used as filters, you’ll want the badges to be removable — you can add a
     {`
       <ul class="a-list-reset u-flex">
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--gray u-h6 u-font--medium">
+          <span class="a-badge a-badge--gray u-h6 u-font-medium">
             badge 1
             <button class="a-button a-button--icon a-button--icon-reversed a-button--small a-badge__button" type="button">
               <svg width="14" height="14" class="a-icon a-icon--m" aria-hidden="true" focusable="false">
@@ -56,7 +56,7 @@ When used as filters, you’ll want the badges to be removable — you can add a
           </span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--brand-1 u-h6 u-font--medium">
+          <span class="a-badge a-badge--brand-1 u-h6 u-font-medium">
             badge 2
             <button class="a-button a-button--icon a-button--icon-reversed a-button--small a-badge__button" type="button">
               <svg width="14" height="14" class="a-icon a-icon--m" aria-hidden="true" focusable="false">
@@ -67,7 +67,7 @@ When used as filters, you’ll want the badges to be removable — you can add a
           </span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--brand-2 u-h6 u-font--medium">
+          <span class="a-badge a-badge--brand-2 u-h6 u-font-medium">
             badge 2
             <button class="a-button a-button--icon a-button--icon-reversed a-button--small a-badge__button" type="button">
               <svg width="14" height="14" class="a-icon a-icon--m" aria-hidden="true" focusable="false">
@@ -78,7 +78,7 @@ When used as filters, you’ll want the badges to be removable — you can add a
           </span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--danger u-h6 u-font--medium">
+          <span class="a-badge a-badge--danger u-h6 u-font-medium">
             badge 2
             <button class="a-button a-button--icon a-button--icon-reversed a-button--small a-badge__button" type="button">
               <svg width="14" height="14" class="a-icon a-icon--m" aria-hidden="true" focusable="false">

--- a/scss/bitstyles/atoms/button--icon-reversed/button--icon-reversed.stories.mdx
+++ b/scss/bitstyles/atoms/button--icon-reversed/button--icon-reversed.stories.mdx
@@ -10,7 +10,7 @@ A variant of the standard `.a-button--icon`, intended to be used on dark backgro
 <Canvas>
   <Story name="Icon-reversed">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <button type="button" class="a-button a-button--icon a-button--icon-reversed" title="button-label">
           <svg width="20" height="20" class="a-icon" aria-hidden="true" focusable="false">
             <use xlink:href="${icons}#icon-plus"></use>
@@ -22,7 +22,7 @@ A variant of the standard `.a-button--icon`, intended to be used on dark backgro
   </Story>
   <Story name="Icon-reversed [disabled]">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <button type="button" class="a-button a-button--icon a-button--icon-reversed" title="button-label" disabled>
           <svg width="20" height="20" class="a-icon" aria-hidden="true" focusable="false">
             <use xlink:href="${icons}#icon-plus"></use>
@@ -38,7 +38,7 @@ A variant of the standard `.a-button--icon`, intended to be used on dark backgro
 <Canvas>
   <Story name="Icon-reversed anchor">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <a href="/" class="a-button a-button--icon a-button--icon-reversed" title="button-label">
           <svg width="20" height="20" class="a-icon" aria-hidden="true" focusable="false">
             <use xlink:href="${icons}#icon-plus"></use>
@@ -50,7 +50,7 @@ A variant of the standard `.a-button--icon`, intended to be used on dark backgro
   </Story>
   <Story name="Icon-reversed anchor [disabled]">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <a href="/" class="a-button a-button--icon a-button--icon-reversed" title="button-label" aria-disabled="true">
           <svg width="20" height="20" class="a-icon" aria-hidden="true" focusable="false">
             <use xlink:href="${icons}#icon-plus"></use>

--- a/scss/bitstyles/atoms/button--nav/button--nav.stories.mdx
+++ b/scss/bitstyles/atoms/button--nav/button--nav.stories.mdx
@@ -13,7 +13,7 @@ One of the links may well be a link to the current page, and should be given an 
 <Canvas>
   <Story name="Nav">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <a href="/" class="a-button a-button--nav">
           Dashboard
         </a>
@@ -22,7 +22,7 @@ One of the links may well be a link to the current page, and should be given an 
   </Story>
   <Story name="Nav [aria-current]">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <a href="/" class="a-button a-button--nav" aria-current="page">
           Dashboard
         </a>
@@ -31,7 +31,7 @@ One of the links may well be a link to the current page, and should be given an 
   </Story>
   <Story name="Nav [disabled]">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <a href="/" class="a-button a-button--nav" aria-disabled="true">
           Dashboard
         </a>
@@ -43,7 +43,7 @@ One of the links may well be a link to the current page, and should be given an 
 <Canvas>
   <Story name="Nav button">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <button type="button" class="a-button a-button--nav">
           Dashboard
         </button>
@@ -52,7 +52,7 @@ One of the links may well be a link to the current page, and should be given an 
   </Story>
   <Story name="Nav button [aria-current]">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <button type="button" class="a-button a-button--nav" aria-current="page">
           Dashboard
         </button>
@@ -61,7 +61,7 @@ One of the links may well be a link to the current page, and should be given an 
   </Story>
   <Story name="Nav button [disabled]">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <button type="button" class="a-button a-button--nav" disabled>
           Dashboard
         </button>
@@ -75,7 +75,7 @@ It’s rare to have only one link, so here’s how it looks with multiple:
 <Canvas>
   <Story name="Nav list">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <ul class="a-list-reset u-flex">
           <li class="u-margin-s-right">
             <a href="/" class="a-button a-button--nav">
@@ -98,7 +98,7 @@ It’s rare to have only one link, so here’s how it looks with multiple:
   </Story>
   <Story name="Nav list current page">
     {`
-      <div class="u-bg--gray-90 u-padding-m">
+      <div class="u-bg-gray-90 u-padding-m">
         <ul class="a-list-reset u-flex">
           <li class="u-margin-s-right">
             <a href="/" class="a-button a-button--nav" aria-current="page">

--- a/scss/bitstyles/atoms/dl/dl.stories.mdx
+++ b/scss/bitstyles/atoms/dl/dl.stories.mdx
@@ -11,15 +11,15 @@ A list of term/description pairs, used to display any set of key-value pairs. It
     {`
       <dl class="a-dl">
         <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-          <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Full name</dt>
+          <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">Full name</dt>
           <dd class="u-col-span-2">Muffin Gummies</dd>
         </div>
         <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-          <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Email</dt>
+          <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">Email</dt>
           <dd class="u-col-span-2">cupcake@tiramisu.com</dd>
         </div>
         <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-          <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Description</dt>
+          <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">Description</dt>
           <dd class="u-col-span-2">Muffin gummies tart fruitcake gummi bears chocolate bar. Jujubes candy macaroon topping dessert biscuit topping sugar plum sesame snaps. Chocolate donut cake tootsie roll donut biscuit caramels sugar plum jelly beans. Dessert dragée jelly-o gummi bears sweet halvah soufflé.</dd>
         </div>
       </dl>

--- a/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
+++ b/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
@@ -12,7 +12,7 @@ A floating container for a list of links.
   <Story name="Dropdown" inline={false} height="20rem">
     {`
       <div class="u-relative" style="height: 10rem; width: 30rem">
-        <ul class="a-dropdown u-overflow--y a-list-reset">
+        <ul class="a-dropdown u-overflow-y a-list-reset">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -38,7 +38,7 @@ A floating container for a list of links.
   <Story name="Dropdown--right" inline={false} height="20rem">
     {`
       <div class="u-relative" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--right u-overflow--y a-list-reset">
+        <ul class="a-dropdown a-dropdown--right u-overflow-y a-list-reset">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -64,7 +64,7 @@ A floating container for a list of links.
   <Story name="Dropdown--top" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--top u-overflow--y a-list-reset">
+        <ul class="a-dropdown a-dropdown--top u-overflow-y a-list-reset">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -91,7 +91,7 @@ A floating container for a list of links.
   <Story name="Dropdown--top dropdown--right" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--top a-dropdown--right u-overflow--y a-list-reset">
+        <ul class="a-dropdown a-dropdown--top a-dropdown--right u-overflow-y a-list-reset">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -121,7 +121,7 @@ Sometimes you need your dropdown to fill the width of the container.
   <Story name="Dropdown--bottom dropdown--full" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--full-width u-overflow--y a-list-reset">
+        <ul class="a-dropdown a-dropdown--full-width u-overflow-y a-list-reset">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -147,7 +147,7 @@ Sometimes you need your dropdown to fill the width of the container.
   <Story name="Dropdown--top dropdown--full" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--top a-dropdown--full-width u-overflow--y a-list-reset">
+        <ul class="a-dropdown a-dropdown--top a-dropdown--full-width u-overflow-y a-list-reset">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>

--- a/scss/bitstyles/organisms/modal/modal.stories.mdx
+++ b/scss/bitstyles/organisms/modal/modal.stories.mdx
@@ -24,7 +24,7 @@ You may use a modal to inform the user of the outcome of an action, give a littl
     {`
       <main id="main" class="a-content">
         <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
-        <p class="u-text--center"><button class="a-link" data-a11y-dialog-show="dialog_1">open dialogue</button></p>
+        <p class="u-text-center"><button class="a-link" data-a11y-dialog-show="dialog_1">open dialogue</button></p>
         <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
       </main>
       <div class="o-modal" data-a11y-dialog="dialog_1" aria-hidden="true" aria-labelledby="dialog-title">
@@ -38,7 +38,7 @@ You may use a modal to inform the user of the outcome of an action, give a littl
             </div>
             <h1 class="u-flex-shrink-0 u-h2" id="dialog-title" tabindex="0">Confirmation email sent</h1>
           </header>
-          <div class="u-flex-grow-1 u-overflow--y u-fg--gray-50 u-text--center">
+          <div class="u-flex-grow-1 u-overflow-y u-fg-gray-50 u-text-center">
             <p>We sent the email to your primary email address. If you do not receive it shortly, please contact your admin.</p>
           </div>
           <button class="u-flex-shrink-0 u-margin-l-top a-button" type="button" data-a11y-dialog-hide>
@@ -59,7 +59,7 @@ If you have multiple options for the user, present them with any information the
     {`
     <main id="main" class="a-content">
       <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
-      <p class="u-text--center">
+      <p class="u-text-center">
         <button class="a-link" data-a11y-dialog-show="dialog_1">open dialogue</button>
       </p>
       <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
@@ -75,7 +75,7 @@ If you have multiple options for the user, present them with any information the
           </div>
           <h1 class="u-flex-shrink-0 u-h2" id="dialog-title" tabindex="0">Send confirmation email?</h1>
         </header>
-        <div class="u-flex-grow-1 u-overflow--y u-fg--gray-50 u-text--center">
+        <div class="u-flex-grow-1 u-overflow-y u-fg-gray-50 u-text-center">
           <p>The previous email we sent to email@example.com will no longer be valid.</p>
         </div>
         <ul class="a-list-reset u-grid u-grid-cols-2@m u-gap-m u-items-center u-margin-l-top">
@@ -101,7 +101,7 @@ Sometimes you just need to show the user a load of text, such as for legal docum
     {`
     <main id="main" class="a-content">
       <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
-      <p class="u-text--center">
+      <p class="u-text-center">
         <button class="a-link" data-a11y-dialog-show="dialog_1">open dialogue</button>
       </p>
       <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
@@ -118,7 +118,7 @@ Sometimes you just need to show the user a load of text, such as for legal docum
           <h1 class="u-flex-shrink-0 u-h2 u-margin-0" id="dialog-title" tabindex="0">The legal stuff</h1>
           <p class="u-h3">Please read and accept</p>
         </header>
-        <div class="u-flex-grow-1 u-overflow--y u-fg--gray-50">
+        <div class="u-flex-grow-1 u-overflow-y u-fg-gray-50">
           <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
           <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>
           <p>Icing powder pie jelly beans soufflé biscuit cupcake fruitcake. Jelly beans bear claw candy canes. Chupa chups gingerbread dessert gingerbread jelly-o icing topping. Marshmallow tiramisu tiramisu cheesecake. Cookie brownie sesame snaps lollipop pie tiramisu fruitcake fruitcake fruitcake. Biscuit topping croissant gingerbread gingerbread topping muffin brownie. Jelly toffee danish fruitcake. Liquorice fruitcake bonbon. Bear claw pudding bonbon jujubes. Danish icing sweet. Biscuit jelly marzipan pie tart. Sugar plum danish gingerbread powder cupcake ice cream sugar plum. Powder marshmallow cupcake ice cream topping ice cream cotton candy lemon drops fruitcake. Chocolate cake wafer jelly beans cupcake lemon drops.</p>

--- a/scss/bitstyles/organisms/navbar/navbar.stories.mdx
+++ b/scss/bitstyles/organisms/navbar/navbar.stories.mdx
@@ -14,7 +14,7 @@ A top-level navigation container, this organism is only responsible for the layo
     {`
       <div style="min-height:25rem;">
         <div class="u-relative">
-          <ul class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg--gray-80" id="navbar-1">
+          <ul class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg-gray-80" id="navbar-1">
             <li class="u-margin-s-bottom">
               <a href="/" class="a-button a-button--nav-large" aria-current="page">Team</a>
             </li>

--- a/scss/bitstyles/organisms/table/table.stories.mdx
+++ b/scss/bitstyles/organisms/table/table.stories.mdx
@@ -24,7 +24,7 @@ A basic table layout. It will need a wrapper to deal with overflow.
             <td>Sesame S. Snaps</td>
             <td>sesame.snaps@gmail.com</td>
             <td><span class="a-badge a-badge--danger">Banned</span></td>
-            <td class="o-table__actions u-text--right">
+            <td class="o-table__actions u-text-right">
               <ul class="a-list-reset u-inline-flex">
                 <li class="u-margin-xs-right">
                   <a href="/" class="a-button a-button--small">Edit</a>
@@ -39,7 +39,7 @@ A basic table layout. It will need a wrapper to deal with overflow.
             <td>Croissant B. Gummies with the very long multi-word name</td>
             <td>croissant.gummies@gmx.de</td>
             <td><span class="a-badge a-badge--positive">Confirmed</span></td>
-            <td class="o-table__actions u-text--right">
+            <td class="o-table__actions u-text-right">
               <ul class="a-list-reset u-inline-flex">
                 <li class="u-margin-xs-right">
                   <a href="/" class="a-button a-button--small">Edit</a>
@@ -54,7 +54,7 @@ A basic table layout. It will need a wrapper to deal with overflow.
             <td>Liquorice G Fruitcake</td>
             <td>liquorice.fruitcake@mailbox.org</td>
             <td><span class="a-badge a-badge--positive">Confirmed</span></td>
-            <td class="o-table__actions u-text--right">
+            <td class="o-table__actions u-text-right">
               <ul class="a-list-reset u-inline-flex">
                 <li class="u-margin-xs-right">
                   <a href="/" class="a-button a-button--small">Edit</a>

--- a/scss/bitstyles/organisms/ui-group/ui-group.stories.mdx
+++ b/scss/bitstyles/organisms/ui-group/ui-group.stories.mdx
@@ -13,13 +13,13 @@ Commonly, this layout is used for buttons.
     {`
       <ul class="o-ui-group u-flex a-list-reset">
         <li>
-          <button type="button" class="a-button a-button--ui o-ui-group__item u-round-0--tr u-round-0--br">First</button>
+          <button type="button" class="a-button a-button--ui o-ui-group__item u-round-0-tr u-round-0-br">First</button>
         </li>
         <li>
           <button type="button" class="a-button a-button--ui o-ui-group__item u-round-0">Middle</button>
         </li>
         <li>
-          <button type="button" class="a-button a-button--ui u-round-0--tl u-round-0--bl">Last</button>
+          <button type="button" class="a-button a-button--ui u-round-0-tl u-round-0-bl">Last</button>
         </li>
       </ul>
     `}
@@ -34,10 +34,10 @@ The `ui-group` is also used for grouping inputs & buttons:
       <ul class="o-ui-group u-flex a-list-reset">
         <li class="u-flex">
           <label for="search_users" class="u-sr-only">Search users</label>
-          <input type="search" id="search_users" class="o-ui-group__item u-round-0--tr u-round-0--br" />
+          <input type="search" id="search_users" class="o-ui-group__item u-round-0-tr u-round-0-br" />
         </li>
         <li class="u-flex">
-          <button type="button" class="a-button a-button--ui u-round-0--tl u-round-0--bl">Search</button>
+          <button type="button" class="a-button a-button--ui u-round-0-tl u-round-0-bl">Search</button>
         </li>
       </ul>
     `}

--- a/scss/bitstyles/ui/Colors.stories.js
+++ b/scss/bitstyles/ui/Colors.stories.js
@@ -41,7 +41,7 @@ const ColorItem = (label, color) =>
     <li style="background-color: ${color};">
       <div style="min-height:4rem;"></div>
       <span
-        class="u-bg--white u-padding-xxs-x u-margin-xxs-left"
+        class="u-bg-white u-padding-xxs-x u-margin-xxs-left"
         style="font-size: 10px;"
       >
         ${label}
@@ -73,7 +73,7 @@ const ColorPalette = () =>
           return `
           <li class="u-margin-xl-bottom u-flex u-items-end">
             <h3
-              class="u-margin-0-bottom u-margin-m-right u-text--right u-line-height--min"
+              class="u-margin-0-bottom u-margin-m-right u-text-right u-line-height-min"
               style="min-width: 9rem"
             >
               ${name}

--- a/scss/bitstyles/ui/app-layouts.stories.mdx
+++ b/scss/bitstyles/ui/app-layouts.stories.mdx
@@ -14,9 +14,9 @@ Sidebar, header, and content that uses all available space.
     {`
       <div class="u-flex u-height-100vh">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex-col">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg-gray-80 u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
@@ -83,14 +83,14 @@ Sidebar, header, and content that uses all available space.
               </a>
             </div>
           </div>
-          <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex-col u-hidden@l">
+          <div class="o-sidebar--small u-bg-gray-80 u-flex u-flex-col u-hidden@l">
             <button class="u-flex-shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
               <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
                 <use xlink:href="${icons}#icon-cross"></use>
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
@@ -159,25 +159,25 @@ Sidebar, header, and content that uses all available space.
           </div>
         </nav>
         <main class="u-flex-grow-1 u-flex u-flex-col">
-          <header class="u-bg--gray-5 u-padding-l-top u-flex-shrink-0">
+          <header class="u-bg-gray-5 u-padding-l-top u-flex-shrink-0">
             <div class="a-content a-content--full">
               <div class="u-padding-xl-bottom">
                 <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Main section</a>
-                    <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                    <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                       <use xlink:href="${icons}#icon-caret-right"></use>
                     </svg>
                   </li>
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Sub section</a>
-                    <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                    <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                       <use xlink:href="${icons}#icon-caret-right"></use>
                     </svg>
                   </li>
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Sub page</a>
-                    <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                    <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                       <use xlink:href="${icons}#icon-caret-right"></use>
                     </svg>
                   </li>
@@ -186,7 +186,7 @@ Sidebar, header, and content that uses all available space.
                   <div class="u-flex u-flex-wrap u-items-center">
                     <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                     <div class="u-flex-shrink-0 u-margin-m-bottom">
-                      <span class="a-badge a-badge--gray u-font--medium">Published</span>
+                      <span class="a-badge a-badge--gray u-font-medium">Published</span>
                     </div>
                   </div>
                   <ul class="a-list-reset u-flex u-flex-wrap">
@@ -204,7 +204,7 @@ Sidebar, header, and content that uses all available space.
                   </ul>
                 </div>
               </div>
-              <ul class="a-list-reset u-flex u-overflow--x l-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
+              <ul class="a-list-reset u-flex u-overflow-x l-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
                 <li class="u-margin-s-right">
                   <button class="a-button a-button--tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">
                     Personal details
@@ -223,35 +223,35 @@ Sidebar, header, and content that uses all available space.
               </ul>
             </div>
           </header>
-          <div class="a-content a-content--full u-padding-l-y u-flex-grow-1 u-overflow--y">
+          <div class="a-content a-content--full u-padding-l-y u-flex-grow-1 u-overflow-y">
             <h2 class="u-sr-only">Users</h2>
             <form action="" method="POST" role="search" class="u-margin-m-bottom u-flex">
               <h3 class="u-sr-only">Filter results</h3>
               <ul class="o-ui-group u-flex a-list-reset">
                 <li class="u-flex">
                   <label for="search_users" class="u-sr-only">Filter users by email</label>
-                  <input type="search" id="search_users" class="o-ui-group__item u-round-0--tr u-round-0--br" placeholder="Filter by email…" />
+                  <input type="search" id="search_users" class="o-ui-group__item u-round-0-tr u-round-0-br" placeholder="Filter by email…" />
                 </li>
                 <li class="u-flex u-relative">
-                  <button type="button" class="a-button a-button--ui u-round-0--tl u-round-0--bl">
+                  <button type="button" class="a-button a-button--ui u-round-0-tl u-round-0-bl">
                     Filter
                   </button>
                 </li>
               </ul>
               <button class="a-button u-sr-only" type="submit">Apply filter</button>
             </form>
-            <div class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative u-margin-xl-bottom">
+            <div class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative u-margin-xl-bottom">
               <div class="u-absolute-center">List or table with long rows of information that need full width of available display</div>
             </div>
             <h2>Further content</h2>
             <ul class="a-list-reset u-grid u-grid-cols-2@l u-grid-cols-3@xl u-gap-l u-margin-xl-bottom">
-              <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+              <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                 <div class="u-absolute-center">Content block</div>
               </li>
-              <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+              <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                 <div class="u-absolute-center">Content block</div>
               </li>
-              <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+              <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                 <div class="u-absolute-center">Content block</div>
               </li>
             </ul>
@@ -267,9 +267,9 @@ Sidebar, header, and content that uses all available space.
     {`
       <div class="u-flex u-height-100vh">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex-col">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg-gray-80 u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
@@ -336,14 +336,14 @@ Sidebar, header, and content that uses all available space.
               </a>
             </div>
           </div>
-          <div class="o-sidebar--small u-bg--gray-80 u-flex u-flex-col u-hidden@l">
+          <div class="o-sidebar--small u-bg-gray-80 u-flex u-flex-col u-hidden@l">
             <button class="u-flex-shrink-0 a-button a-button--icon a-button--icon-reversed u-margin-xxs-left" title="Close menu" aria-controls="navbar-1" aria-expanded="true">
               <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
                 <use xlink:href="${icons}#icon-cross"></use>
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs--left" aria-hidden="true" focusable="false">
@@ -412,25 +412,25 @@ Sidebar, header, and content that uses all available space.
           </div>
         </nav>
         <main class="u-flex-grow-1 u-flex u-flex-col">
-          <header class="u-bg--gray-5 u-padding-l-top u-flex-shrink-0">
+          <header class="u-bg-gray-5 u-padding-l-top u-flex-shrink-0">
             <div class="a-content a-content--full">
               <div class="u-padding-xl-bottom">
                 <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Main section</a>
-                    <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                    <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                       <use xlink:href="${icons}#icon-caret-right"></use>
                     </svg>
                   </li>
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Sub section</a>
-                    <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                    <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                       <use xlink:href="${icons}#icon-caret-right"></use>
                     </svg>
                   </li>
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Sub page</a>
-                    <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                    <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                       <use xlink:href="${icons}#icon-caret-right"></use>
                     </svg>
                   </li>
@@ -439,7 +439,7 @@ Sidebar, header, and content that uses all available space.
                   <div class="u-flex u-flex-wrap u-items-center">
                     <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                     <div class="u-flex-shrink-0 u-margin-m-bottom">
-                      <span class="a-badge a-badge--gray u-font--medium">Published</span>
+                      <span class="a-badge a-badge--gray u-font-medium">Published</span>
                     </div>
                   </div>
                   <ul class="a-list-reset u-flex u-flex-wrap">
@@ -457,7 +457,7 @@ Sidebar, header, and content that uses all available space.
                   </ul>
                 </div>
               </div>
-              <ul class="a-list-reset u-flex u-overflow--x l-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
+              <ul class="a-list-reset u-flex u-overflow-x l-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
                 <li class="u-margin-s-right">
                   <button class="a-button a-button--tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">
                     Personal details
@@ -476,24 +476,24 @@ Sidebar, header, and content that uses all available space.
               </ul>
             </div>
           </header>
-          <div class="u-flex-grow-1 u-overflow--y u-grid u-gap-l u-grid-cols-2@xl a-content a-content--full u-margin-0">
+          <div class="u-flex-grow-1 u-overflow-y u-grid u-gap-l u-grid-cols-2@xl a-content a-content--full u-margin-0">
             <div class="u-padding-l-y">
               <form action="" method="POST" role="search" class="u-margin-m-bottom u-flex">
                 <h3 class="u-sr-only">Filter results</h3>
                 <ul class="o-ui-group u-flex a-list-reset">
                   <li class="u-flex">
                     <label for="search_users" class="u-sr-only">Filter users by email</label>
-                    <input type="search" id="search_users" class="o-ui-group__item u-round-0--tr u-round-0--br" placeholder="Filter by email…" />
+                    <input type="search" id="search_users" class="o-ui-group__item u-round-0-tr u-round-0-br" placeholder="Filter by email…" />
                   </li>
                   <li class="u-flex u-relative">
-                    <button type="button" class="a-button a-button--ui u-round-0--tl u-round-0--bl">
+                    <button type="button" class="a-button a-button--ui u-round-0-tl u-round-0-bl">
                       Filter
                     </button>
                   </li>
                 </ul>
                 <button class="a-button u-sr-only" type="submit">Apply filter</button>
               </form>
-              <div class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative u-margin-xl-bottom">
+              <div class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative u-margin-xl-bottom">
                 <div class="u-absolute-center">
                   To make the content easier to read, width is limited by the grid system. Other content follows below, except on xl screens, where other content is allowed adjacent
                 </div>
@@ -502,22 +502,22 @@ Sidebar, header, and content that uses all available space.
             <div class="u-padding-l-y">
               <h2>Further content</h2>
               <ul class="a-list-reset u-grid u-grid-cols-2@l u-grid-cols-3@xl u-gap-l u-margin-xl-bottom">
-                <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+                <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                   <div class="u-absolute-center">Content block</div>
                 </li>
-                <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+                <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                   <div class="u-absolute-center">Content block</div>
                 </li>
-                <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+                <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                   <div class="u-absolute-center">Content block</div>
                 </li>
-                <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+                <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                   <div class="u-absolute-center">Content block</div>
                 </li>
-                <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+                <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                   <div class="u-absolute-center">Content block</div>
                 </li>
-                <li class="a-card u-bg--background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
+                <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                   <div class="u-absolute-center">Content block</div>
                 </li>
               </ul>

--- a/scss/bitstyles/ui/breadcrumbs.stories.mdx
+++ b/scss/bitstyles/ui/breadcrumbs.stories.mdx
@@ -8,7 +8,7 @@ import icons from '../../../assets/images/icons.svg';
 A list of links charting the user’s place in the site structure. The title of the current page is most often in an `<h1>` on the page, so it isn’t needed here.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-icon--icon">a-icon</a></li>
     <li><a href="/docs/atoms-list-reset--list-reset">a-list-reset</a></li>
@@ -17,7 +17,7 @@ A list of links charting the user’s place in the site structure. The title of 
     <li><a href="/docs/utilities-box-alignment--items-center">u-items-center</a></li>
     <li><a href="/docs/utilities-color--brand-1">u-fg</a></li>
     <li><a href="/docs/utilities-margin--margin-m">u-margin</a></li>
-    <li><a href="/docs/utilities-line-height--u-line-height-min">u-line-height--min</a></li>
+    <li><a href="/docs/utilities-line-height--u-line-height-min">u-line-height-min</a></li>
   </ul>
 </details>
 
@@ -28,19 +28,19 @@ A list of links charting the user’s place in the site structure. The title of 
         <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/">Main section</a>
-            <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-right"></use>
             </svg>
           </li>
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/">Sub section</a>
-            <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-right"></use>
             </svg>
           </li>
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/">Sub page</a>
-            <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-right"></use>
             </svg>
           </li>
@@ -56,27 +56,27 @@ Using the same structure, your root page might be represented with an icon, for 
   <Story name="Breadcrumbs with icon">
     {`
       <nav aria-label="breadcrumbs">
-        <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center u-line-height--min">
+        <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center u-line-height-min">
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/" class="u-margin-xs-right u-flex u-items-center">
               <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" class="a-icon a-icon--l" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-home"></use>
               </svg>
               <span class="u-sr-only">Home</span>
-              <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <svg width="14" height="14" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-right"></use>
             </svg>
             </a>
           </li>
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/">Sub section</a>
-            <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-right"></use>
             </svg>
           </li>
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/">Sub page</a>
-            <svg width="14" height="14" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <svg width="14" height="14" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-right"></use>
             </svg>
           </li>

--- a/scss/bitstyles/ui/button-groups.stories.mdx
+++ b/scss/bitstyles/ui/button-groups.stories.mdx
@@ -8,7 +8,7 @@ import icons from '../../../assets/images/icons.svg';
 A group of buttons aligned horizontally, collapsing onto a new row when there’s not enough space in their container for them all.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-icon--icon">a-icon</a></li>

--- a/scss/bitstyles/ui/buttons.stories.mdx
+++ b/scss/bitstyles/ui/buttons.stories.mdx
@@ -11,7 +11,7 @@ The button classes are used to make an interactive element look like a “button
 All the buttons produce a larger-than-text hit target, and by default react to `:hover`, `:focus`, `:active`, and `:disabled`. Visited states are not shown even if the button is an anchor, as “visited” doesn’t make sense for an action.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-danger--danger">a-button--danger</a></li>

--- a/scss/bitstyles/ui/dl.stories.mdx
+++ b/scss/bitstyles/ui/dl.stories.mdx
@@ -7,7 +7,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 A list of term/description pairs, used to display any set of key-value pairs. It’s totally valid to have multiple descriptions for a single term though — this can handle glossaries or dictionaries, where a single entry can have multiple values.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-content--content">a-content</a></li>
     <li><a href="/docs/atoms-dl--dl">a-dl</a></li>
@@ -27,19 +27,19 @@ A list of term/description pairs, used to display any set of key-value pairs. It
       <div class="a-content">
         <div class="u-padding-m-y u-padding-m@m">
           <h3 class="u-margin-0">Section title</h3>
-          <p class="u-fg--gray-50 u-h6">Cookie croissant jujubes tart. Jelly beans marshmallow cake apple pie. Sweet carrot cake marshmallow bonbon gummies lollipop bear claw.</p>
+          <p class="u-fg-gray-50 u-h6">Cookie croissant jujubes tart. Jelly beans marshmallow cake apple pie. Sweet carrot cake marshmallow bonbon gummies lollipop bear claw.</p>
         </div>
         <dl class="a-dl">
           <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-            <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Full name</dt>
+            <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">Full name</dt>
             <dd class="u-col-span-2">Muffin Gummies</dd>
           </div>
           <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-            <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Email</dt>
+            <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">Email</dt>
             <dd class="u-col-span-2">cupcake@tiramisu.com</dd>
           </div>
           <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-            <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Description</dt>
+            <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">Description</dt>
             <dd class="u-col-span-2">Muffin gummies tart fruitcake gummi bears chocolate bar. Jujubes candy macaroon topping dessert biscuit topping sugar plum sesame snaps. Chocolate donut cake tootsie roll donut biscuit caramels sugar plum jelly beans. Dessert dragée jelly-o gummi bears sweet halvah soufflé.</dd>
           </div>
         </dl>

--- a/scss/bitstyles/ui/dropdown-menu.stories.mdx
+++ b/scss/bitstyles/ui/dropdown-menu.stories.mdx
@@ -9,12 +9,12 @@ A button that when clicked reveals a floating menu of links. This is a combinati
 
 The component requires JS to show and hide the `ul`, and update the aria attributes when the user clicks the `.a-button--ui`.
 
-<div class="u-bg--gray-10 u-padding-m-x u-padding-xs-y">
+<div class="u-bg-gray-10 u-padding-m-x u-padding-xs-y">
   <p>These examples use AlpineJS for the behavior. If you’re using a different JS package, replace the blocks of html attributes starting with `x-`, and with `@click`.</p>
 </div>
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-ui--ui">a-button--ui</a></li>
@@ -27,7 +27,7 @@ The component requires JS to show and hide the `ul`, and update the aria attribu
     <li><a href="/docs/utilities-typography--typography">u-h6</a></li>
     <li><a href="/docs/utilities-color--brand-1">u-fg</a></li>
     <li><a href="/docs/utilities-margin--margin-m">u-margin</a></li>
-    <li><a href="/docs/utilities-overflow--overflow-y">u-overflow--y</a></li>
+    <li><a href="/docs/utilities-overflow--overflow-y">u-overflow-y</a></li>
     <li><a href="/docs/utilities-padding--padding-m">u-padding</a></li>
     <li><a href="/docs/utilities-relative--relative">u-relative</a></li>
   </ul>
@@ -66,7 +66,7 @@ These examples show various contents for the dropdown menus — what you put in 
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown u-overflow--y a-list-reset u-margin-s-top"
+            class="a-dropdown u-overflow-y a-list-reset u-margin-s-top"
             id="dropdown-1"
           >
             <li>
@@ -132,7 +132,7 @@ These examples show various contents for the dropdown menus — what you put in 
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown u-overflow--y a-list-reset u-margin-s-top"
+            class="a-dropdown u-overflow-y a-list-reset u-margin-s-top"
             id="dropdown-2"
           >
             <li>
@@ -198,16 +198,16 @@ These examples show various contents for the dropdown menus — what you put in 
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown u-overflow--y a-list-reset u-margin-s-top"
+            class="a-dropdown u-overflow-y a-list-reset u-margin-s-top"
             id="dropdown-3"
           >
             <li>
-              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
+              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height-min">
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
                 <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
-                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span class="u-fg-gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
               </div>
@@ -276,15 +276,15 @@ The default dropdowns are aligned to the left edge of their relative parent, und
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
             id="dropdown-3"
-            class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s-top"
+            class="a-dropdown a-dropdown--right u-overflow-y a-list-reset u-margin-s-top"
           >
             <li>
-              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
+              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height-min">
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
                 <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
-                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span class="u-fg-gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
               </div>
@@ -342,16 +342,16 @@ The default dropdowns are aligned to the left edge of their relative parent, und
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown a-dropdown--top u-overflow--y a-list-reset u-margin-s-bottom"
+            class="a-dropdown a-dropdown--top u-overflow-y a-list-reset u-margin-s-bottom"
             id="dropdown-3"
           >
             <li>
-              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
+              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height-min">
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
                 <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
-                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span class="u-fg-gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
               </div>
@@ -408,16 +408,16 @@ The default dropdowns are aligned to the left edge of their relative parent, und
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown a-dropdown--full-width u-overflow--y a-list-reset u-margin-s-top"
+            class="a-dropdown a-dropdown--full-width u-overflow-y a-list-reset u-margin-s-top"
             id="dropdown-3"
           >
             <li>
-              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
+              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height-min">
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
                 <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
-                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span class="u-fg-gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
               </div>
@@ -480,16 +480,16 @@ The directions can be combined.
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown a-dropdown--top a-dropdown--right u-overflow--y a-list-reset u-margin-s-bottom"
+            class="a-dropdown a-dropdown--top a-dropdown--right u-overflow-y a-list-reset u-margin-s-bottom"
             id="dropdown-3"
           >
             <li>
-              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
+              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height-min">
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
                 <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
-                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span class="u-fg-gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
               </div>
@@ -547,16 +547,16 @@ The directions can be combined.
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow--y a-list-reset u-margin-s-bottom"
+            class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y a-list-reset u-margin-s-bottom"
             id="dropdown-3"
           >
             <li>
-              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height--min">
+              <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height-min">
                 <div class="a-avatar a-avatar--l u-flex-shrink-0 u-flex u-items-center u-margin-s-right">
                   <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
                 </div>
                 <div class="u-flex-shrink-0 u-flex u-flex-col u-items-start">
-                  <span class="u-fg--gray-40">Signed in as</span>
+                  <span class="u-fg-gray-40">Signed in as</span>
                   <span>Username</span>
                 </div>
               </div>

--- a/scss/bitstyles/ui/filter.stories.mdx
+++ b/scss/bitstyles/ui/filter.stories.mdx
@@ -8,12 +8,12 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 When a user wants to filter a list of objects by fields which have a limited number of set values, present them with a group of checkboxes to choose from. To keep the UI clear, they can be hidden within a well-labelled dropdown menu.
 
-<div class="u-bg--gray-10 u-padding-m-x u-padding-xs-y">
+<div class="u-bg-gray-10 u-padding-m-x u-padding-xs-y">
   <p>These examples use AlpineJS for the behavior. If you’re using a different JS package, replace the blocks of html attributes starting with `x-`, and with `@click`.</p>
 </div>
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-ui--ui">a-button--ui</a></li>
@@ -26,7 +26,7 @@ When a user wants to filter a list of objects by fields which have a limited num
     <li><a href="/docs/atoms-list-reset--list-reset">a-list-reset</a></li>
     <li><a href="/docs/utilities-typography--typography">u-h6</a></li>
     <li><a href="/docs/utilities-margin--margin-m">u-margin</a></li>
-    <li><a href="/docs/utilities-overflow--overflow-y">u-overflow--y</a></li>
+    <li><a href="/docs/utilities-overflow--overflow-y">u-overflow-y</a></li>
     <li><a href="/docs/utilities-relative--relative">u-relative</a></li>
     <li><a href="/docs/utilities-sr-only--sr-only">u-sr-only</a></li>
   </ul>
@@ -63,7 +63,7 @@ When a user wants to filter a list of objects by fields which have a limited num
                 x-transition:leave-start="is-on-screen"
                 x-transition:leave-end="is-off-screen"
                 @click.away="dropdownOpen = false"
-                class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s-top"
+                class="a-dropdown a-dropdown--right u-overflow-y a-list-reset u-margin-s-top"
                 id="dropdown-1"
               >
                 <li>
@@ -116,7 +116,7 @@ When a user wants to filter a list of objects by fields which have a limited num
                 x-transition:leave-start="is-on-screen"
                 x-transition:leave-end="is-off-screen"
                 @click.away="dropdownOpen = false"
-                class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s-top"
+                class="a-dropdown a-dropdown--right u-overflow-y a-list-reset u-margin-s-top"
                 id="dropdown-2"
               >
                 <li>
@@ -167,12 +167,12 @@ Some fields such as names and emails will need to be filtered by user-entered fr
           <ul class="o-ui-group u-flex a-list-reset">
             <li class="u-flex">
               <label for="search_users" class="u-sr-only">Search users</label>
-              <input type="search" id="search_users" class="o-ui-group__item u-round-0--tr u-round-0--br" placeholder="Search users…" />
+              <input type="search" id="search_users" class="o-ui-group__item u-round-0-tr u-round-0-br" placeholder="Search users…" />
             </li>
             <li class="u-flex u-relative" x-data="{ dropdownOpen: false }">
               <button
                 type="button"
-                class="a-button a-button--ui u-round-0--tl u-round-0--bl"
+                class="a-button a-button--ui u-round-0-tl u-round-0-bl"
                 aria-controls="dropdown-1"
                 @click="dropdownOpen = !dropdownOpen"
                 :aria-expanded="dropdownOpen"
@@ -191,7 +191,7 @@ Some fields such as names and emails will need to be filtered by user-entered fr
                 x-transition:leave-start="is-on-screen"
                 x-transition:leave-end="is-off-screen"
                 @click.away="dropdownOpen = false"
-                class="a-dropdown a-dropdown--right u-margin-s-top u-overflow--y a-list-reset u-margin-s-bottom"
+                class="a-dropdown a-dropdown--right u-margin-s-top u-overflow-y a-list-reset u-margin-s-bottom"
                 id="dropdown-1"
               >
                 <li>
@@ -237,12 +237,12 @@ When giving the user filters by category and free text, place the free text sear
               <ul class="o-ui-group u-flex a-list-reset">
                 <li class="u-flex">
                   <label for="search_users" class="u-sr-only">Search users</label>
-                  <input type="search" id="search_users" class="o-ui-group__item u-round-0--tr u-round-0--br" placeholder="Search users…" />
+                  <input type="search" id="search_users" class="o-ui-group__item u-round-0-tr u-round-0-br" placeholder="Search users…" />
                 </li>
                 <li class="u-flex u-relative" x-data="{ dropdownOpen: false }">
                   <button
                     type="button"
-                    class="a-button a-button--ui u-round-0--tl u-round-0--bl"
+                    class="a-button a-button--ui u-round-0-tl u-round-0-bl"
                     aria-controls="dropdown-1"
                     @click="dropdownOpen = !dropdownOpen"
                     :aria-expanded="dropdownOpen"
@@ -262,7 +262,7 @@ When giving the user filters by category and free text, place the free text sear
                     x-transition:leave-start="is-on-screen"
                     x-transition:leave-end="is-off-screen"
                     @click.away="dropdownOpen = false"
-                    class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s-top"
+                    class="a-dropdown a-dropdown--right u-overflow-y a-list-reset u-margin-s-top"
                     id="dropdown-1"
                   >
                     <li>
@@ -305,7 +305,7 @@ When giving the user filters by category and free text, place the free text sear
                 x-transition:leave-start="is-on-screen"
                 x-transition:leave-end="is-off-screen"
                 @click.away="dropdownOpen = false"
-                class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s-top"
+                class="a-dropdown a-dropdown--right u-overflow-y a-list-reset u-margin-s-top"
                 id="dropdown-1"
               >
                 <li>

--- a/scss/bitstyles/ui/flashes.stories.mdx
+++ b/scss/bitstyles/ui/flashes.stories.mdx
@@ -8,7 +8,7 @@ import icons from '../../../assets/images/icons.svg';
 Inform the user of a global or important event, such as may happen after a page reload. There are several variants, which use color, iconography, and html attributes to indicate severity.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-content--content">a-content</a></li>
     <li><a href="/docs/atoms-flash--flash-brand-1">a-flash</a></li>
@@ -26,7 +26,7 @@ Inform the user of a global or important event, such as may happen after a page 
     {`
       <div aria-live="polite">
         <div class="u-padding-l-y a-flash--brand-1">
-          <div class="a-content u-flex u-items-center u-font--medium">
+          <div class="a-content u-flex u-items-center u-font-medium">
             <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-info-circle"></use>
             </svg>
@@ -40,7 +40,7 @@ Inform the user of a global or important event, such as may happen after a page 
     {`
       <div aria-live="polite">
         <div class="u-padding-l-y a-flash--positive" aria-live="polite">
-          <div class="a-content u-flex u-items-center u-font--medium">
+          <div class="a-content u-flex u-items-center u-font-medium">
             <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-check-circle"></use>
             </svg>
@@ -54,7 +54,7 @@ Inform the user of a global or important event, such as may happen after a page 
     {`
       <div aria-live="polite">
         <div class="u-padding-l-y a-flash--warning" aria-live="polite">
-          <div class="a-content u-flex u-items-center u-font--medium">
+          <div class="a-content u-flex u-items-center u-font-medium">
             <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-question-circle"></use>
             </svg>
@@ -68,7 +68,7 @@ Inform the user of a global or important event, such as may happen after a page 
     {`
       <div aria-live="polite">
         <div class="u-padding-l-y a-flash--danger" role="alert">
-          <div class="a-content u-flex u-items-center u-font--medium">
+          <div class="a-content u-flex u-items-center u-font-medium">
             <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-exclamation"></use>
             </svg>

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -14,7 +14,7 @@ Form elements will take 100% of the available width, so you’ll likely want to 
 Here are some examples using the grid utility classes to create common form layouts.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-card--card">a-card</a></li>
     <li><a href="/docs/atoms-content--content">a-content</a></li>
@@ -37,7 +37,7 @@ Here are some examples using the grid utility classes to create common form layo
   <Story name="Login form">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card-l@m u-bg--white" method="POST" action="">
+        <form class="a-card-l@m u-bg-white" method="POST" action="">
           <h2>Login</h2>
           <ul class="a-list-reset u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
@@ -80,7 +80,7 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
   <Story name="Login form with errors">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card-l@m u-bg--white" method="POST" action="">
+        <form class="a-card-l@m u-bg-white" method="POST" action="">
           <div class="a-card-l__header@m a-flash a-flash--warning" role="alert">
             <div class="u-flex u-items-center">
               <svg width="14" height="14" class="a-icon a-icon--l u-flex-shrink-0 u-margin-m-right" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -94,7 +94,7 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
             <li class="u-margin-m-bottom">
               <label for="email">Email</label>
               <input id="email" type="email" autocomplete="email" aria-invalid="true" aria-describedby="email-help-text" />
-              <span id="email-help-text" class="u-fg--warning u-margin-xs-top">Missing email address</span>
+              <span id="email-help-text" class="u-fg-warning u-margin-xs-top">Missing email address</span>
             </li>
             <li class="u-margin-m-bottom u-flex u-flex-col">
               <label for="password">Password</label>
@@ -126,7 +126,7 @@ This form has the commonly-required fields for creating an account. Note the wor
   <Story name="Sign up form">
     {`
       <div class="a-content a-content--s">
-        <form class="a-card-l@m u-bg--white" method="POST" action="">
+        <form class="a-card-l@m u-bg-white" method="POST" action="">
           <h2>Create an account</h2>
           <ul class="a-list-reset u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
@@ -167,7 +167,7 @@ For a more complex form, `.u-grid-cols-6@m` allows for fields of different sizes
         <h2>Profile</h2>
         <fieldset class="u-margin-xl-bottom u-padding-xl-bottom">
           <div class="a-bordered-header u-margin-xl-bottom">
-            <legend class="u-h3 u-font--bold">Account details</legend>
+            <legend class="u-h3 u-font-bold">Account details</legend>
           </div>
           <div class="u-grid u-gap-m u-grid-cols-6@l u-gap-m">
             <ul class="a-list-reset u-col-start-3@l u-grid u-gap-m u-grid-cols-6@m u-col-span-4@l">
@@ -191,11 +191,11 @@ For a more complex form, `.u-grid-cols-6@m` allows for fields of different sizes
         </fieldset>
         <fieldset class="u-margin-xl-bottom u-padding-xl-bottom">
           <div class="a-bordered-header u-margin-xl-bottom">
-            <legend class="u-h3 u-font--bold a-bordered-header">Address</legend>
+            <legend class="u-h3 u-font-bold a-bordered-header">Address</legend>
           </div>
           <div class="u-grid u-gap-m u-grid-cols-6@l">
             <div class="u-col-span-2@l">
-              <p class="u-h6 u-fg--gray-50 u-padding-l-y@l u-padding-xl-right@m">Some intro text can go here, to describe this section</p>
+              <p class="u-h6 u-fg-gray-50 u-padding-l-y@l u-padding-xl-right@m">Some intro text can go here, to describe this section</p>
             </div>
             <ul class="a-list-reset u-col-start-3@l u-col-span-4@l u-grid u-gap-m u-grid-cols-6@m u-gap-m">
               <li class="u-col-span-4@m u-col-span-3@l">
@@ -283,8 +283,8 @@ The `role="search"` attribute highlights this functionality for screenreader use
     {`
     <form role="search" action="" method="POST" class="u-flex o-ui-group">
       <label for="search" class="u-sr-only">Search users</label>
-      <input type="search" id="search" placeholder="Username or email…" class="u-flex-grow-1 u-round-0--tr u-round-0--br o-ui-group__item" />
-      <button type="submit" class="a-button a-button--ui o-ui-group__item o-ui-group__last u-round-0--tl u-round-0--bl">Search</button>
+      <input type="search" id="search" placeholder="Username or email…" class="u-flex-grow-1 u-round-0-tr u-round-0-br o-ui-group__item" />
+      <button type="submit" class="a-button a-button--ui o-ui-group__item o-ui-group__last u-round-0-tl u-round-0-bl">Search</button>
     </form>
     `}
   </Story>
@@ -295,8 +295,8 @@ The `role="search"` attribute highlights this functionality for screenreader use
     {`
     <form role="search" action="" method="POST" class="u-flex o-ui-group">
       <label for="search" class="u-sr-only">Search users</label>
-      <input type="search" id="search" placeholder="Username or email…" class="u-flex-grow-1 o-ui-group__item u-round-0--tr u-round-0--br" />
-      <button type="submit" class="a-button a-button--ui o-ui-group__item o-ui-group__last u-round-0--tl u-round-0--bl" title="Search users">
+      <input type="search" id="search" placeholder="Username or email…" class="u-flex-grow-1 o-ui-group__item u-round-0-tr u-round-0-br" />
+      <button type="submit" class="a-button a-button--ui o-ui-group__item o-ui-group__last u-round-0-tl u-round-0-bl" title="Search users">
         <svg width="18" height="18" class="a-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
           <use xlink:href="${icons}#icon-search"></use>
         </svg>

--- a/scss/bitstyles/ui/joined-buttons.stories.mdx
+++ b/scss/bitstyles/ui/joined-buttons.stories.mdx
@@ -12,7 +12,7 @@ For a series of buttons that are very directly related e.g.
 - pagination buttons
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-icon-icon">a-button--icon</a></li>
@@ -39,7 +39,7 @@ When you have multiple actions that are applied to a single entity, group those 
     {`
       <ul class="a-list-reset u-inline-flex u-items-stretch o-ui-group">
         <li class="u-flex">
-          <button class="a-button a-button--icon a-button--ui u-round-0--tr u-round-0--br o-ui-group__item" type="button">
+          <button class="a-button a-button--icon a-button--ui u-round-0-tr u-round-0-br o-ui-group__item" type="button">
             <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-minus"></use>
             </svg>
@@ -47,7 +47,7 @@ When you have multiple actions that are applied to a single entity, group those 
           </button>
         </li>
         <li class="u-flex">
-          <button class="a-button a-button--icon a-button--ui o-ui-group__item o-ui-group__last u-round-0--tl u-round-0--bl" type="button">
+          <button class="a-button a-button--icon a-button--ui o-ui-group__item o-ui-group__last u-round-0-tl u-round-0-bl" type="button">
             <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-plus"></use>
             </svg>
@@ -64,7 +64,7 @@ When you have multiple actions that are applied to a single entity, group those 
     {`
       <ul class="a-list-reset u-inline-flex u-items-stretch o-ui-group">
         <li class="u-flex">
-          <button class="a-button a-button--icon a-button--ui u-round-0--tr u-round-0--br o-ui-group__item" type="button">
+          <button class="a-button a-button--icon a-button--ui u-round-0-tr u-round-0-br o-ui-group__item" type="button">
             <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-left"></use>
             </svg>
@@ -72,7 +72,7 @@ When you have multiple actions that are applied to a single entity, group those 
           </button>
         </li>
         <li class="u-flex">
-          <button class="a-button a-button--icon a-button--ui o-ui-group__item o-ui-group__last u-round-0--tl u-round-0--bl" type="button">
+          <button class="a-button a-button--icon a-button--ui o-ui-group__item o-ui-group__last u-round-0-tl u-round-0-bl" type="button">
             <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
               <use xlink:href="${icons}#icon-caret-right"></use>
             </svg>
@@ -94,7 +94,7 @@ Mark the current page in a series of pagination buttons by giving the link the `
       <nav aria-label="pagination">
         <ul class="a-list-reset u-inline-flex u-items-stretch o-ui-group">
           <li class="u-flex">
-            <a href="/" class="a-button a-button--icon a-button--ui u-round-0--tr u-round-0--br o-ui-group__item">
+            <a href="/" class="a-button a-button--icon a-button--ui u-round-0-tr u-round-0-br o-ui-group__item">
               <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-caret-left"></use>
               </svg>
@@ -122,7 +122,7 @@ Mark the current page in a series of pagination buttons by giving the link the `
             </a>
           </li>
           <li class="u-flex">
-            <a href="/" class="a-button a-button--icon a-button--ui o-ui-group__item o-ui-group__last u-round-0--tl u-round-0--bl">
+            <a href="/" class="a-button a-button--icon a-button--ui o-ui-group__item o-ui-group__last u-round-0-tl u-round-0-bl">
               <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-caret-right"></use>
               </svg>
@@ -138,7 +138,7 @@ Mark the current page in a series of pagination buttons by giving the link the `
       <nav aria-label="pagination">
         <ul class="a-list-reset u-inline-flex u-items-stretch o-ui-group">
           <li class="u-flex">
-            <a href="/" class="a-button a-button--icon a-button--ui u-round-0--tr u-round-0--br o-ui-group__item" aria-disabled="true">
+            <a href="/" class="a-button a-button--icon a-button--ui u-round-0-tr u-round-0-br o-ui-group__item" aria-disabled="true">
               <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-caret-left"></use>
               </svg>
@@ -166,7 +166,7 @@ Mark the current page in a series of pagination buttons by giving the link the `
             </a>
           </li>
           <li class="u-flex">
-            <a href="/" class="a-button a-button--icon a-button--ui o-ui-group__item o-ui-group__last u-round-0--tl u-round-0--bl" aria-disabled="true">
+            <a href="/" class="a-button a-button--icon a-button--ui o-ui-group__item o-ui-group__last u-round-0-tl u-round-0-bl" aria-disabled="true">
               <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                 <use xlink:href="${icons}#icon-caret-right"></use>
               </svg>

--- a/scss/bitstyles/ui/mode-switch-buttons.stories.mdx
+++ b/scss/bitstyles/ui/mode-switch-buttons.stories.mdx
@@ -9,7 +9,7 @@ A series of buttons to switch between modes of a view. In the example below, the
 The currently-selected mode is indicated with the `aria-pressed="true"` attribute.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-mode-mode">a-button--mode</a></li>
@@ -25,7 +25,7 @@ The currently-selected mode is indicated with the `aria-pressed="true"` attribut
 <Canvas>
   <Story name="Mode-switch buttons">
     {`
-      <ul class="a-list-reset u-inline-flex u-items-stretch u-items-center a-button--mode-container u-padding-xs u-bg--gray-20">
+      <ul class="a-list-reset u-inline-flex u-items-stretch u-items-center a-button--mode-container u-padding-xs u-bg-gray-20">
         <li class="u-margin-xs-right">
           <button class="a-button a-button--mode u-h6" type="button">
             Year

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -11,12 +11,12 @@ A top-level navigation container, with two sections separated to the left & righ
 
 Give the active link the `aria-current="page"` attribute.
 
-<div class="u-bg--gray-10 u-padding-m-x u-padding-xs-y">
+<div class="u-bg-gray-10 u-padding-m-x u-padding-xs-y">
   <p>These examples use AlpineJS for the behavior. If you’re using a different JS package, replace the blocks of html attributes starting with `x-`, and with `@click`.</p>
 </div>
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-avatar--avatar">a-avatar</a></li>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
@@ -40,12 +40,12 @@ Give the active link the `aria-current="page"` attribute.
 <Canvas>
   <Story name="Navbar" inline={false} height="80vh">
     {`
-      <nav class="u-bg--gray-80 u-padding-s-top u-padding-s-bottom u-relative">
+      <nav class="u-bg-gray-80 u-padding-s-top u-padding-s-bottom u-relative">
         <div class="u-padding-m-x u-flex u-justify-between u-items-center u-flex-wrap">
           <div class="u-flex-shrink-1 u-flex u-items-center">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden u-block@l" />
             <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden@l" />
-            <div class="u-hidden u-block@l u-flex-shrink-1 u-overflow--x">
+            <div class="u-hidden u-block@l u-flex-shrink-1 u-overflow-x">
               <ul class="u-flex a-list-reset">
                 <li class="u-margin-m-right">
                   <a href="/" class="a-button a-button--nav" aria-current="page">Team</a>
@@ -81,7 +81,7 @@ Give the active link the `aria-current="page"` attribute.
               <span class="u-sr-only">Toggle menu</span>
             </button>
             <ul
-              class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg--gray-80"
+              class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg-gray-80"
               id="navbar-1"
               x-show="navbarOpen"
               @click.away="navbarOpen = false"
@@ -124,12 +124,12 @@ This navbar is only intended to hold a few link to the main sections of your sit
 <Canvas>
   <Story name="Navbar with many links" inline={false} height="80vh">
     {`
-      <nav class="u-bg--gray-80 u-padding-s-top u-padding-s-bottom u-relative">
+      <nav class="u-bg-gray-80 u-padding-s-top u-padding-s-bottom u-relative">
         <div class="u-padding-m-x u-flex u-justify-between u-items-center">
           <div class="u-flex-shrink-1 u-flex u-items-center">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden u-block@l" />
             <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden@l" />
-            <div class="u-hidden u-block@l u-flex-shrink-1 u-overflow--x">
+            <div class="u-hidden u-block@l u-flex-shrink-1 u-overflow-x">
               <ul class="u-flex a-list-reset">
                 <li class="u-margin-m-right">
                   <a href="/" class="a-button a-button--nav" aria-current="page">Team</a>
@@ -177,7 +177,7 @@ This navbar is only intended to hold a few link to the main sections of your sit
               <span class="u-sr-only">Toggle menu</span>
             </button>
             <ul
-              class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg--gray-80"
+              class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg-gray-80"
               id="navbar-1"
               x-show="navbarOpen"
               @click.away="navbarOpen = false"

--- a/scss/bitstyles/ui/notifications.stories.mdx
+++ b/scss/bitstyles/ui/notifications.stories.mdx
@@ -14,7 +14,7 @@ Notifications are presented in an element with `aria-live="polite"`, which shoul
 Some notifications may require or enable further actions by the user — add buttons underneath the text content for this.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-ui--ui">a-button--ui</a></li>

--- a/scss/bitstyles/ui/page-header.stories.mdx
+++ b/scss/bitstyles/ui/page-header.stories.mdx
@@ -12,12 +12,12 @@ The intro to every page, containing slots for:
 - action [buttons](/docs/ui-buttons-buttons--page)
 - [tabs](/docs/ui-navigation-tabs--tabs) for organising the content (note that no tabpanels are shown here)
 
-<div class="u-bg--gray-10 u-padding-m-x u-padding-xs-y">
+<div class="u-bg-gray-10 u-padding-m-x u-padding-xs-y">
   <p>These examples use AlpineJS for the behavior. If you’re using a different JS package, replace the blocks of html attributes starting with `x-`, and with `@click`.</p>
 </div>
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-ui--ui">a-button--ui</a></li>
@@ -45,25 +45,25 @@ This first example shows a header with all these slots filled:
   <Story name="Page header">
     {`
       <article>
-        <header class="u-bg--gray-5 u-padding-l-top">
+        <header class="u-bg-gray-5 u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
               <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Sub section</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Sub page</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>
@@ -72,7 +72,7 @@ This first example shows a header with all these slots filled:
                 <div class="u-flex u-flex-wrap u-items-center">
                   <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                   <div class="u-flex-shrink-0 u-margin-m-bottom">
-                    <span class="a-badge a-badge--gray u-font--medium">Published</span>
+                    <span class="a-badge a-badge--gray u-font-medium">Published</span>
                   </div>
                 </div>
                 <ul class="a-list-reset u-flex u-flex-wrap">
@@ -98,7 +98,7 @@ This first example shows a header with all these slots filled:
                       x-transition:leave-start="is-on-screen"
                       x-transition:leave-end="is-off-screen"
                       @click.away="dropdownOpen = false"
-                      class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s-top"
+                      class="a-dropdown a-dropdown--right u-overflow-y a-list-reset u-margin-s-top"
                       id="dropdown-1"
                     >
                       <li>
@@ -142,7 +142,7 @@ This first example shows a header with all these slots filled:
                 </ul>
               </div>
             </div>
-            <ul class="a-list-reset u-flex u-overflow--x u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
+            <ul class="a-list-reset u-flex u-overflow-x u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
               <li class="u-margin-s-right">
                 <button class="a-button a-button--tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">
                   Personal details
@@ -172,25 +172,25 @@ It’s also common to not need tabs — if the content is not large and varied e
   <Story name="Page header, no tabs">
     {`
       <article>
-        <header class="u-bg--gray-5 u-padding-l-top">
+        <header class="u-bg-gray-5 u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
               <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Sub section</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Sub page</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>
@@ -199,7 +199,7 @@ It’s also common to not need tabs — if the content is not large and varied e
                 <div class="u-flex u-flex-wrap u-items-center">
                   <h1 class="u-margin-m-right u-break-text">Resource name/ID</h1>
                   <div class="u-flex-shrink-0 u-margin-m-bottom">
-                    <span class="a-badge a-badge--gray u-font--medium">Published</span>
+                    <span class="a-badge a-badge--gray u-font-medium">Published</span>
                   </div>
                 </div>
                 <ul class="a-list-reset u-flex u-flex-wrap">
@@ -225,7 +225,7 @@ It’s also common to not need tabs — if the content is not large and varied e
                       x-transition:leave-start="is-on-screen"
                       x-transition:leave-end="is-off-screen"
                       @click.away="dropdownOpen = false"
-                      class="a-dropdown a-dropdown--right u-overflow--y a-list-reset u-margin-s-top"
+                      class="a-dropdown a-dropdown--right u-overflow-y a-list-reset u-margin-s-top"
                       id="dropdown-1"
                     >
                       <li>
@@ -282,25 +282,25 @@ This is a minimal example, with only breadcrumbs and a heading.
   <Story name="Page header, minimal">
     {`
       <article>
-        <header class="u-bg--gray-5 u-padding-l-top">
+        <header class="u-bg-gray-5 u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
               <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Sub section</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Sub page</a>
-                  <svg width="18" height="18" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                     <use xlink:href="${icons}#icon-caret-right"></use>
                   </svg>
                 </li>

--- a/scss/bitstyles/ui/section-heading.stories.mdx
+++ b/scss/bitstyles/ui/section-heading.stories.mdx
@@ -7,7 +7,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 A heading with optional actions, badges and labels. Be sure to use the correct h-level heading element (all heading here are `<h3>`s).
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-ui--ui">a-button--ui</a></li>
@@ -48,7 +48,7 @@ Next to the heading text is a good place to add important information about the 
         <h3 class="u-margin-0 u-margin-xs-right">
           Recent bookings
         </h3>
-        <span class="u-fg--gray-50 u-font--normal u-h6">[3/10]<span>
+        <span class="u-fg-gray-50 u-font-normal u-h6">[3/10]<span>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -11,12 +11,12 @@ A vertical navbar provides more space than a horizontal version, useful for a lo
 
 Uses a fullwidth dropdown to fit with no overlap.
 
-<div class="u-bg--gray-10 u-padding-m-x u-padding-xs-y">
+<div class="u-bg-gray-10 u-padding-m-x u-padding-xs-y">
   <p>These examples use AlpineJS for the behavior. If you’re using a different JS package, replace the blocks of html attributes starting with `x-`, and with `@click`.</p>
 </div>
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-avatar--avatar">a-avatar</a></li>
     <li><a href="/docs/atoms-button-menu--menu">a-button--menu</a></li>
@@ -43,9 +43,9 @@ Uses a fullwidth dropdown to fit with no overlap.
     {`
       <div class="u-flex u-height-100vh" x-data="{ sidebarOpen: false }">
         <nav class="u-flex">
-          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg--gray-80 u-padding-m-top u-flex@l u-flex-col">
+          <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg-gray-80 u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
@@ -120,7 +120,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 <span class="a-button__label">Jane Dobermann</span>
               </button>
               <ul
-                class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow--y a-list-reset u-margin-s-bottom"
+                class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y a-list-reset u-margin-s-bottom"
                 id="dropdown-3"
                 x-show="dropdownOpen"
                 x-transition:enter="is-transitioning"
@@ -156,7 +156,7 @@ Uses a fullwidth dropdown to fit with no overlap.
             </div>
           </div>
           <div
-            class="o-sidebar--small u-bg--gray-80 u-flex u-flex-col u-hidden@l"
+            class="o-sidebar--small u-bg-gray-80 u-flex u-flex-col u-hidden@l"
             x-show="sidebarOpen"
             @click.away="sidebarOpen = false"
             x-transition:enter="is-transitioning"
@@ -178,7 +178,7 @@ Uses a fullwidth dropdown to fit with no overlap.
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-xxs-left" aria-hidden="true" focusable="false">
@@ -256,7 +256,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 x-show="dropdownOpen"
                 @click.away="dropdownOpen = false"
                 id="dropdown-4"
-                class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow--y a-list-reset u-margin-s-bottom"
+                class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y a-list-reset u-margin-s-bottom"
               >
                 <li>
                   <a href="/" class="a-button a-button--menu u-h6">
@@ -283,7 +283,7 @@ Uses a fullwidth dropdown to fit with no overlap.
             </div>
           </div>
         </nav>
-        <main class="u-flex-grow-1 u-padding-xxl-left@l u-padding-xl-right@l u-padding-xl-bottom u-padding-m u-overflow--y">
+        <main class="u-flex-grow-1 u-padding-xxl-left@l u-padding-xl-right@l u-padding-xl-bottom u-padding-m u-overflow-y">
           <div class="u-flex u-items-center u-margin-m-bottom">
             <button
               class="u-flex-shrink-0 u-margin-neg-m-left a-button a-button--icon a-button--icon-reversed u-margin-xs-right u-hidden@l"

--- a/scss/bitstyles/ui/stats.stories.mdx
+++ b/scss/bitstyles/ui/stats.stories.mdx
@@ -10,7 +10,7 @@ Highlight a few statistics that will be important to the user as soon as they ar
 Highlighting a few statistics presents us the opportunity to give context and increase rapid understanding. This example indicates the direction of change over time for each statistic.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-badge--badge">a-badge</a></li>
     <li><a href="/docs/utilities-color--gray-50">u-fg</a></li>
@@ -43,8 +43,8 @@ Highlighting a few statistics presents us the opportunity to give context and in
               </div>
             </div>
             <div>
-              <dt class="u-font--medium u-h6 u-fg--gray-50">In storage</dt>
-              <dd class="u-h2 u-font--bold u-line-height--min">104</dd>
+              <dt class="u-font-medium u-h6 u-fg-gray-50">In storage</dt>
+              <dd class="u-h2 u-font-bold u-line-height-min">104</dd>
             </div>
           </div>
           <div class="a-card u-flex u-items-center">
@@ -57,8 +57,8 @@ Highlighting a few statistics presents us the opportunity to give context and in
               </div>
             </div>
             <div>
-              <dt class="u-font--medium u-h6 u-fg--gray-50">In transit</dt>
-              <dd class="u-h2 u-font--bold u-line-height--min">32</dd>
+              <dt class="u-font-medium u-h6 u-fg-gray-50">In transit</dt>
+              <dd class="u-h2 u-font-bold u-line-height-min">32</dd>
             </div>
           </div>
           <div class="a-card u-flex u-items-center">
@@ -71,8 +71,8 @@ Highlighting a few statistics presents us the opportunity to give context and in
               </div>
             </div>
             <div>
-              <dt class="u-font--medium u-h6 u-fg--gray-50">Submitted</dt>
-              <dd class="u-h2 u-font--bold u-line-height--min">379</dd>
+              <dt class="u-font-medium u-h6 u-fg-gray-50">Submitted</dt>
+              <dd class="u-h2 u-font-bold u-line-height-min">379</dd>
             </div>
           </div>
         </dl>
@@ -97,8 +97,8 @@ As in this next example, the change indicators could be replaced by static icono
               </div>
             </div>
             <div>
-              <dt class="u-font--medium u-h6 u-fg--gray-50">In storage</dt>
-              <dd class="u-h2 u-font--bold u-line-height--min">104</dd>
+              <dt class="u-font-medium u-h6 u-fg-gray-50">In storage</dt>
+              <dd class="u-h2 u-font-bold u-line-height-min">104</dd>
             </div>
           </div>
           <div class="a-card u-flex u-items-center">
@@ -110,8 +110,8 @@ As in this next example, the change indicators could be replaced by static icono
               </div>
             </div>
             <div>
-              <dt class="u-font--medium u-h6 u-fg--gray-50">In transit</dt>
-              <dd class="u-h2 u-font--bold u-line-height--min">32</dd>
+              <dt class="u-font-medium u-h6 u-fg-gray-50">In transit</dt>
+              <dd class="u-h2 u-font-bold u-line-height-min">32</dd>
             </div>
           </div>
           <div class="a-card u-flex u-items-center">
@@ -124,8 +124,8 @@ As in this next example, the change indicators could be replaced by static icono
               </div>
             </div>
             <div>
-              <dt class="u-font--medium u-h6 u-fg--gray-50">Submitted</dt>
-              <dd class="u-h2 u-font--bold u-line-height--min">379</dd>
+              <dt class="u-font-medium u-h6 u-fg-gray-50">Submitted</dt>
+              <dd class="u-h2 u-font-bold u-line-height-min">379</dd>
             </div>
           </div>
         </dl>
@@ -142,16 +142,16 @@ The simplest form (but least easily-digestible for the user) shows some text-onl
       <div class="a-content">
         <dl class="u-grid u-grid-cols-3@m u-gap-m">
           <div class="a-card">
-            <dt class="u-font--medium u-h6 u-fg--gray-50">In storage</dt>
-            <dd class="u-h2 u-font--bold u-line-height--min">104</dd>
+            <dt class="u-font-medium u-h6 u-fg-gray-50">In storage</dt>
+            <dd class="u-h2 u-font-bold u-line-height-min">104</dd>
           </div>
           <div class="a-card">
-            <dt class="u-font--medium u-h6 u-fg--gray-50">In transit</dt>
-            <dd class="u-h2 u-font--bold u-line-height--min">32</dd>
+            <dt class="u-font-medium u-h6 u-fg-gray-50">In transit</dt>
+            <dd class="u-h2 u-font-bold u-line-height-min">32</dd>
           </div>
           <div class="a-card">
-            <dt class="u-font--medium u-h6 u-fg--gray-50">Submitted</dt>
-            <dd class="u-h2 u-font--bold u-line-height--min">379</dd>
+            <dt class="u-font-medium u-h6 u-fg-gray-50">Submitted</dt>
+            <dd class="u-h2 u-font-bold u-line-height-min">379</dd>
           </div>
         </dl>
       </div>

--- a/scss/bitstyles/ui/table.stories.mdx
+++ b/scss/bitstyles/ui/table.stories.mdx
@@ -7,7 +7,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 Add base styling to your tables by giving them the `o-table` class. As shown here, always add an overflow wrapper to handle smaller viewports. Tables do not resize well, so allowing horizontal scrolling is a simple and clear way to make the table accessible to smaller devices.
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-badge--badge">a-badge</a></li>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
@@ -30,7 +30,7 @@ Add base styling to your tables by giving them the `o-table` class. As shown her
 <Canvas>
   <Story name="Table">
     {`
-      <div class="a-card u-padding-0 u-overflow--x">
+      <div class="a-card u-padding-0 u-overflow-x">
         <table class="o-table u-h6">
           <caption class="u-sr-only">Describe the table content here</caption>
           <thead>
@@ -46,7 +46,7 @@ Add base styling to your tables by giving them the `o-table` class. As shown her
               <td>Sesame S. Snaps</td>
               <td>sesame.snaps@gmail.com</td>
               <td><span class="a-badge a-badge--danger">Banned</span></td>
-              <td class="o-table__actions u-text--right">
+              <td class="o-table__actions u-text-right">
                 <ul class="a-list-reset u-inline-flex">
                   <li class="u-margin-xs-right">
                     <a href="/" class="a-button a-button--ui a-button--small">Show</a>
@@ -64,7 +64,7 @@ Add base styling to your tables by giving them the `o-table` class. As shown her
               <td>Croissant B. Gummies with the very long multi-word name</td>
               <td>croissant.gummies@gmx.de</td>
               <td><span class="a-badge a-badge--positive">Confirmed</span></td>
-              <td class="o-table__actions u-text--right">
+              <td class="o-table__actions u-text-right">
                 <ul class="a-list-reset u-inline-flex">
                   <li class="u-margin-xs-right">
                     <a href="/" class="a-button a-button--ui a-button--small">Show</a>
@@ -82,7 +82,7 @@ Add base styling to your tables by giving them the `o-table` class. As shown her
               <td>Liquorice G Fruitcake</td>
               <td>liquorice.fruitcake@mailbox.org</td>
               <td><span class="a-badge a-badge--positive">Confirmed</span></td>
-              <td class="o-table__actions u-text--right">
+              <td class="o-table__actions u-text-right">
                 <ul class="a-list-reset u-inline-flex">
                   <li class="u-margin-xs-right">
                     <a href="/" class="a-button a-button--ui a-button--small">Show</a>

--- a/scss/bitstyles/ui/tabs.stories.mdx
+++ b/scss/bitstyles/ui/tabs.stories.mdx
@@ -11,7 +11,7 @@ Take note of all the aria attributes that tie the tabs to their tabpanels, and v
 Also note the differences in attributes of selected/deselected tabs (`aria-selected` is switched) and selected/deselected tabpanels (`hidden` attribute is added/removed).
 
 <details class="u-margin-xl-y">
-  <summary class="u-h4 u-font--medium">Examples use</summary>
+  <summary class="u-h4 u-font-medium">Examples use</summary>
   <ul>
     <li><a href="/docs/atoms-button-base--button-element">a-button</a></li>
     <li><a href="/docs/atoms-button-tab--tab">a-button--tab</a></li>
@@ -29,7 +29,7 @@ Also note the differences in attributes of selected/deselected tabs (`aria-selec
 <Canvas isColumn>
   <Story name="Tabs">
     {`
-      <div class="u-bg--gray-5 u-padding-xl-top">
+      <div class="u-bg-gray-5 u-padding-xl-top">
         <div class="a-content">
           <ul class="a-list-reset u-flex u-flex-wrap u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
             <li class="u-margin-s-right">

--- a/scss/bitstyles/utilities/absolute-center/absolute-center.stories.mdx
+++ b/scss/bitstyles/utilities/absolute-center/absolute-center.stories.mdx
@@ -11,7 +11,7 @@ As this class makes use of absolute positioning, the element is no longer in the
 <Canvas>
   <Story name="Absolute center">
     {`
-      <div class="u-bg--brand-2" style="min-height: 10rem; position: relative">
+      <div class="u-bg-brand-2" style="min-height: 10rem; position: relative">
         <div class="u-absolute-center">This element is exactly centered within the parent element</div>
       </div>
     `}

--- a/scss/bitstyles/utilities/absolute-cover/absolute-cover.stories.mdx
+++ b/scss/bitstyles/utilities/absolute-cover/absolute-cover.stories.mdx
@@ -9,7 +9,7 @@ This creates an element that completely covers its closest non-statically positi
 <Canvas>
   <Story name="Absolute cover">
     {`
-      <div class="u-bg--brand-2" style="min-height: 10rem; position: relative">
+      <div class="u-bg-brand-2" style="min-height: 10rem; position: relative">
         <div class="u-absolute-cover">This element covers the entire parent element</div>
       </div>
     `}

--- a/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
+++ b/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
@@ -20,15 +20,15 @@ $bitstyles-aspect-ratios: (
 <Canvas isColumn>
   <Story name="aspect-ratio-1-1">
     {`
-      <div class="u-aspect-ratio-1-1 u-bg--brand-2 u-relative">
-        <div class="u-absolute-center u-text--center">1:1 <span class="u-block">(try resizing)</span></div>
+      <div class="u-aspect-ratio-1-1 u-bg-brand-2 u-relative">
+        <div class="u-absolute-center u-text-center">1:1 <span class="u-block">(try resizing)</span></div>
       </div>
     `}
   </Story>
   <Story name="aspect-ratio-16-9">
     {`
-      <div class="u-aspect-ratio-16-9 u-bg--brand-2 u-relative">
-        <div class="u-absolute-center u-text--center">16:9 <span class="u-block">(try resizing)</span></div>
+      <div class="u-aspect-ratio-16-9 u-bg-brand-2 u-relative">
+        <div class="u-absolute-center u-text-center">16:9 <span class="u-block">(try resizing)</span></div>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/bg/_bg.scss
+++ b/scss/bitstyles/utilities/bg/_bg.scss
@@ -1,8 +1,19 @@
 @use './settings';
-@use '../../settings/setup';
+@use '../../tools/directional-properties';
+@use '../../tools/media-query';
 
-@each $variant, $color in (settings.$values) {
-  .#{setup.$namespace}u-bg--#{$variant} {
-    background-color: $color;
+@include directional-properties.output-properties(
+  $property-name: 'background-color',
+  $classname-root: 'bg',
+  $values: settings.$values
+);
+
+@each $breakpoint in settings.$breakpoints {
+  @include media-query.media-query($breakpoint) {
+    @include directional-properties.output-properties(
+      $property-name: 'background-color',
+      $classname-root: 'bg',
+      $values: settings.$values
+    );
   }
 }

--- a/scss/bitstyles/utilities/bg/_settings.scss
+++ b/scss/bitstyles/utilities/bg/_settings.scss
@@ -12,3 +12,4 @@ $values: (
   'gray-10': palette.get('gray', '10'),
   'gray-5': palette.get('gray', '5'),
 ) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/bg/bg.stories.mdx
+++ b/scss/bitstyles/utilities/bg/bg.stories.mdx
@@ -7,14 +7,79 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 Define which background colours you require in the `$background-colors` Sass list, using the colours as defined in `$bitstyles-palette`.
 
 <Canvas>
-  <Story name="Background">
+  <Story name="black-80">
     {`
-      <div class="u-bg--background">Some content here</div>
+      <div class="u-bg-black-80">u-bg-black-80</div>
     `}
   </Story>
-  <Story name="Brand 2">
+  <Story name="background">
     {`
-      <div class="u-bg--brand-2">Some content here</div>
+      <div class="u-bg-background">u-bg-background</div>
+    `}
+  </Story>
+  <Story name="white">
+    {`
+      <div class="u-bg-white">u-bg-white</div>
+    `}
+  </Story>
+  <Story name="brand-2">
+    {`
+      <div class="u-bg-brand-2">u-bg-brand-2</div>
+    `}
+  </Story>
+  <Story name="gray-90">
+    {`
+      <div class="u-bg-black-80">u-bg-black-80</div>
+    `}
+  </Story>
+  <Story name="gray-80">
+    {`
+      <div class="u-bg-gray-80">u-bg-gray-80</div>
+    `}
+  </Story>
+  <Story name="gray-50">
+    {`
+      <div class="u-bg-gray-50">u-bg-gray-50</div>
+    `}
+  </Story>
+  <Story name="gray-20">
+    {`
+      <div class="u-bg-gray-20">u-bg-gray-20</div>
+    `}
+  </Story>
+  <Story name="gray-10">
+    {`
+      <div class="u-bg-gray-10">u-bg-gray-10</div>
+    `}
+  </Story>
+  <Story name="gray-5">
+    {`
+      <div class="u-bg-gray-5">u-bg-gray-5</div>
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available background-colors can be customized by overriding the `$bitstyles-bg-values` Sass variable:
+
+```scss
+$bitstyles-bg-values: (
+  'black-80': palette.get('black', '80'),
+  'background': palette.get('background'),
+  'white': palette.get('white'),
+  'brand-2': palette.get('brand-2', '100'),
+  'gray-90': palette.get('gray', '90'),
+  'gray-80': palette.get('gray', '80'),
+  'gray-50': palette.get('gray', '50'),
+  'gray-20': palette.get('gray', '20'),
+  'gray-10': palette.get('gray', '10'),
+  'gray-5': palette.get('gray', '5'),
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-bg-breakpoints`:
+
+```scss
+$bitstyles-bg-breakpoints: ('m', 'l');
+```

--- a/scss/bitstyles/utilities/clearfix/clearfix.stories.mdx
+++ b/scss/bitstyles/utilities/clearfix/clearfix.stories.mdx
@@ -14,7 +14,7 @@ Only useful when floats are used in your layout, which is likely only when a pag
   <Story name="Clearfix">
     {`
       <div>
-        <div class="u-clearfix u-bg--brand-2">
+        <div class="u-clearfix u-bg-brand-2">
           <div style="float: left; border: 1px solid #f00">Floated content here</div>
           <div style="float: left; border: 1px solid #00f">Floated content here</div>
         </div>

--- a/scss/bitstyles/utilities/col-span/col-span.stories.mdx
+++ b/scss/bitstyles/utilities/col-span/col-span.stories.mdx
@@ -9,25 +9,25 @@ For some layouts, you’ll want to allow some of the grid children a little more
 <Canvas isColumn>
   <Story name="u-col-span-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-2 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-span-2">Grid child 1, span 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-2 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-2">Grid child 1, span 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-span-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-span-3">Grid child 1, span 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-3 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-3">Grid child 1, span 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>
@@ -40,49 +40,49 @@ The `col-span` classes are also all available at `s`, `m`, and `xl` breakpoints.
 <Canvas isColumn>
   <Story name="u-col-span-6@s">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-span-6@s">Grid child 1, span 6 @s</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@s">Grid child 1, span 6 @s</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-span-6@m">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-span-6@m">Grid child 1, span 6 @m</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@m">Grid child 1, span 6 @m</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-span-6@l">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-span-6@l">Grid child 1, span 6 @l</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@l">Grid child 1, span 6 @l</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-span-6@xl">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-span-6@xl">Grid child 1, span 6 @xl</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@xl">Grid child 1, span 6 @xl</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>

--- a/scss/bitstyles/utilities/col-start/_col-start.scss
+++ b/scss/bitstyles/utilities/col-start/_col-start.scss
@@ -1,4 +1,4 @@
-@use './settings.scss';
+@use './settings';
 @use '../../tools/directional-properties';
 @use '../../tools/media-query';
 

--- a/scss/bitstyles/utilities/col-start/col-start.stories.mdx
+++ b/scss/bitstyles/utilities/col-start/col-start.stories.mdx
@@ -13,73 +13,73 @@ It’s common to use `.u-col-start-1` to force an element to start a new row —
 <Canvas isColumn>
   <Story name="u-col-start-1">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-1">6-column grid, child 3, col-start-1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1">6-column grid, child 3, col-start-1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-start-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-2">6-column grid, child 3, col-start-2</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-2">6-column grid, child 3, col-start-2</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-start-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 3</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-3">6-column grid, child 4, col-start-3</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-3">6-column grid, child 4, col-start-3</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-start-4">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-4">6-column grid, child 3, col-start-4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-4">6-column grid, child 3, col-start-4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-start-5">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-5">6-column grid, child 3, col-start-5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-5">6-column grid, child 3, col-start-5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-start-6">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-6">6-column grid, child 3, col-start-6</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-6">6-column grid, child 3, col-start-6</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
@@ -92,37 +92,37 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 <Canvas isColumn>
   <Story name="u-col-start-1@s">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-1@s">6-column grid, child 3, col-start-1@s</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@s">6-column grid, child 3, col-start-1@s</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-start-1@m">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-1@m">6-column grid, child 3, col-start-1@m</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@m">6-column grid, child 3, col-start-1@m</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-col-start-1@xl">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-col-start-1@xl">6-column grid, child 3, col-start-1@xl</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@xl">6-column grid, child 3, col-start-1@xl</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>

--- a/scss/bitstyles/utilities/display/_display.scss
+++ b/scss/bitstyles/utilities/display/_display.scss
@@ -1,19 +1,20 @@
 @use './settings';
-@use '../../settings/setup';
+@use '../../tools/directional-properties';
 @use '../../tools/media-query';
 
-@each $classname, $value in (settings.$values) {
-  .#{setup.$namespace}u-#{$classname} {
-    display: #{$value};
-  }
-}
+@include directional-properties.output-properties(
+  $property-name: 'display',
+  $classname-root: null,
+  $values: settings.$values
+);
 
-@each $breakpoint in settings.$breakpoints {
-  @include media-query.media-query($breakpoint) {
-    @each $classname, $value in (settings.$values) {
-      .#{setup.$namespace}u-#{$classname}\@#{$breakpoint} {
-        display: #{$value};
-      }
-    }
+@each $breakpoint-alias in settings.$breakpoints {
+  @include media-query.media-query($breakpoint-alias) {
+    @include directional-properties.output-properties(
+      $property-name: 'display',
+      $classname-root: null,
+      $values: settings.$values,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
   }
 }

--- a/scss/bitstyles/utilities/display/_settings.scss
+++ b/scss/bitstyles/utilities/display/_settings.scss
@@ -1,8 +1,8 @@
 $values: (
-  'block': 'block',
-  'grid': 'grid',
-  'flex': 'flex',
-  'inline-flex': 'inline-flex',
-  'hidden': 'none'
+  'block': block,
+  'grid': grid,
+  'flex': flex,
+  'inline-flex': inline-flex,
+  'hidden': none
 ) !default;
 $breakpoints: ('s', 'm', 'l') !default;

--- a/scss/bitstyles/utilities/display/display.stories.mdx
+++ b/scss/bitstyles/utilities/display/display.stories.mdx
@@ -13,11 +13,11 @@ These classes are all available at breakpoints (see examples), resize your brows
 <Canvas isColumn>
   <Story name="u-block">
     {`
-      <div class="u-bg--gray-10 u-padding-m">
-        <span class="u-bg--background u-padding-xs">Span 1 content</span>
-        <span class="u-block u-bg--background u-padding-xs">span.u-block</span>
-        <span class="u-bg--background u-padding-xs">Span 3 content</span>
-        <span class="u-bg--background u-padding-xs">Span 4 content</span>
+      <div class="u-bg-gray-10 u-padding-m">
+        <span class="u-bg-background u-padding-xs">Span 1 content</span>
+        <span class="u-block u-bg-background u-padding-xs">span.u-block</span>
+        <span class="u-bg-background u-padding-xs">Span 3 content</span>
+        <span class="u-bg-background u-padding-xs">Span 4 content</span>
       </div>
     `}
   </Story>
@@ -26,31 +26,31 @@ These classes are all available at breakpoints (see examples), resize your brows
 <Canvas isColumn>
   <Story name="u-block@s">
     {`
-      <div class="u-bg--gray-10 u-padding-m">
-        <span class="u-bg--background u-padding-xs">Span 1 content</span>
-        <span class="u-block@s u-bg--background u-padding-xs">span.u-block@s</span>
-        <span class="u-bg--background u-padding-xs">Span 3 content</span>
-        <span class="u-bg--background u-padding-xs">Span 4 content</span>
+      <div class="u-bg-gray-10 u-padding-m">
+        <span class="u-bg-background u-padding-xs">Span 1 content</span>
+        <span class="u-block@s u-bg-background u-padding-xs">span.u-block@s</span>
+        <span class="u-bg-background u-padding-xs">Span 3 content</span>
+        <span class="u-bg-background u-padding-xs">Span 4 content</span>
       </div>
     `}
   </Story>
   <Story name="u-block@m">
     {`
-      <div class="u-bg--gray-10 u-padding-m">
-        <span class="u-bg--background u-padding-xs">Span 1 content</span>
-        <span class="u-block@m u-bg--background u-padding-xs">span.u-block@m</span>
-        <span class="u-bg--background u-padding-xs">Span 3 content</span>
-        <span class="u-bg--background u-padding-xs">Span 4 content</span>
+      <div class="u-bg-gray-10 u-padding-m">
+        <span class="u-bg-background u-padding-xs">Span 1 content</span>
+        <span class="u-block@m u-bg-background u-padding-xs">span.u-block@m</span>
+        <span class="u-bg-background u-padding-xs">Span 3 content</span>
+        <span class="u-bg-background u-padding-xs">Span 4 content</span>
       </div>
     `}
   </Story>
   <Story name="u-block@l">
     {`
-      <div class="u-bg--gray-10 u-padding-m">
-        <span class="u-bg--background u-padding-xs">Span 1 content</span>
-        <span class="u-block@l u-bg--background u-padding-xs">span.u-block@l</span>
-        <span class="u-bg--background u-padding-xs">Span 3 content</span>
-        <span class="u-bg--background u-padding-xs">Span 4 content</span>
+      <div class="u-bg-gray-10 u-padding-m">
+        <span class="u-bg-background u-padding-xs">Span 1 content</span>
+        <span class="u-block@l u-bg-background u-padding-xs">span.u-block@l</span>
+        <span class="u-bg-background u-padding-xs">Span 3 content</span>
+        <span class="u-bg-background u-padding-xs">Span 4 content</span>
       </div>
     `}
   </Story>
@@ -63,11 +63,11 @@ See the documentation for [flex](/docs/utilities-flex--flex-with-grow-1-child) c
 <Canvas isColumn>
   <Story name="u-flex">
     {`
-      <div class="u-flex u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Flex child one</div>
-        <div class="a-card u-bg--background">Flex child two with longer content</div>
-        <div class="a-card u-bg--background">Flex child three</div>
-        <div class="a-card u-bg--background">Flex child four</div>
+      <div class="u-flex u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Flex child one</div>
+        <div class="a-card u-bg-background">Flex child two with longer content</div>
+        <div class="a-card u-bg-background">Flex child three</div>
+        <div class="a-card u-bg-background">Flex child four</div>
       </div>
     `}
   </Story>
@@ -76,31 +76,31 @@ See the documentation for [flex](/docs/utilities-flex--flex-with-grow-1-child) c
 <Canvas isColumn>
   <Story name="u-flex@s">
     {`
-      <div class="u-flex@s u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Flex child one</div>
-        <div class="a-card u-bg--background">Flex child two</div>
-        <div class="a-card u-bg--background">Flex child three</div>
-        <div class="a-card u-bg--background">Flex child four</div>
+      <div class="u-flex@s u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Flex child one</div>
+        <div class="a-card u-bg-background">Flex child two</div>
+        <div class="a-card u-bg-background">Flex child three</div>
+        <div class="a-card u-bg-background">Flex child four</div>
       </div>
     `}
   </Story>
   <Story name="u-flex@m">
     {`
-      <div class="u-flex@m u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Flex child one</div>
-        <div class="a-card u-bg--background">Flex child two</div>
-        <div class="a-card u-bg--background">Flex child three</div>
-        <div class="a-card u-bg--background">Flex child four</div>
+      <div class="u-flex@m u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Flex child one</div>
+        <div class="a-card u-bg-background">Flex child two</div>
+        <div class="a-card u-bg-background">Flex child three</div>
+        <div class="a-card u-bg-background">Flex child four</div>
       </div>
     `}
   </Story>
   <Story name="u-flex@l">
     {`
-      <div class="u-flex@l u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Flex child one</div>
-        <div class="a-card u-bg--background">Flex child two</div>
-        <div class="a-card u-bg--background">Flex child three</div>
-        <div class="a-card u-bg--background">Flex child four</div>
+      <div class="u-flex@l u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Flex child one</div>
+        <div class="a-card u-bg-background">Flex child two</div>
+        <div class="a-card u-bg-background">Flex child three</div>
+        <div class="a-card u-bg-background">Flex child four</div>
       </div>
     `}
   </Story>
@@ -113,13 +113,13 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 <Canvas isColumn>
   <Story name="u-grid">
     {`
-      <div class="u-grid u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 6</div>
+      <div class="u-grid u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 6</div>
       </div>
     `}
   </Story>
@@ -128,37 +128,37 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 <Canvas isColumn>
   <Story name="u-grid@s">
     {`
-      <div class="u-grid@s u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 6</div>
+      <div class="u-grid@s u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 6</div>
       </div>
     `}
   </Story>
   <Story name="u-grid@m">
     {`
-      <div class="u-grid@m u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 6</div>
+      <div class="u-grid@m u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 6</div>
       </div>
     `}
   </Story>
   <Story name="u-grid@l">
     {`
-      <div class="u-grid@l u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 6</div>
+      <div class="u-grid@l u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 6</div>
       </div>
     `}
   </Story>
@@ -169,10 +169,10 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 <Canvas isColumn>
   <Story name="u-hidden">
     {`
-      <div class="u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Element 1 content</div>
-        <div class="u-hidden u-bg--background u-padding-m a-card">Element 2 content, always hidden</div>
-        <div class="u-bg--background u-padding-m a-card">Element 3 content</div>
+      <div class="u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Element 1 content</div>
+        <div class="u-hidden u-bg-background u-padding-m a-card">Element 2 content, always hidden</div>
+        <div class="u-bg-background u-padding-m a-card">Element 3 content</div>
       </div>
     `}
   </Story>
@@ -181,28 +181,28 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 <Canvas isColumn>
   <Story name="u-hidden@s">
     {`
-      <div class="u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Element 1 content</div>
-        <div class="u-hidden@s u-bg--background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
-        <div class="u-bg--background u-padding-m a-card">Element 3 content</div>
+      <div class="u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Element 1 content</div>
+        <div class="u-hidden@s u-bg-background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
+        <div class="u-bg-background u-padding-m a-card">Element 3 content</div>
       </div>
     `}
   </Story>
   <Story name="u-hidden@m">
     {`
-      <div class="u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Element 1 content</div>
-        <div class="u-hidden@m u-bg--background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
-        <div class="u-bg--background u-padding-m a-card">Element 3 content</div>
+      <div class="u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Element 1 content</div>
+        <div class="u-hidden@m u-bg-background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
+        <div class="u-bg-background u-padding-m a-card">Element 3 content</div>
       </div>
     `}
   </Story>
   <Story name="u-hidden@l">
     {`
-      <div class="u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Element 1 content</div>
-        <div class="u-hidden@l u-bg--background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
-        <div class="u-bg--background u-padding-m a-card">Element 3 content</div>
+      <div class="u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Element 1 content</div>
+        <div class="u-hidden@l u-bg-background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
+        <div class="u-bg-background u-padding-m a-card">Element 3 content</div>
       </div>
     `}
   </Story>
@@ -217,11 +217,11 @@ See the documentation for [flex](/docs/utilities-flex--flex-with-grow-1-child) c
 <Canvas isColumn>
   <Story name="u-inline-flex">
     {`
-      <div class="u-inline-flex u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Flexchild one</div>
-        <div class="a-card u-bg--background">Flexchild two with longer content</div>
-        <div class="a-card u-bg--background">Flexchild three</div>
-        <div class="a-card u-bg--background">Flexchild four</div>
+      <div class="u-inline-flex u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Flexchild one</div>
+        <div class="a-card u-bg-background">Flexchild two with longer content</div>
+        <div class="a-card u-bg-background">Flexchild three</div>
+        <div class="a-card u-bg-background">Flexchild four</div>
       </div>
       other content
     `}
@@ -231,33 +231,33 @@ See the documentation for [flex](/docs/utilities-flex--flex-with-grow-1-child) c
 <Canvas isColumn>
   <Story name="u-inline-flex@s">
     {`
-      <div class="u-inline-flex@s u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Flexchild one</div>
-        <div class="a-card u-bg--background">Flexchild two</div>
-        <div class="a-card u-bg--background">Flexchild three</div>
-        <div class="a-card u-bg--background">Flexchild four</div>
+      <div class="u-inline-flex@s u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Flexchild one</div>
+        <div class="a-card u-bg-background">Flexchild two</div>
+        <div class="a-card u-bg-background">Flexchild three</div>
+        <div class="a-card u-bg-background">Flexchild four</div>
       </div>
       other content
     `}
   </Story>
   <Story name="u-inline-flex@m">
     {`
-      <div class="u-inline-flex@m u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Flexchild one</div>
-        <div class="a-card u-bg--background">Flexchild two</div>
-        <div class="a-card u-bg--background">Flexchild three</div>
-        <div class="a-card u-bg--background">Flexchild four</div>
+      <div class="u-inline-flex@m u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Flexchild one</div>
+        <div class="a-card u-bg-background">Flexchild two</div>
+        <div class="a-card u-bg-background">Flexchild three</div>
+        <div class="a-card u-bg-background">Flexchild four</div>
       </div>
       other content
     `}
   </Story>
   <Story name="u-inline-flex@l">
     {`
-      <div class="u-inline-flex@l u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Flexchild one</div>
-        <div class="a-card u-bg--background">Flexchild two</div>
-        <div class="a-card u-bg--background">Flexchild three</div>
-        <div class="a-card u-bg--background">Flexchild four</div>
+      <div class="u-inline-flex@l u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Flexchild one</div>
+        <div class="a-card u-bg-background">Flexchild two</div>
+        <div class="a-card u-bg-background">Flexchild three</div>
+        <div class="a-card u-bg-background">Flexchild four</div>
       </div>
       other content
     `}
@@ -271,20 +271,40 @@ Another use is to add `.u-hidden` to “remove” an element from the page, then
 <Canvas isColumn>
   <Story name="Show only @s">
     {`
-      <div class="u-inline-flex@l u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Element 1 content</div>
-        <div class="u-hidden u-block@s a-card u-bg--background">Element 2 content, only shown on @s viewports</div>
-        <div class="a-card u-bg--background">Element 3 content</div>
+      <div class="u-inline-flex@l u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Element 1 content</div>
+        <div class="u-hidden u-block@s a-card u-bg-background">Element 2 content, only shown on @s viewports</div>
+        <div class="a-card u-bg-background">Element 3 content</div>
       </div>
     `}
   </Story>
   <Story name="Show only @m">
     {`
-      <div class="u-inline-flex@l u-padding-m u-bg--gray-10">
-        <div class="a-card u-bg--background">Element 1 content</div>
-        <div class="u-hidden u-block@m a-card u-bg--background">Element 2 content, only shown on @m viewports</div>
-        <div class="a-card u-bg--background">Element 3 content</div>
+      <div class="u-inline-flex@l u-padding-m u-bg-gray-10">
+        <div class="a-card u-bg-background">Element 1 content</div>
+        <div class="u-hidden u-block@m a-card u-bg-background">Element 2 content, only shown on @m viewports</div>
+        <div class="a-card u-bg-background">Element 3 content</div>
       </div>
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available display types can be customized by overriding the `$bitstyles-display-values` Sass variable:
+
+```scss
+$bitstyles-display-values: (
+  'block': block,
+  'grid': grid,
+  'flex': flex,
+  'inline-flex': inline-flex,
+  'hidden': none
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-display-breakpoints` variable:
+
+```scss
+$bitstyles-display-breakpoints: ('s', 'm', 'xl');
+```

--- a/scss/bitstyles/utilities/fg/_fg.scss
+++ b/scss/bitstyles/utilities/fg/_fg.scss
@@ -3,16 +3,16 @@
 @use '../../tools/media-query';
 
 @include directional-properties.output-properties(
-  $property-name: 'fg',
-  $classname-root: 'color',
+  $property-name: 'color',
+  $classname-root: 'fg',
   $values: settings.$values
 );
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.media-query($breakpoint-alias) {
     @include directional-properties.output-properties(
-      $property-name: 'fg',
-      $classname-root: 'color',
+      $property-name: 'color',
+      $classname-root: 'fg',
       $values: settings.$values,
       $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
     );

--- a/scss/bitstyles/utilities/fg/_fg.scss
+++ b/scss/bitstyles/utilities/fg/_fg.scss
@@ -1,8 +1,20 @@
 @use './settings';
-@use '../../settings/setup';
+@use '../../tools/directional-properties';
+@use '../../tools/media-query';
 
-@each $variant, $color in (settings.$values) {
-  .#{setup.$namespace}u-fg--#{$variant} {
-    color: $color;
+@include directional-properties.output-properties(
+  $property-name: 'fg',
+  $classname-root: 'color',
+  $values: settings.$values
+);
+
+@each $breakpoint-alias in settings.$breakpoints {
+  @include media-query.media-query($breakpoint-alias) {
+    @include directional-properties.output-properties(
+      $property-name: 'fg',
+      $classname-root: 'color',
+      $values: settings.$values,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
   }
 }

--- a/scss/bitstyles/utilities/fg/_settings.scss
+++ b/scss/bitstyles/utilities/fg/_settings.scss
@@ -4,7 +4,9 @@ $values: (
   'brand-1': palette.get('brand-1', '100'),
   'brand-2': palette.get('brand-2', '100'),
   'warning': palette.get('warning', '100'),
+  'white': palette.get('white', '100'),
   'gray-50': palette.get('gray', '50'),
   'gray-40': palette.get('gray', '40'),
   'gray-30': palette.get('gray', '30'),
 ) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/fg/fg.stories.mdx
+++ b/scss/bitstyles/utilities/fg/fg.stories.mdx
@@ -7,19 +7,56 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 Define which foreground colours you require in the `$foreground-colors` Sass list, using the colours as defined in `$bitstyles-palette`.
 
 <Canvas>
-  <Story name="Brand 1">
+  <Story name="brand-1">
     {`
-      <div class="u-fg--brand-1">Some content here</div>
+      <div class="u-fg-brand-1">u-fg-brand-1</div>
     `}
   </Story>
-  <Story name="Brand 2">
+  <Story name="brand-2">
     {`
-      <div class="u-fg--brand-2">Some content here</div>
+      <div class="u-fg-brand-2">u-fg-brand-2</div>
     `}
   </Story>
-  <Story name="Warning">
+  <Story name="warning">
     {`
-      <div class="u-fg--warning">Some content here</div>
+      <div class="u-fg-warning">u-fg-warning</div>
+    `}
+  </Story>
+  <Story name="gray-50">
+    {`
+      <div class="u-fg-gray-50">u-fg-gray-50</div>
+    `}
+  </Story>
+  <Story name="gray-40">
+    {`
+      <div class="u-fg-gray-40">u-fg-gray-40</div>
+    `}
+  </Story>
+  <Story name="gray-30">
+    {`
+      <div class="u-fg-gray-30">u-fg-gray-30</div>
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available display types can be customized by overriding the `$bitstyles-fg-values` Sass variable:
+
+```scss
+$bitstyles-fg-values: (
+  'brand-1': palette.get('brand-1', '100'),
+  'brand-2': palette.get('brand-2', '100'),
+  'warning': palette.get('warning', '100'),
+  'gray-50': palette.get('gray', '50'),
+  'gray-40': palette.get('gray', '40'),
+  'gray-30': palette.get('gray', '30'),
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-fg-breakpoints` variable:
+
+```scss
+$bitstyles-fg-breakpoints: ('s', 'm', 'xl');
+```
+

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -27,7 +27,7 @@ These first examples show the layouts with a small amount of text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>List item one</li>
-        <li class="u-flex-grow-0 u-bg--brand-2">u-flex-grow-0</li>
+        <li class="u-flex-grow-0 u-bg-brand-2">u-flex-grow-0</li>
         <li>List item three</li>
         <li>List item four</li>
       </ul>
@@ -37,7 +37,7 @@ These first examples show the layouts with a small amount of text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>List item one</li>
-        <li class="u-flex-grow-1 u-bg--brand-2">u-flex-grow-1</li>
+        <li class="u-flex-grow-1 u-bg-brand-2">u-flex-grow-1</li>
         <li>List item three</li>
         <li>List item four</li>
       </ul>
@@ -47,7 +47,7 @@ These first examples show the layouts with a small amount of text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>List item one</li>
-        <li class="u-flex-shrink-0 u-bg--brand-2">u-flex-shrink-0</li>
+        <li class="u-flex-shrink-0 u-bg-brand-2">u-flex-shrink-0</li>
         <li>List item three</li>
         <li>List item four</li>
       </ul>
@@ -57,7 +57,7 @@ These first examples show the layouts with a small amount of text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>List item one</li>
-        <li class="u-flex-shrink-1 u-bg--brand-2">u-flex-shrink-1</li>
+        <li class="u-flex-shrink-1 u-bg-brand-2">u-flex-shrink-1</li>
         <li>List item three</li>
         <li>List item four</li>
       </ul>
@@ -72,7 +72,7 @@ These next examples show how the same layouts behave with long text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex-grow-0 u-bg--brand-2">u-flex-grow-0. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-grow-0 u-bg-brand-2">u-flex-grow-0. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -82,7 +82,7 @@ These next examples show how the same layouts behave with long text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex-grow-1 u-bg--brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-grow-1 u-bg-brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -92,7 +92,7 @@ These next examples show how the same layouts behave with long text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex-shrink-0 u-bg--brand-2">u-flex-shrink-0. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-shrink-0 u-bg-brand-2">u-flex-shrink-0. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -102,7 +102,7 @@ These next examples show how the same layouts behave with long text content.
     {`
       <ul class="u-flex a-list-reset">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-flex-shrink-1 u-bg--brand-2">u-flex-shrink-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-flex-shrink-1 u-bg-brand-2">u-flex-shrink-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -121,7 +121,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-padding-m u-flex-grow-0 u-bg--brand-2">
+        <li class="u-padding-m u-flex-grow-0 u-bg-brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
           u-flex-grow-0
         </li>
@@ -140,7 +140,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-padding-m u-flex-grow-1 u-bg--brand-2">
+        <li class="u-padding-m u-flex-grow-1 u-bg-brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
           u-flex-grow-1
         </li>
@@ -159,7 +159,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-padding-m u-flex-shrink-0 u-bg--brand-2">
+        <li class="u-padding-m u-flex-shrink-0 u-bg-brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
           u-flex-shrink-0
         </li>
@@ -178,7 +178,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-padding-m u-flex-shrink-1 u-bg--brand-2">
+        <li class="u-padding-m u-flex-shrink-1 u-bg-brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
           u-flex-shrink-1
         </li>
@@ -202,7 +202,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-padding-m u-flex-grow-0@m u-bg--brand-2">
+        <li class="u-padding-m u-flex-grow-0@m u-bg-brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
           u-flex-grow-0@m
         </li>
@@ -221,7 +221,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-padding-m u-flex-grow-1@m u-bg--brand-2">
+        <li class="u-padding-m u-flex-grow-1@m u-bg-brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
           u-flex-grow-1@m
         </li>
@@ -240,7 +240,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-padding-m u-flex-shrink-0@m u-bg--brand-2">
+        <li class="u-padding-m u-flex-shrink-0@m u-bg-brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
           u-flex-shrink-0@m
         </li>
@@ -259,7 +259,7 @@ And this time the same layouts, with images as content (any element with intrins
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
-        <li class="u-padding-m u-flex-shrink-1@m u-bg--brand-2">
+        <li class="u-padding-m u-flex-shrink-1@m u-bg-brand-2">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
           u-flex-shrink-1@m
         </li>
@@ -285,7 +285,7 @@ Note this layout may not be so useful with elements that take all available spac
     {`
       <ul class="u-flex u-flex-wrap a-list-reset">
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-padding-m u-flex-grow-1 u-bg--brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m u-flex-grow-1 u-bg-brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -295,7 +295,7 @@ Note this layout may not be so useful with elements that take all available spac
     {`
       <ul class="u-flex u-flex-wrap@m a-list-reset">
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
-        <li class="u-padding-m u-flex-grow-1 u-bg--brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
+        <li class="u-padding-m u-flex-grow-1 u-bg-brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
       </ul>
@@ -305,7 +305,7 @@ Note this layout may not be so useful with elements that take all available spac
     {`
       <ul class="u-flex u-flex-wrap a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
-        <li class="u-flex-grow-1 u-bg--brand-2 u-padding-m">u-flex-grow-1</li>
+        <li class="u-flex-grow-1 u-bg-brand-2 u-padding-m">u-flex-grow-1</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
       </ul>
@@ -315,7 +315,7 @@ Note this layout may not be so useful with elements that take all available spac
     {`
       <ul class="u-flex u-flex-wrap@m a-list-reset">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
-        <li class="u-flex-grow-1 u-bg--brand-2 u-padding-m">u-flex-grow-1</li>
+        <li class="u-flex-grow-1 u-bg-brand-2 u-padding-m">u-flex-grow-1</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
       </ul>

--- a/scss/bitstyles/utilities/font/_font.scss
+++ b/scss/bitstyles/utilities/font/_font.scss
@@ -1,0 +1,35 @@
+@use './settings';
+@use '../../tools/directional-properties';
+@use '../../tools/media-query';
+
+@include directional-properties.output-properties(
+  $property-name: 'font-weight',
+  $classname-root: 'font',
+  $values: settings.$weight-values
+);
+
+@each $breakpoint in settings.$weight-breakpoints {
+  @include media-query.media-query($breakpoint) {
+    @include directional-properties.output-properties(
+      $property-name: 'font-weight',
+      $classname-root: 'font',
+      $values: settings.$weight-values
+    );
+  }
+}
+
+@include directional-properties.output-properties(
+  $property-name: 'font-style',
+  $classname-root: 'font',
+  $values: settings.$style-values
+);
+
+@each $breakpoint in settings.$style-breakpoints {
+  @include media-query.media-query($breakpoint) {
+    @include directional-properties.output-properties(
+      $property-name: 'font-style',
+      $classname-root: 'font',
+      $values: settings.$style-values
+    );
+  }
+}

--- a/scss/bitstyles/utilities/font/_index.import.scss
+++ b/scss/bitstyles/utilities/font/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-font-*;
+@forward 'font';

--- a/scss/bitstyles/utilities/font/_index.scss
+++ b/scss/bitstyles/utilities/font/_index.scss
@@ -1,26 +1,2 @@
-@use '../../settings/setup';
-@use '../../settings/typography';
-
-.#{setup.$namespace}u-font--light {
-  font-weight: typography.$font-weight-light;
-}
-
-.#{setup.$namespace}u-font--normal {
-  font-weight: typography.$font-weight-normal;
-}
-
-.#{setup.$namespace}u-font--medium {
-  font-weight: typography.$font-weight-medium;
-}
-
-.#{setup.$namespace}u-font--bold {
-  font-weight: typography.$font-weight-bold;
-}
-
-.#{setup.$namespace}u-font--italic {
-  font-style: italic;
-}
-
-.#{setup.$namespace}u-font--not-italic {
-  font-style: normal;
-}
+@forward 'settings';
+@forward 'font';

--- a/scss/bitstyles/utilities/font/_settings.scss
+++ b/scss/bitstyles/utilities/font/_settings.scss
@@ -1,0 +1,14 @@
+@use '../../settings/typography';
+
+$weight-values: (
+  'light': typography.$font-weight-light,
+  'normal': typography.$font-weight-normal,
+  'medium': typography.$font-weight-medium,
+  'bold': typography.$font-weight-bold
+) !default;
+$weight-breakpoints: () !default;
+$style-values: (
+  'italic': italic,
+  'not-italic': normal
+) !default;
+$style-breakpoints: () !default;

--- a/scss/bitstyles/utilities/font/font.stories.mdx
+++ b/scss/bitstyles/utilities/font/font.stories.mdx
@@ -8,44 +8,68 @@ Set font properties of an element.
 
 ## Font Weight
 
-The Nunito font provided has no `light` font-weight, so in the following list you’ll see no difference to `font--normal`.
+The Nunito font provided has no `light` font-weight, so in the following list you’ll see no difference to `font-normal`.
 
 <Canvas isColumn>
-  <Story name="font--light">
+  <Story name="font-light">
     {`
-      <p class="u-bg--background u-font--light"><span class="u-fg--brand-2">u-font--light</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
+      <p class="u-bg-background u-font-light"><span class="u-fg-brand-2">u-font-light</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
     `}
   </Story>
-  <Story name="font--normal">
+  <Story name="font-normal">
     {`
-      <p class="u-bg--background u-font--normal"><span class="u-fg--brand-2">u-font--normal</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
+      <p class="u-bg-background u-font-normal"><span class="u-fg-brand-2">u-font-normal</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
     `}
   </Story>
-  <Story name="font--medium">
+  <Story name="font-medium">
     {`
-      <p class="u-bg--background u-font--medium"><span class="u-fg--brand-2">u-font--medium</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
+      <p class="u-bg-background u-font-medium"><span class="u-fg-brand-2">u-font-medium</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
     `}
   </Story>
-  <Story name="font--bold">
+  <Story name="font-bold">
     {`
-      <p class="u-bg--background u-font--bold"><span class="u-fg--brand-2">u-font--bold</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
+      <p class="u-bg-background u-font-bold"><span class="u-fg-brand-2">u-font-bold</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
     `}
   </Story>
 </Canvas>
 
 ## Font style
 
-Using bolded italics is normally not needed or wanted, and we’re not providing webfont files for those variations, so here you’ll see italics only on regular-weight fonts. If you need it, and you provide the font files, you can apply both `.u-font--italic` and `.u-font--bold` to an element.
+Using bolded italics is normally not needed or wanted, and we’re not providing webfont files for those variations, so here you’ll see italics only on regular-weight fonts. If you need it, and you provide the font files, you can apply both `.u-font-italic` and `.u-font-bold` to an element.
 
 <Canvas isColumn>
-  <Story name="font--italic">
+  <Story name="font-italic">
     {`
-      <p class="u-bg--background u-font--italic"><span class="u-fg--brand-2">u-font--italic</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</p>
+      <p class="u-bg-background u-font-italic"><span class="u-fg-brand-2">u-font-italic</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</p>
     `}
   </Story>
-  <Story name="font--not-italic">
+  <Story name="font-not-italic">
     {`
-      <p class="u-bg--background u-font--not-italic"><span class="u-fg--brand-2">u-font--not-italic</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</p>
+      <p class="u-bg-background u-font-not-italic"><span class="u-fg-brand-2">u-font-not-italic</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</p>
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available font-weights and font-styles can be customized by overriding the `$bitstyles-font-weight-values` and `$bitstyles-font-weight-values` Sass variables respectively:
+
+```scss
+$bitstyles-font-weight-values: (
+  'light': typography.$font-weight-light,
+  'normal': typography.$font-weight-normal,
+  'medium': typography.$font-weight-medium,
+  'bold': typography.$font-weight-bold
+);
+$bitstyles-font-style-values: (
+  'italic': italic,
+  'not-italic': normal
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-font-weight-breakpoints` and ``$bitstyles-font-style-breakpoints` Sass variables respectively:
+
+```scss
+$bitstyles-font-weight-breakpoints: ();
+$bitstyles-font-style-breakpoints: ();
+```

--- a/scss/bitstyles/utilities/gap/gap.stories.mdx
+++ b/scss/bitstyles/utilities/gap/gap.stories.mdx
@@ -9,37 +9,37 @@ The gap classes specify gaps on your grid elements — space between each grid i
 <Canvas>
   <Story name="u-gap-s">
     {`
-      <div class="u-grid u-padding-m u-gap-s u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 6</div>
+      <div class="u-grid u-padding-m u-gap-s u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 6</div>
       </div>
     `}
   </Story>
   <Story name="u-gap-m">
     {`
-      <div class="u-grid u-padding-m u-gap-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 6</div>
+      <div class="u-grid u-padding-m u-gap-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 6</div>
       </div>
     `}
   </Story>
   <Story name="u-gap-l">
     {`
-      <div class="u-grid u-padding-m u-gap-l u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">Grid child 6</div>
+      <div class="u-grid u-padding-m u-gap-l u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">Grid child 6</div>
       </div>
     `}
   </Story>
@@ -52,25 +52,25 @@ Gap classes are available at `m` and `xl` breakpoints using the suffix on the cl
 <Canvas isColumn>
   <Story name="u-gap-s@m">
     {`
-      <div class="u-grid u-padding-m u-gap-s@m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@m, Grid child 6</div>
+      <div class="u-grid u-padding-m u-gap-s@m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@m, Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@m, Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@m, Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@m, Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@m, Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@m, Grid child 6</div>
       </div>
     `}
   </Story>
   <Story name="u-gap-s@xl">
     {`
-      <div class="u-grid u-padding-m u-gap-s@xl u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 1</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 2</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 3</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 4</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 5</div>
-        <div class="u-bg--background u-padding-m a-card">u-gap-s@xl, Grid child 6</div>
+      <div class="u-grid u-padding-m u-gap-s@xl u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@xl, Grid child 1</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@xl, Grid child 2</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@xl, Grid child 3</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@xl, Grid child 4</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@xl, Grid child 5</div>
+        <div class="u-bg-background u-padding-m a-card">u-gap-s@xl, Grid child 6</div>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
+++ b/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
@@ -13,13 +13,13 @@ The grid classes are only rarely used without the [gap](/docs/utilities-gap--u-g
 <Canvas>
   <Story name="u-grid">
     {`
-      <div class="u-grid u-gap-m u-padding-m u-bg--gray-10">
-        <div class="u-bg--background u-padding-m a-card">1-column grid, child 1</div>
-        <div class="u-bg--background u-padding-m a-card">1-column grid, child 2</div>
-        <div class="u-bg--background u-padding-m a-card">1-column grid, child 3</div>
-        <div class="u-bg--background u-padding-m a-card">1-column grid, child 4</div>
-        <div class="u-bg--background u-padding-m a-card">1-column grid, child 5</div>
-        <div class="u-bg--background u-padding-m a-card">1-column grid, child 6</div>
+      <div class="u-grid u-gap-m u-padding-m u-bg-gray-10">
+        <div class="u-bg-background u-padding-m a-card">1-column grid, child 1</div>
+        <div class="u-bg-background u-padding-m a-card">1-column grid, child 2</div>
+        <div class="u-bg-background u-padding-m a-card">1-column grid, child 3</div>
+        <div class="u-bg-background u-padding-m a-card">1-column grid, child 4</div>
+        <div class="u-bg-background u-padding-m a-card">1-column grid, child 5</div>
+        <div class="u-bg-background u-padding-m a-card">1-column grid, child 6</div>
       </div>
     `}
   </Story>
@@ -30,13 +30,13 @@ If you’re rendering a list of related items, use a list element (could be a `<
 <Canvas>
   <Story name="u-grid (list)">
     {`
-      <ul class="u-grid u-gap-m a-list-reset u-padding-m u-bg--gray-10">
-        <li class="u-bg--background u-padding-m a-card">1-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">1-column grid, child 2</li>
-        <li class="u-bg--background u-padding-m a-card">1-column grid, child 3</li>
-        <li class="u-bg--background u-padding-m a-card">1-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">1-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">1-column grid, child 6</li>
+      <ul class="u-grid u-gap-m a-list-reset u-padding-m u-bg-gray-10">
+        <li class="u-bg-background u-padding-m a-card">1-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">1-column grid, child 2</li>
+        <li class="u-bg-background u-padding-m a-card">1-column grid, child 3</li>
+        <li class="u-bg-background u-padding-m a-card">1-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">1-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">1-column grid, child 6</li>
       </ul>
     `}
   </Story>
@@ -49,49 +49,49 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
 <Canvas isColumn>
   <Story name="u-grid-cols-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-2 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">2-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">2-column grid, child 2</li>
-        <li class="u-bg--background u-padding-m a-card">2-column grid, child 3</li>
-        <li class="u-bg--background u-padding-m a-card">2-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">2-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">2-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-2 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">2-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">2-column grid, child 2</li>
+        <li class="u-bg-background u-padding-m a-card">2-column grid, child 3</li>
+        <li class="u-bg-background u-padding-m a-card">2-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">2-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">2-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-grid-cols-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">3-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">3-column grid, child 2</li>
-        <li class="u-bg--background u-padding-m a-card">3-column grid, child 3</li>
-        <li class="u-bg--background u-padding-m a-card">3-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">3-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">3-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-3 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">3-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">3-column grid, child 2</li>
+        <li class="u-bg-background u-padding-m a-card">3-column grid, child 3</li>
+        <li class="u-bg-background u-padding-m a-card">3-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">3-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">3-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-grid-cols-4">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-4 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">4-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">4-column grid, child 2</li>
-        <li class="u-bg--background u-padding-m a-card">4-column grid, child 3</li>
-        <li class="u-bg--background u-padding-m a-card">4-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">4-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">4-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-4 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">4-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">4-column grid, child 2</li>
+        <li class="u-bg-background u-padding-m a-card">4-column grid, child 3</li>
+        <li class="u-bg-background u-padding-m a-card">4-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">4-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">4-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-grid-cols-6">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 3</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
@@ -104,37 +104,37 @@ Column classes are available at `s`, `m`, and `xl` breakpoints using the suffix 
 <Canvas isColumn>
   <Story name="u-grid-cols-3@s">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3@s u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-3@s u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-grid-cols-3@m">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3@m u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-3@m u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-grid-cols-3@xl">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3@m u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">Grid child 1</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 2</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 3</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 4</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 5</li>
-        <li class="u-bg--background u-padding-m a-card">Grid child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-3@m u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
       </ul>
     `}
   </Story>

--- a/scss/bitstyles/utilities/height/height.stories.mdx
+++ b/scss/bitstyles/utilities/height/height.stories.mdx
@@ -9,7 +9,7 @@ Force an element’s height regardless of the content.
 <Canvas>
   <Story name="100vh">
     {`
-      <div class="u-height-100vh u-bg--gray-10">
+      <div class="u-height-100vh u-bg-gray-10">
         This element will take the height of the viewport, regardless how much content.
       </div>
     `}

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -11,14 +11,14 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
 <Canvas isColumn>
   <Story name="items-center">
     {`
-      <ul class="a-list-reset u-flex u-items-center u-fg--white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+      <ul class="a-list-reset u-flex u-items-center u-fg-white">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 10rem;">
           u-items-center
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 15rem;">
           u-items-center
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 12rem;">
           u-items-center
         </li>
       </ul>
@@ -26,14 +26,14 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
   </Story>
   <Story name="items-end">
     {`
-      <ul class="a-list-reset u-flex u-items-end u-fg--white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+      <ul class="a-list-reset u-flex u-items-end u-fg-white">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 10rem;">
           u-items-end
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 15rem;">
           u-items-end
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 12rem;">
           u-items-end
         </li>
       </ul>
@@ -41,14 +41,14 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
   </Story>
   <Story name="items-start">
     {`
-      <ul class="a-list-reset u-flex u-items-start u-fg--white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+      <ul class="a-list-reset u-flex u-items-start u-fg-white">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 10rem;">
           u-items-start
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 15rem;">
           u-items-start
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 12rem;">
           u-items-start
         </li>
       </ul>
@@ -56,14 +56,14 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
   </Story>
   <Story name="items-stretch">
     {`
-      <ul class="a-list-reset u-flex u-items-stretch u-fg--white" style="min-height: 10rem;">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+      <ul class="a-list-reset u-flex u-items-stretch u-fg-white" style="min-height: 10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="flex-basis: 33%">
           u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="flex-basis: 33%">
           u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o. Danish sesame snaps chocolate cake chocolate bar croissant liquorice jelly topping.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="flex-basis: 33%">
           u-items-stretch. Elements with different amounts of content.
         </li>
       </ul>
@@ -71,14 +71,14 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
   </Story>
   <Story name="items-baseline">
     {`
-      <ul class="a-list-reset u-flex u-items-baseline u-fg--white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+      <ul class="a-list-reset u-flex u-items-baseline u-fg-white">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           u-items-baseline. Elements with different padding top & bottom.
         </li>
-        <li class="u-margin-m u-padding-m u-padding-xl-y u-bg--gray-20">
+        <li class="u-margin-m u-padding-m u-padding-xl-y u-bg-gray-20">
           u-items-baseline. Elements with different padding top & bottom.
         </li>
-        <li class="u-margin-m u-padding-m-left u-padding-m-right u-padding-xl-bottom u-bg--gray-20">
+        <li class="u-margin-m u-padding-m-left u-padding-m-right u-padding-xl-bottom u-bg-gray-20">
           u-items-baseline. Elements with different padding top & bottom.
         </li>
       </ul>
@@ -93,14 +93,14 @@ These classes are all available at the `m` breakpoint.
 <Canvas isColumn>
   <Story name="items-center@m">
     {`
-      <ul class="a-list-reset u-flex u-items-center@m u-fg--white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+      <ul class="a-list-reset u-flex u-items-center@m u-fg-white">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 10rem;">
           u-items-center
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 15rem;">
           u-items-center
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 12rem;">
           u-items-center
         </li>
       </ul>
@@ -108,14 +108,14 @@ These classes are all available at the `m` breakpoint.
   </Story>
   <Story name="items-end@m">
     {`
-      <ul class="a-list-reset u-flex u-items-end@m u-fg--white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+      <ul class="a-list-reset u-flex u-items-end@m u-fg-white">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 10rem;">
           u-items-end
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 15rem;">
           u-items-end
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 12rem;">
           u-items-end
         </li>
       </ul>
@@ -123,14 +123,14 @@ These classes are all available at the `m` breakpoint.
   </Story>
   <Story name="items-start@m">
     {`
-      <ul class="a-list-reset u-flex u-items-start@m u-fg--white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+      <ul class="a-list-reset u-flex u-items-start@m u-fg-white">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 10rem;">
           u-items-start
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 15rem;">
           u-items-start
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 12rem;">
           u-items-start
         </li>
       </ul>
@@ -138,14 +138,14 @@ These classes are all available at the `m` breakpoint.
   </Story>
   <Story name="items-stretch@m">
     {`
-      <ul class="a-list-reset u-flex u-items-stretch@m u-fg--white" style="min-height: 10rem;">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+      <ul class="a-list-reset u-flex u-items-stretch@m u-fg-white" style="min-height: 10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="flex-basis: 33%">
           u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="flex-basis: 33%">
           u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o. Danish sesame snaps chocolate cake chocolate bar croissant liquorice jelly topping.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="flex-basis: 33%">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="flex-basis: 33%">
           u-items-stretch. Elements with different amounts of content.
         </li>
       </ul>
@@ -153,14 +153,14 @@ These classes are all available at the `m` breakpoint.
   </Story>
   <Story name="items-baseline@m">
     {`
-      <ul class="a-list-reset u-flex u-items-baseline@m u-fg--white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+      <ul class="a-list-reset u-flex u-items-baseline@m u-fg-white">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           u-items-baseline. Elements with different padding top & bottom.
         </li>
-        <li class="u-margin-m u-padding-m u-padding-xl-y u-bg--gray-20">
+        <li class="u-margin-m u-padding-m u-padding-xl-y u-bg-gray-20">
           u-items-baseline. Elements with different padding top & bottom.
         </li>
-        <li class="u-margin-m u-padding-m-left u-padding-m-right u-padding-xl-bottom u-bg--gray-20">
+        <li class="u-margin-m u-padding-m-left u-padding-m-right u-padding-xl-bottom u-bg-gray-20">
           u-items-baseline. Elements with different padding top & bottom.
         </li>
       </ul>

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -11,11 +11,11 @@ The `u-justify-` classes set  set `justify-content` to align flex children to th
 <Canvas isColumn>
   <Story name="justify-between">
     {`
-      <ul class="a-list-reset u-flex u-justify-between u-fg--white" style="min-height:10rem;">
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+      <ul class="a-list-reset u-flex u-justify-between u-fg-white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           Between
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           Between
         </li>
       </ul>
@@ -23,11 +23,11 @@ The `u-justify-` classes set  set `justify-content` to align flex children to th
   </Story>
   <Story name="justify-start">
     {`
-      <ul class="a-list-reset u-flex u-justify-start u-fg--white" style="min-height:10rem;">
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+      <ul class="a-list-reset u-flex u-justify-start u-fg-white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           Start
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           Start
         </li>
       </ul>
@@ -35,11 +35,11 @@ The `u-justify-` classes set  set `justify-content` to align flex children to th
   </Story>
   <Story name="justify-end">
     {`
-      <ul class="a-list-reset u-flex u-justify-end u-fg--white" style="min-height:10rem;">
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+      <ul class="a-list-reset u-flex u-justify-end u-fg-white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           End
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           End
         </li>
       </ul>
@@ -54,11 +54,11 @@ These classes are available at the `m` breakpoint.
 <Canvas isColumn>
   <Story name="justify-between@m">
     {`
-      <ul class="a-list-reset u-flex u-justify-between@m u-fg--white" style="min-height:10rem;">
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+      <ul class="a-list-reset u-flex u-justify-between@m u-fg-white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           Between
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           Between
         </li>
       </ul>
@@ -66,11 +66,11 @@ These classes are available at the `m` breakpoint.
   </Story>
   <Story name="justify-start@m">
     {`
-      <ul class="a-list-reset u-flex u-justify-start@m u-fg--white" style="min-height:10rem;">
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+      <ul class="a-list-reset u-flex u-justify-start@m u-fg-white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           Start
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           Start
         </li>
       </ul>
@@ -78,11 +78,11 @@ These classes are available at the `m` breakpoint.
   </Story>
   <Story name="justify-end@m">
     {`
-      <ul class="a-list-reset u-flex u-justify-end@m u-fg--white" style="min-height:10rem;">
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+      <ul class="a-list-reset u-flex u-justify-end@m u-fg-white" style="min-height:10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           End
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20">
+        <li class="u-margin-m u-padding-m u-bg-gray-20">
           End
         </li>
       </ul>

--- a/scss/bitstyles/utilities/line-height/_index.scss
+++ b/scss/bitstyles/utilities/line-height/_index.scss
@@ -1,6 +1,6 @@
 @use '../../settings/setup';
 @use '../../settings/typography';
 
-.#{setup.$namespace}u-line-height--min {
+.#{setup.$namespace}u-line-height-min {
   line-height: typography.$line-height-min;
 }

--- a/scss/bitstyles/utilities/line-height/line-height.stories.mdx
+++ b/scss/bitstyles/utilities/line-height/line-height.stories.mdx
@@ -9,7 +9,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
     {`
       <div class="u-flex">
         <h1 class="u-bg-gray-10">Default line-height</h1>
-        <h1 class="u-bg-gray-20 u-line-height-min">u-line-height--min</h1>
+        <h1 class="u-bg-gray-20 u-line-height-min">u-line-height-min</h1>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/line-height/line-height.stories.mdx
+++ b/scss/bitstyles/utilities/line-height/line-height.stories.mdx
@@ -5,11 +5,11 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 # Line-height
 
 <Canvas>
-  <Story name="u-line-height--min">
+  <Story name="u-line-height-min">
     {`
       <div class="u-flex">
-        <h1 class="u-bg--gray-10">Default line-height</h1>
-        <h1 class="u-bg--gray-20 u-line-height--min">u-line-height--min</h1>
+        <h1 class="u-bg-gray-10">Default line-height</h1>
+        <h1 class="u-bg-gray-20 u-line-height-min">u-line-height--min</h1>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/margin/margin.stories.mdx
+++ b/scss/bitstyles/utilities/margin/margin.stories.mdx
@@ -36,57 +36,57 @@ $bitstyles-margin-sizes: (
 <Canvas>
   <Story name="margin-0">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-0">u-margin-0</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-0">u-margin-0</div>
       </div>
     `}
   </Story>
   <Story name="margin-xxs">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xxs">u-margin-xxs</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xxs">u-margin-xxs</div>
       </div>
     `}
   </Story>
   <Story name="margin-xs">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xs">u-margin-xs</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xs">u-margin-xs</div>
       </div>
     `}
   </Story>
   <Story name="margin-s">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-s">u-margin-s</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-s">u-margin-s</div>
       </div>
     `}
   </Story>
   <Story name="margin-m">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-m">u-margin-m</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-m">u-margin-m</div>
       </div>
     `}
   </Story>
   <Story name="margin-l">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-l">u-margin-l</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-l">u-margin-l</div>
       </div>
     `}
   </Story>
   <Story name="margin-xl">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl">u-margin-xl</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl">u-margin-xl</div>
       </div>
     `}
   </Story>
   <Story name="margin-auto">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-auto">u-margin-auto</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-auto">u-margin-auto</div>
       </div>
     `}
   </Story>
@@ -97,43 +97,43 @@ $bitstyles-margin-sizes: (
 <Canvas>
   <Story name="margin-neg-xxs">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-neg-xxs">u-margin-neg-xxs</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-neg-xxs">u-margin-neg-xxs</div>
       </div>
     `}
   </Story>
   <Story name="margin-neg-xs">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-neg-xs">u-margin-neg-xs</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-neg-xs">u-margin-neg-xs</div>
       </div>
     `}
   </Story>
   <Story name="margin-neg-s">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-neg-s">u-margin-neg-s</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-neg-s">u-margin-neg-s</div>
       </div>
     `}
   </Story>
   <Story name="margin-neg-m">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-neg-m">u-margin-neg-m</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-neg-m">u-margin-neg-m</div>
       </div>
     `}
   </Story>
   <Story name="margin-neg-l">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-neg-l">u-margin-neg-l</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-neg-l">u-margin-neg-l</div>
       </div>
     `}
   </Story>
   <Story name="margin-neg-xl">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-neg-xl">u-margin-neg-xl</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-neg-xl">u-margin-neg-xl</div>
       </div>
     `}
   </Story>
@@ -163,43 +163,43 @@ The `'': null` entry is needed to render the margin classes with no directional 
   <Story id="utilities-margin--margin-xl" />
   <Story name="margin-xl-top">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl-top">u-margin-xl-top</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl-top">u-margin-xl-top</div>
       </div>
     `}
   </Story>
   <Story name="margin-xl-right">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl-right">u-margin-xl-right</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl-right">u-margin-xl-right</div>
       </div>
     `}
   </Story>
   <Story name="margin-xl-bottom">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl-bottom">u-margin-xl-bottom</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl-bottom">u-margin-xl-bottom</div>
       </div>
     `}
   </Story>
   <Story name="margin-xl-left">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl-left">u-margin-xl-left</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl-left">u-margin-xl-left</div>
       </div>
     `}
   </Story>
   <Story name="margin-xl-x">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl-x">u-margin-xl-x</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl-x">u-margin-xl-x</div>
       </div>
     `}
   </Story>
   <Story name="margin-xl-y">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl-y">u-margin-xl-y</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl-y">u-margin-xl-y</div>
       </div>
     `}
   </Story>
@@ -218,15 +218,15 @@ If you remove `base`, margin classes will not be output without a breakpoint.
 <Canvas>
   <Story name="margin-xl@s">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl@s">u-margin-xl@s</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl@s">u-margin-xl@s</div>
       </div>
     `}
   </Story>
   <Story name="margin-xl@m">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-margin-xl@m">u-margin-xl@m</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-margin-xl@m">u-margin-xl@m</div>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/overflow/_index.scss
+++ b/scss/bitstyles/utilities/overflow/_index.scss
@@ -1,10 +1,10 @@
 @use '../../settings/setup';
 @use '../../tools/overflow';
 
-.#{setup.$namespace}u-overflow--y {
+.#{setup.$namespace}u-overflow-y {
   @include overflow.overflow-y;
 }
 
-.#{setup.$namespace}u-overflow--x {
+.#{setup.$namespace}u-overflow-x {
   @include overflow.overflow-x;
 }

--- a/scss/bitstyles/utilities/overflow/overflow.stories.mdx
+++ b/scss/bitstyles/utilities/overflow/overflow.stories.mdx
@@ -11,9 +11,9 @@ Any vertical overflow on the element is allowed to scroll, horizontal overflow i
 Different browsers/OSes have different strategies for displaying scrollbars when they’re needed, this class standardises that behavior and ensures no scrollbars are displayed unless there’s something to scroll.
 
 <Canvas>
-  <Story name="Overflow--y">
+  <Story name="overflow-y">
     {`
-      <div class="u-overflow--y u-bg--brand-2" style="height: 5rem">
+      <div class="u-overflow-y u-bg-brand-2" style="height: 5rem">
         Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.
       </div>
     `}
@@ -23,7 +23,7 @@ Different browsers/OSes have different strategies for displaying scrollbars when
 <Canvas>
   <Story name="Overflow--x">
     {`
-      <div class="u-overflow--x u-bg--brand-2" style="width: 10rem">
+      <div class="u-overflow-x u-bg-brand-2" style="width: 10rem">
         Jelly&nbsp;cake&nbsp;marshmallow.&nbsp;Pie&nbsp;cotton&nbsp;candy&nbsp;chupa&nbsp;chups&nbsp;marzipan&nbsp;liquorice&nbsp;cheesecake&nbsp;wafer.
       </div>
     `}

--- a/scss/bitstyles/utilities/overflow/overflow.stories.mdx
+++ b/scss/bitstyles/utilities/overflow/overflow.stories.mdx
@@ -11,7 +11,7 @@ Any vertical overflow on the element is allowed to scroll, horizontal overflow i
 Different browsers/OSes have different strategies for displaying scrollbars when they’re needed, this class standardises that behavior and ensures no scrollbars are displayed unless there’s something to scroll.
 
 <Canvas>
-  <Story name="overflow-y">
+  <Story name="u-overflow-y">
     {`
       <div class="u-overflow-y u-bg-brand-2" style="height: 5rem">
         Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.
@@ -21,7 +21,7 @@ Different browsers/OSes have different strategies for displaying scrollbars when
 </Canvas>
 
 <Canvas>
-  <Story name="Overflow--x">
+  <Story name="u-overflow-x">
     {`
       <div class="u-overflow-x u-bg-brand-2" style="width: 10rem">
         Jelly&nbsp;cake&nbsp;marshmallow.&nbsp;Pie&nbsp;cotton&nbsp;candy&nbsp;chupa&nbsp;chups&nbsp;marzipan&nbsp;liquorice&nbsp;cheesecake&nbsp;wafer.

--- a/scss/bitstyles/utilities/padding/padding.stories.mdx
+++ b/scss/bitstyles/utilities/padding/padding.stories.mdx
@@ -27,50 +27,50 @@ $bitstyles-padding-sizes: (
 <Canvas>
   <Story name="padding-0">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-0">u-padding-0</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-0">u-padding-0</div>
       </div>
     `}
   </Story>
   <Story name="padding-xs">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xs">u-padding-xs</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xs">u-padding-xs</div>
       </div>
     `}
   </Story>
   <Story name="padding-s">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-s">u-padding-s</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-s">u-padding-s</div>
       </div>
     `}
   </Story>
   <Story name="padding-m">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-m">u-padding-m</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-m">u-padding-m</div>
       </div>
     `}
   </Story>
   <Story name="padding-l">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-l">u-padding-l</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-l">u-padding-l</div>
       </div>
     `}
   </Story>
   <Story name="padding-xl">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl">u-padding-xl</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl">u-padding-xl</div>
       </div>
     `}
   </Story>
   <Story name="padding-xxl">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xxl">u-padding-xxl</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xxl">u-padding-xxl</div>
       </div>
     `}
   </Story>
@@ -100,43 +100,43 @@ The `'': null` entry is needed to render the padding classes with no directional
   <Story id="utilities-padding--padding-xl" />
   <Story name="padding-xl-top">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl-top">u-padding-xl-top</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl-top">u-padding-xl-top</div>
       </div>
     `}
   </Story>
   <Story name="padding-xl-right">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl-right">u-padding-xl-right</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl-right">u-padding-xl-right</div>
       </div>
     `}
   </Story>
   <Story name="padding-xl-bottom">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl-bottom">u-padding-xl-bottom</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl-bottom">u-padding-xl-bottom</div>
       </div>
     `}
   </Story>
   <Story name="padding-xl-left">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl-left">u-padding-xl-left</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl-left">u-padding-xl-left</div>
       </div>
     `}
   </Story>
   <Story name="padding-xl-x">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl-x">u-padding-xl-x</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl-x">u-padding-xl-x</div>
       </div>
     `}
   </Story>
   <Story name="padding-xl-y">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl-y">u-padding-xl-y</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl-y">u-padding-xl-y</div>
       </div>
     `}
   </Story>
@@ -155,15 +155,15 @@ If you remove `base`, padding classes will not be output without a breakpoint.
 <Canvas>
   <Story name="padding-xl@m">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl@m">u-padding-xl@m</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl@m">u-padding-xl@m</div>
       </div>
     `}
   </Story>
   <Story name="padding-xl@l">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-padding-xl@l">u-padding-xl@l</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-padding-xl@l">u-padding-xl@l</div>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/relative/relative.stories.mdx
+++ b/scss/bitstyles/utilities/relative/relative.stories.mdx
@@ -10,9 +10,9 @@ Gives the element `position: relative`.
   <Story name="Relative">
     {`
       <div style="position:relative">
-        <div class="u-bg--gray-20 u-padding-xl" style="height: 10rem;">
+        <div class="u-bg-gray-20 u-padding-xl" style="height: 10rem;">
           <p style="position: absolute;top: 0; left: 0;">No relative parent</p>
-          <div class="u-relative u-bg--background" style="min-height:2rem;">
+          <div class="u-relative u-bg-background" style="min-height:2rem;">
             <p style="position: absolute; top: 0; left: 0;">With relative parent</p>
           </div>
         </div>

--- a/scss/bitstyles/utilities/round/_index.scss
+++ b/scss/bitstyles/utilities/round/_index.scss
@@ -4,18 +4,18 @@
   border-radius: 0;
 }
 
-.#{setup.$namespace}u-round-0--tr {
+.#{setup.$namespace}u-round-0-tr {
   border-top-right-radius: 0;
 }
 
-.#{setup.$namespace}u-round-0--br {
+.#{setup.$namespace}u-round-0-br {
   border-bottom-right-radius: 0;
 }
 
-.#{setup.$namespace}u-round-0--bl {
+.#{setup.$namespace}u-round-0-bl {
   border-bottom-left-radius: 0;
 }
 
-.#{setup.$namespace}u-round-0--tl {
+.#{setup.$namespace}u-round-0-tl {
   border-top-left-radius: 0;
 }

--- a/scss/bitstyles/utilities/round/round.stories.mdx
+++ b/scss/bitstyles/utilities/round/round.stories.mdx
@@ -12,24 +12,24 @@ Override border-radius per-corner.
       <button class="a-button u-round-0">u-round-0</button>
     `}
   </Story>
-  <Story name="u-round-0--tr">
+  <Story name="u-round-0-tr">
     {`
-      <button class="a-button u-round-0--tr">u-round-0--tr</button>
+      <button class="a-button u-round-0-tr">u-round-0-tr</button>
     `}
   </Story>
-  <Story name="u-round-0--br">
+  <Story name="u-round-0-br">
     {`
-      <button class="a-button u-round-0--br">u-round-0--br</button>
+      <button class="a-button u-round-0-br">u-round-0-br</button>
     `}
   </Story>
-  <Story name="u-round-0--bl">
+  <Story name="u-round-0-bl">
     {`
-      <button class="a-button u-round-0--bl">u-round-0--bl</button>
+      <button class="a-button u-round-0-bl">u-round-0-bl</button>
     `}
   </Story>
-  <Story name="u-round-0--tl">
+  <Story name="u-round-0-tl">
     {`
-      <button class="a-button u-round-0--tl">u-round-0--tl</button>
+      <button class="a-button u-round-0-tl">u-round-0-tl</button>
     `}
   </Story>
 </Canvas>

--- a/scss/bitstyles/utilities/row-start/row-start.stories.mdx
+++ b/scss/bitstyles/utilities/row-start/row-start.stories.mdx
@@ -11,73 +11,73 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
 <Canvas isColumn>
   <Story name="u-row-start-1">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-1">6-column grid, child 3, row-start-1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-1">6-column grid, child 3, row-start-1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-row-start-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-2">6-column grid, child 3, row-start-2</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2">6-column grid, child 3, row-start-2</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-row-start-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 3</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-3">6-column grid, child 4, row-start-3</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-3">6-column grid, child 4, row-start-3</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-row-start-4">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-4">6-column grid, child 3, row-start-4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-4">6-column grid, child 3, row-start-4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-row-start-5">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-5">6-column grid, child 3, row-start-5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-5">6-column grid, child 3, row-start-5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-row-start-6">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-6">6-column grid, child 3, row-start-6</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-6">6-column grid, child 3, row-start-6</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
@@ -90,37 +90,37 @@ The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 <Canvas isColumn>
   <Story name="u-row-start-2@s">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-2@s">6-column grid, child 3, row-start-1@s</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@s">6-column grid, child 3, row-start-1@s</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-row-start-2@m">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-2@m">6-column grid, child 3, row-start-1@m</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@m">6-column grid, child 3, row-start-1@m</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>
   <Story name="u-row-start-2@xl">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg--gray-10 a-list-reset">
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 1</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 2</li>
-        <li class="u-bg--brand-2 u-padding-m a-card u-row-start-2@xl">6-column grid, child 3, row-start-1@xl</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 4</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 5</li>
-        <li class="u-bg--background u-padding-m a-card">6-column grid, child 6</li>
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
+        <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@xl">6-column grid, child 3, row-start-1@xl</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 4</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 5</li>
+        <li class="u-bg-background u-padding-m a-card">6-column grid, child 6</li>
       </ul>
     `}
   </Story>

--- a/scss/bitstyles/utilities/self/self.stories.mdx
+++ b/scss/bitstyles/utilities/self/self.stories.mdx
@@ -14,16 +14,16 @@ Set `align-self` to align a flex child to the flex end:
   <Story name="self-end">
     {`
       <ul class="a-list-reset u-flex u-items-start u-fg-white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 10rem;">
           Elements of different height.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 15rem;">
           Elements of different height.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 12rem;">
           Elements of different height.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--brand-2 u-self-end" style="height: 10rem;">
+        <li class="u-margin-m u-padding-m u-bg-brand-2 u-self-end" style="height: 10rem;">
           u-self-end. Elements of different height.
         </li>
       </ul>
@@ -39,16 +39,16 @@ The classes are available at the `m` breakpoint.
   <Story name="self-end@m">
     {`
       <ul class="a-list-reset u-flex u-items-start u-fg-white">
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 10rem;">
           Elements of different height.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 15rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 15rem;">
           Elements of different height.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 12rem;">
+        <li class="u-margin-m u-padding-m u-bg-gray-20" style="height: 12rem;">
           Elements of different height.
         </li>
-        <li class="u-margin-m u-padding-m u-bg--brand-2 u-self-end@m" style="height: 10rem;">
+        <li class="u-margin-m u-padding-m u-bg-brand-2 u-self-end@m" style="height: 10rem;">
           u-self-end@m. Elements of different height.
         </li>
       </ul>

--- a/scss/bitstyles/utilities/self/self.stories.mdx
+++ b/scss/bitstyles/utilities/self/self.stories.mdx
@@ -13,7 +13,7 @@ Set `align-self` to align a flex child to the flex end:
 <Canvas>
   <Story name="self-end">
     {`
-      <ul class="a-list-reset u-flex u-items-start u-fg--white">
+      <ul class="a-list-reset u-flex u-items-start u-fg-white">
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
           Elements of different height.
         </li>
@@ -38,7 +38,7 @@ The classes are available at the `m` breakpoint.
 <Canvas>
   <Story name="self-end@m">
     {`
-      <ul class="a-list-reset u-flex u-items-start u-fg--white">
+      <ul class="a-list-reset u-flex u-items-start u-fg-white">
         <li class="u-margin-m u-padding-m u-bg--gray-20" style="height: 10rem;">
           Elements of different height.
         </li>

--- a/scss/bitstyles/utilities/text/_index.scss
+++ b/scss/bitstyles/utilities/text/_index.scss
@@ -1,7 +1,20 @@
-@use '../../settings/setup';
+@use './settings';
+@use '../../tools/directional-properties';
+@use '../../tools/media-query';
 
-@each $position in ('left', 'right', 'center', 'justify') {
-  .#{setup.$namespace}u-text--#{$position} {
-    text-align: #{$position};
+@include directional-properties.output-properties(
+  $property-name: 'text-align',
+  $classname-root: 'text',
+  $values: settings.$values
+);
+
+@each $breakpoint-alias in settings.$breakpoints {
+  @include media-query.media-query($breakpoint-alias) {
+    @include directional-properties.output-properties(
+      $property-name: 'text-align',
+      $classname-root: 'text',
+      $values: settings.$values,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
   }
 }

--- a/scss/bitstyles/utilities/text/_settings.scss
+++ b/scss/bitstyles/utilities/text/_settings.scss
@@ -1,0 +1,7 @@
+$values: (
+  'left': left,
+  'right': right,
+  'center': center,
+  'justify': justify,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/text/text.stories.mdx
+++ b/scss/bitstyles/utilities/text/text.stories.mdx
@@ -9,29 +9,29 @@ Set text-align properties on an element.
 <Canvas isColumn>
   <Story name="u-text-left">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-text-left">u-text-left. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-text-left">u-text-left. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
       </div>
     `}
   </Story>
   <Story name="u-text-right">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-text-right">u-text-right. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-text-right">u-text-right. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
       </div>
     `}
   </Story>
   <Story name="u-text-center">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-text-center">u-text-center. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-text-center">u-text-center. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
       </div>
     `}
   </Story>
   <Story name="u-text-justify">
     {`
-      <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-text-justify">u-text-justify. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
+      <div class="u-bg-brand-2 u-padding-m">
+        <div class="u-bg-background u-text-justify">u-text-justify. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/text/text.stories.mdx
+++ b/scss/bitstyles/utilities/text/text.stories.mdx
@@ -7,31 +7,31 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 Set text-align properties on an element.
 
 <Canvas isColumn>
-  <Story name="text--left">
+  <Story name="u-text-left">
     {`
       <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-text--left">u-text--left. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
+        <div class="u-bg--background u-text-left">u-text-left. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
       </div>
     `}
   </Story>
-  <Story name="text--right">
+  <Story name="u-text-right">
     {`
       <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-text--right">u-text--right. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
+        <div class="u-bg--background u-text-right">u-text-right. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
       </div>
     `}
   </Story>
-  <Story name="text--center">
+  <Story name="u-text-center">
     {`
       <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-text--center">u-text--center. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
+        <div class="u-bg--background u-text-center">u-text-center. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
       </div>
     `}
   </Story>
-  <Story name="text--justify">
+  <Story name="u-text-justify">
     {`
       <div class="u-bg--brand-2 u-padding-m">
-        <div class="u-bg--background u-text--justify">u-text--justify. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
+        <div class="u-bg--background u-text-justify">u-text-justify. Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</div>
       </div>
     `}
   </Story>

--- a/scss/bitstyles/utilities/text/text.stories.mdx
+++ b/scss/bitstyles/utilities/text/text.stories.mdx
@@ -36,3 +36,22 @@ Set text-align properties on an element.
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available text-align values can be customized by overriding the `$bitstyles-text-values` Sass variable:
+
+```scss
+$bitstyles-text-values: (
+  'left': left,
+  'right': right,
+  'center': center,
+  'justify': justify,
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-text-breakpoints` variable:
+
+```scss
+$bitstyles-text-breakpoints: ('m');
+```

--- a/scss/bitstyles/utilities/truncate/truncate.stories.mdx
+++ b/scss/bitstyles/utilities/truncate/truncate.stories.mdx
@@ -11,7 +11,7 @@ Note the exact algorithm is defined per browser and is of varying quality — yo
 <Canvas>
   <Story name="Truncate">
     {`
-      <div class="u-bg--brand-2" style="width:5rem">
+      <div class="u-bg-brand-2" style="width:5rem">
         <p class="u-truncate">Truncated content goes here</p>
       </div>
     `}

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1575,7 +1575,7 @@ table {
     content: '';
   }
 }
-.bsu-bg-f00 {
+.bs-u-bg-f00 {
   background-color: red;
 }
 .bs-u-border-f00 {
@@ -1652,25 +1652,25 @@ table {
     grid-column-start: 100;
   }
 }
-.bsu-inline-block {
+.bs-u-inline-block {
   display: inline-block;
 }
 @media screen and (max-width: 20em) {
-  .bsu-inline-block\@s {
+  .bs-u-inline-block\@s {
     display: inline-block;
   }
 }
 @media screen and (min-width: 30em) {
-  .bsu-inline-block\@m {
+  .bs-u-inline-block\@m {
     display: inline-block;
   }
 }
 @media screen and (min-width: 55em) {
-  .bsu-inline-block\@l {
+  .bs-u-inline-block\@l {
     display: inline-block;
   }
 }
-.bsu-fg--f00 {
+.bs-u-fg-f00 {
   color: red;
 }
 .bs-u-flex-wrap {
@@ -1717,22 +1717,22 @@ table {
     flex-shrink: 1;
   }
 }
-.bsu-font--light {
+.bs-u-font-light {
   font-weight: 300;
 }
-.bsu-font--normal {
+.bs-u-font-normal {
   font-weight: 400;
 }
-.bsu-font--medium {
+.bs-u-font-medium {
   font-weight: 600;
 }
-.bsu-font--bold {
+.bs-u-font-bold {
   font-weight: 800;
 }
-.bsu-font--italic {
+.bs-u-font-italic {
   font-style: italic;
 }
-.bsu-font--not-italic {
+.bs-u-font-not-italic {
   font-style: normal;
 }
 .bs-u-gap-100 {
@@ -2773,11 +2773,11 @@ table {
 .bsu-outline-0:focus {
   outline: none;
 }
-.bsu-overflow--y {
+.bsu-overflow-y {
   -webkit-overflow-scrolling: touch;
   overflow-y: auto;
 }
-.bsu-overflow--x {
+.bsu-overflow-x {
   -webkit-overflow-scrolling: touch;
   overflow-x: auto;
 }
@@ -3348,16 +3348,16 @@ table {
 .bsu-round-0 {
   border-radius: 0;
 }
-.bsu-round-0--tr {
+.bsu-round-0-tr {
   border-top-right-radius: 0;
 }
-.bsu-round-0--br {
+.bsu-round-0-br {
   border-bottom-right-radius: 0;
 }
-.bsu-round-0--bl {
+.bsu-round-0-bl {
   border-bottom-left-radius: 0;
 }
-.bsu-round-0--tl {
+.bsu-round-0-tl {
   border-top-left-radius: 0;
 }
 .bs-u-row-start-100 {
@@ -3426,16 +3426,16 @@ table {
     border: 0;
   }
 }
-.bsu-text--left {
+.bs-u-text-left {
   text-align: left;
 }
-.bsu-text--right {
+.bs-u-text-right {
   text-align: right;
 }
-.bsu-text--center {
+.bs-u-text-center {
   text-align: center;
 }
-.bsu-text--justify {
+.bs-u-text-justify {
   text-align: justify;
 }
 .bsu-truncate {

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1575,7 +1575,7 @@ table {
     content: '';
   }
 }
-.bsu-bg--f00 {
+.bsu-bg-f00 {
   background-color: red;
 }
 .bs-u-border-f00 {
@@ -1790,7 +1790,7 @@ table {
     justify-content: start;
   }
 }
-.bsu-line-height--min {
+.bsu-line-height-min {
   line-height: 1.25;
 }
 .bs-u-margin-0 {

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -1604,34 +1604,34 @@ table {
     content: '';
   }
 }
-.u-bg--black-80 {
+.u-bg-black-80 {
   background-color: #333;
 }
-.u-bg--background {
+.u-bg-background {
   background-color: #f7f8ff;
 }
-.u-bg--white {
+.u-bg-white {
   background-color: #fff;
 }
-.u-bg--brand-2 {
+.u-bg-brand-2 {
   background-color: #fa0;
 }
-.u-bg--gray-90 {
+.u-bg-gray-90 {
   background-color: #171931;
 }
-.u-bg--gray-80 {
+.u-bg-gray-80 {
   background-color: #2e2f47;
 }
-.u-bg--gray-50 {
+.u-bg-gray-50 {
   background-color: #73758d;
 }
-.u-bg--gray-20 {
+.u-bg-gray-20 {
   background-color: #b8b9d1;
 }
-.u-bg--gray-10 {
+.u-bg-gray-10 {
   background-color: #cfd0e9;
 }
-.u-bg--gray-5 {
+.u-bg-gray-5 {
   background-color: #dadbf3;
 }
 .u-border-gray-70 {
@@ -1932,22 +1932,25 @@ table {
     display: none;
   }
 }
-.u-fg--brand-1 {
+.u-fg-brand-1 {
   color: #000dff;
 }
-.u-fg--brand-2 {
+.u-fg-brand-2 {
   color: #fa0;
 }
-.u-fg--warning {
+.u-fg-warning {
   color: #fe881e;
 }
-.u-fg--gray-50 {
+.u-fg-white {
+  color: #fff;
+}
+.u-fg-gray-50 {
   color: #73758d;
 }
-.u-fg--gray-40 {
+.u-fg-gray-40 {
   color: #8a8ba3;
 }
-.u-fg--gray-30 {
+.u-fg-gray-30 {
   color: #a1a2bb;
 }
 .u-flex-wrap {
@@ -2000,22 +2003,22 @@ table {
     flex-shrink: 1;
   }
 }
-.u-font--light {
+.u-font-light {
   font-weight: 300;
 }
-.u-font--normal {
+.u-font-normal {
   font-weight: 400;
 }
-.u-font--medium {
+.u-font-medium {
   font-weight: 600;
 }
-.u-font--bold {
+.u-font-bold {
   font-weight: 800;
 }
-.u-font--italic {
+.u-font-italic {
   font-style: italic;
 }
-.u-font--not-italic {
+.u-font-not-italic {
   font-style: normal;
 }
 .u-gap-xs {
@@ -2181,7 +2184,7 @@ table {
     justify-content: flex-start;
   }
 }
-.u-line-height--min {
+.u-line-height-min {
   line-height: 1.25;
 }
 .u-margin-0 {
@@ -3164,11 +3167,11 @@ table {
 .u-outline-0:focus {
   outline: none;
 }
-.u-overflow--y {
+.u-overflow-y {
   -webkit-overflow-scrolling: touch;
   overflow-y: auto;
 }
-.u-overflow--x {
+.u-overflow-x {
   -webkit-overflow-scrolling: touch;
   overflow-x: auto;
 }
@@ -3739,16 +3742,16 @@ table {
 .u-round-0 {
   border-radius: 0;
 }
-.u-round-0--tr {
+.u-round-0-tr {
   border-top-right-radius: 0;
 }
-.u-round-0--br {
+.u-round-0-br {
   border-bottom-right-radius: 0;
 }
-.u-round-0--bl {
+.u-round-0-bl {
   border-bottom-left-radius: 0;
 }
-.u-round-0--tl {
+.u-round-0-tl {
   border-top-left-radius: 0;
 }
 .u-row-start-1 {
@@ -3850,16 +3853,16 @@ table {
   white-space: nowrap;
   border: 0;
 }
-.u-text--left {
+.u-text-left {
   text-align: left;
 }
-.u-text--right {
+.u-text-right {
   text-align: right;
 }
-.u-text--center {
+.u-text-center {
   text-align: center;
 }
-.u-text--justify {
+.u-text-justify {
   text-align: justify;
 }
 .u-truncate {

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -138,7 +138,7 @@ $bitstyles-col-start-values: (
   '100': 100
 );
 $bitstyles-display-values: (
-  'inline-block': 'inline-block',
+  inline-block: inline-block,
 );
 $bitstyles-fg-values: (
   'f00': #f00,

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -138,7 +138,7 @@ $bitstyles-col-start-values: (
   '100': 100
 );
 $bitstyles-display-values: (
-  'inline-block': 'inline-block',
+  inline-block: inline-block,
 );
 $bitstyles-fg-values: (
   'f00': #f00,

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -126,7 +126,7 @@
     '100': 100
   ),
   $display-values: (
-    'inline-block': 'inline-block',
+    inline-block: inline-block,
   ),
   $fg-values: (
     'f00': #f00,

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -244,7 +244,7 @@
 );
 @use '../../scss/bitstyles/utilities/display' with (
   $values: (
-    'inline-block': 'inline-block',
+    inline-block: inline-block,
   )
 );
 @use '../../scss/bitstyles/utilities/fg' with (


### PR DESCRIPTION
Fixes #544 

The following changes are contained in this pull request:

- Switches to using `directional-properties` helpers for generating more of the utility classes (the ones which have the most advantage from being specified using overiddable variables, and/or available at different media-queries)
- Removes the double-dash from utility classes that are manually written

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
