### PR TITLE
[#554] Align dt/dd to baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - `.u-col-span-` and `.u-col-start-` classes are available at `@l` breakpoint again. Fixes the complex form example
 - `$bitstyles-col-span-breakpoints` variable has been corrected to `$bitstyles-col-start-breakpoints`. If you were using this variable, you’ll need to rename it
 
+### Changed
+
+- `dl` examples are now aligned to the baseline, using the `u-items-baseline` class. Update `dl` classnames in your project to match
+
 ### Breaking
 
 - As `.a-card` elements now set their own padding, remove any utility padding classes. If the padding does not match your requirements, it can be customized using the cards’ sass variables

--- a/scss/bitstyles/atoms/dl/dl.stories.mdx
+++ b/scss/bitstyles/atoms/dl/dl.stories.mdx
@@ -10,15 +10,15 @@ A list of term/description pairs, used to display any set of key-value pairs. It
   <Story name="dl">
     {`
       <dl class="a-dl">
-        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
           <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Full name</dt>
           <dd class="u-col-span-2">Muffin Gummies</dd>
         </div>
-        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
           <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Email</dt>
           <dd class="u-col-span-2">cupcake@tiramisu.com</dd>
         </div>
-        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
           <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Description</dt>
           <dd class="u-col-span-2">Muffin gummies tart fruitcake gummi bears chocolate bar. Jujubes candy macaroon topping dessert biscuit topping sugar plum sesame snaps. Chocolate donut cake tootsie roll donut biscuit caramels sugar plum jelly beans. Dessert dragée jelly-o gummi bears sweet halvah soufflé.</dd>
         </div>

--- a/scss/bitstyles/ui/dl.stories.mdx
+++ b/scss/bitstyles/ui/dl.stories.mdx
@@ -30,15 +30,15 @@ A list of term/description pairs, used to display any set of key-value pairs. It
           <p class="u-fg--gray-50 u-h6">Cookie croissant jujubes tart. Jelly beans marshmallow cake apple pie. Sweet carrot cake marshmallow bonbon gummies lollipop bear claw.</p>
         </div>
         <dl class="a-dl">
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Full name</dt>
             <dd class="u-col-span-2">Muffin Gummies</dd>
           </div>
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Email</dt>
             <dd class="u-col-span-2">cupcake@tiramisu.com</dd>
           </div>
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">Description</dt>
             <dd class="u-col-span-2">Muffin gummies tart fruitcake gummi bears chocolate bar. Jujubes candy macaroon topping dessert biscuit topping sugar plum sesame snaps. Chocolate donut cake tootsie roll donut biscuit caramels sugar plum jelly beans. Dessert dragée jelly-o gummi bears sweet halvah soufflé.</dd>
           </div>


### PR DESCRIPTION
Fixes #554 

The following changes are contained in this pull request:
- Example `dl`s are now aligned to baseline

## Looks like

<img width="873" alt="Screenshot 2021-11-10 at 16 40 55" src="https://user-images.githubusercontent.com/2479422/141144262-6eee9ef2-cf7f-4945-b342-246d8b775c74.png">



Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
