### PR TITLE
[#560] Double 1px solid in dropdown separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+### Fixed
+
+- The `border-width` and `border-style` are no longer hardcoded in the dropdown separator styles. The existing default value for the `$separator-border` variable already set those properties, so you so not need to change anything unless you override that variable in your project. This fixes the issue of an invalid `border` property when your build does not get automatically fixed by the build tools (in the case of bitstyles, postcss was correcting the border property)
+
 ## [[3.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0) - 2021-11-17
 
 ### Added

--- a/scss/bitstyles/atoms/dropdown/_dropdown.scss
+++ b/scss/bitstyles/atoms/dropdown/_dropdown.scss
@@ -20,7 +20,7 @@
 
   [role="separator"] {
     margin: settings.$separator-spacing 0;
-    border-top: 1px solid settings.$separator-border;
+    border-top: settings.$separator-border;
   }
 
   @include media-query.media-query('motion-ok') {


### PR DESCRIPTION
Fixes #560 

The following changes are contained in this pull request:

- Removes the hard-coded border properties, now handled only by the variable. Nothing to show visually here because it was not an issue in bitstyles build (as postcss was correcting the invalid border property) but was an issue for other projects 

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
