### PR TITLE
[#559] Allow font base url to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - `dl` examples are now aligned to the baseline, using the `u-items-baseline` class. Update `dl` classnames in your project to match
+- `$font-family-webfont` is now `$webfont-family-name`, if you’ve overrideen this variable, you will need to rename it. The variable should now only contain the filename (no filename extansions, as before), as the path to your fonts is set with the `$webfont-base-url` variable (defaults to `../assets/fonts/`). If you host your fonts in a different location, you can change this value to match
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 - `dl` examples are now aligned to the baseline, using the `u-items-baseline` class. Update `dl` classnames in your project to match
-- `$font-family-webfont` is now `$webfont-family-name`, if you’ve overrideen this variable, you will need to rename it. The variable should now only contain the filename (no filename extansions, as before), as the path to your fonts is set with the `$webfont-base-url` variable (defaults to `../assets/fonts/`). If you host your fonts in a different location, you can change this value to match
+- `$font-family-webfont` is now `$webfont-family-name`. If you’ve overridden this variable, you will need to rename it. The variable should only contain the filename (no filename extensions, as before), as the path to your fonts is now set with the `$webfont-base-url` variable (which defaults to `../assets/fonts/`). If you host your fonts in a different location, you should change this value to match
 
 ### Breaking
 

--- a/script/test
+++ b/script/test
@@ -25,6 +25,7 @@ printf "\nComparing generated CSS against expected CSS…\n"
 diff -u -w --from-file $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-import-all.css \
   && diff -u -w --from-file $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-use-all.css \
   && diff -u -w --from-file $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-import-each.css \
+  && diff -u -w --from-file $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-use-each.css \
   && diff -u -w --from-file $FIXTURES_FOLDER/bitstyles.css $TEMP_FOLDER/bitstyles.css
 
 compare_result=$?

--- a/scss/bitstyles/base/font-face/_index.scss
+++ b/scss/bitstyles/base/font-face/_index.scss
@@ -4,9 +4,9 @@
 
 @each $webfont-variant, $webfont-variant-settings in typography.$webfont-variants {
   @include font-face.webfont(
-    map.get($webfont-variant-settings, 'font-family'),
-    map.get($webfont-variant-settings, 'font-style'),
-    map.get($webfont-variant-settings, 'font-weight'),
-    map.get($webfont-variant-settings, 'url'),
+    $font-family: map.get($webfont-variant-settings, 'font-family'),
+    $font-style: map.get($webfont-variant-settings, 'font-style'),
+    $font-weight: map.get($webfont-variant-settings, 'font-weight'),
+    $font-url: typography.$webfont-base-url + map.get($webfont-variant-settings, 'filename'),
   );
 }

--- a/scss/bitstyles/settings/_typography.scss
+++ b/scss/bitstyles/settings/_typography.scss
@@ -6,31 +6,32 @@ $font-weight-medium: 600 !default;
 $font-weight-bold: 800 !default;
 
 /* stylelint-disable value-keyword-case */
-$font-family-webfont: 'Nunito' !default;
+$webfont-family-name: 'Nunito' !default;
+$webfont-base-url: '../assets/fonts/' !default;
 $webfont-variants: (
   'normal': (
-    'font-family': 'Nunito',
+    'font-family': $webfont-family-name,
     'font-style': normal,
     'font-weight': $font-weight-normal,
-    'url': '../assets/fonts/nunito-v16-latin-400'
+    'filename': 'nunito-v16-latin-400'
   ),
   'italic': (
-    'font-family': 'Nunito',
+    'font-family': $webfont-family-name,
     'font-style': italic,
     'font-weight': $font-weight-normal,
-    'url': '../assets/fonts/nunito-v16-latin-italic'
+    'filename': 'nunito-v16-latin-italic'
   ),
   'medium': (
-    'font-family': 'Nunito',
+    'font-family': $webfont-family-name,
     'font-style': normal,
     'font-weight': $font-weight-medium,
-    'url': '../assets/fonts/nunito-v16-latin-600'
+    'filename': 'nunito-v16-latin-600'
   ),
   'bold': (
-    'font-family': 'Nunito',
+    'font-family': $webfont-family-name,
     'font-style': normal,
     'font-weight': $font-weight-bold,
-    'url': '../assets/fonts/nunito-v16-latin-800'
+    'filename': 'nunito-v16-latin-800'
   )
 ) !default;
 
@@ -38,8 +39,8 @@ $font-family-header-stack: (-apple-system, BlinkMacSystemFont, "Segoe UI", Robot
 $font-family-body-stack: (-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, helvetica, arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol") !default;
 /* stylelint-enable value-keyword-case */
 
-$font-family-header: list.join($font-family-webfont, $font-family-header-stack) !default;
-$font-family-body: list.join($font-family-webfont, $font-family-body-stack) !default;
+$font-family-header: list.join($webfont-family-name, $font-family-header-stack) !default;
+$font-family-body: list.join($webfont-family-name, $font-family-body-stack) !default;
 
 $font-size-base-small: 16px !default;
 $font-size-base: 18px !default;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -191,32 +191,32 @@ figcaption {
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url(../assets/fonts/nunito-v16-latin-400.woff2) format('woff2'),
-    url(../assets/fonts/nunito-v16-latin-400.woff) format('woff');
+  src: url(nunito-v16-latin-400.woff2) format('woff2'),
+    url(nunito-v16-latin-400.woff) format('woff');
 }
 @font-face {
   font-family: FakeFont;
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url(../assets/fonts/nunito-v16-latin-italic.woff2) format('woff2'),
-    url(../assets/fonts/nunito-v16-latin-italic.woff) format('woff');
+  src: url(nunito-v16-latin-italic.woff2) format('woff2'),
+    url(nunito-v16-latin-italic.woff) format('woff');
 }
 @font-face {
   font-family: FakeFont;
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url(../assets/fonts/nunito-v16-latin-600.woff2) format('woff2'),
-    url(../assets/fonts/nunito-v16-latin-600.woff) format('woff');
+  src: url(nunito-v16-latin-600.woff2) format('woff2'),
+    url(nunito-v16-latin-600.woff) format('woff');
 }
 @font-face {
   font-family: FakeFont;
   font-style: normal;
   font-weight: 800;
   font-display: swap;
-  src: url(../assets/fonts/nunito-v16-latin-800.woff2) format('woff2'),
-    url(../assets/fonts/nunito-v16-latin-800.woff) format('woff');
+  src: url(nunito-v16-latin-800.woff2) format('woff2'),
+    url(nunito-v16-latin-800.woff) format('woff');
 }
 fieldset {
   padding: 10rem;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -187,7 +187,7 @@ figcaption {
   color: #000;
 }
 @font-face {
-  font-family: Nunito;
+  font-family: FakeFont;
   font-style: normal;
   font-weight: 400;
   font-display: swap;
@@ -195,7 +195,7 @@ figcaption {
     url(../assets/fonts/nunito-v16-latin-400.woff) format('woff');
 }
 @font-face {
-  font-family: Nunito;
+  font-family: FakeFont;
   font-style: italic;
   font-weight: 400;
   font-display: swap;
@@ -203,7 +203,7 @@ figcaption {
     url(../assets/fonts/nunito-v16-latin-italic.woff) format('woff');
 }
 @font-face {
-  font-family: Nunito;
+  font-family: FakeFont;
   font-style: normal;
   font-weight: 600;
   font-display: swap;
@@ -211,7 +211,7 @@ figcaption {
     url(../assets/fonts/nunito-v16-latin-600.woff) format('woff');
 }
 @font-face {
-  font-family: Nunito;
+  font-family: FakeFont;
   font-style: normal;
   font-weight: 800;
   font-display: swap;
@@ -577,8 +577,9 @@ textarea:disabled {
   }
 }
 html {
-  font-family: sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-    helvetica, arial, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  font-family: FakeFont, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
   line-height: 1.5;
   color: #000;
   -webkit-text-size-adjust: 100%;
@@ -591,8 +592,9 @@ h4,
 h5,
 h6 {
   margin: 0;
-  font-family: sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-    helvetica, arial, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  font-family: FakeFont, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
   font-weight: 800;
   text-rendering: optimizeLegibility;
 }

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -68,6 +68,7 @@ $bitstyles-color-palette-color-palette: (
 $bitstyles-layout-size-base: 10rem;
 $bitstyles-setup-namespace: 'bs';
 $bitstyles-typography-webfont-family-name: 'FakeFont';
+$bitstyles-typography-webfont-base-url: './';
 
 //
 // Base settings /////////////////////////////////////

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -67,7 +67,7 @@ $bitstyles-color-palette-color-palette: (
 );
 $bitstyles-layout-size-base: 10rem;
 $bitstyles-setup-namespace: 'bs';
-$bitstyles-typography-font-family-webfont: sans-serif;
+$bitstyles-typography-webfont-family-name: 'FakeFont';
 
 //
 // Base settings /////////////////////////////////////

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -68,6 +68,7 @@ $bitstyles-color-palette-color-palette: (
 $bitstyles-layout-size-base: 10rem;
 $bitstyles-setup-namespace: 'bs';
 $bitstyles-typography-webfont-family-name: 'FakeFont';
+$bitstyles-typography-webfont-base-url: './';
 
 //
 // Base settings /////////////////////////////////////

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -67,7 +67,7 @@ $bitstyles-color-palette-color-palette: (
 );
 $bitstyles-layout-size-base: 10rem;
 $bitstyles-setup-namespace: 'bs';
-$bitstyles-typography-font-family-webfont: sans-serif;
+$bitstyles-typography-webfont-family-name: 'FakeFont';
 
 //
 // Base settings /////////////////////////////////////

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -67,7 +67,7 @@
   ),
   $layout-size-base: 10rem,
   $setup-namespace: 'bs',
-  $typography-font-family-webfont: sans-serif,
+  $typography-webfont-family-name: 'FakeFont',
   // base
   $figure-font-style: bold,
   $forms-fieldset-padding: 10rem,

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -68,6 +68,7 @@
   $layout-size-base: 10rem,
   $setup-namespace: 'bs',
   $typography-webfont-family-name: 'FakeFont',
+  $typography-webfont-base-url: './',
   // base
   $figure-font-style: bold,
   $forms-fieldset-padding: 10rem,

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -78,7 +78,8 @@
   $namespace: 'bs'
 );
 @use '../../scss/bitstyles/settings/typography' as settings-typography with (
-  $webfont-family-name: 'FakeFont'
+  $webfont-family-name: 'FakeFont',
+  $webfont-base-url: './'
 );
 
 //

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -78,7 +78,7 @@
   $namespace: 'bs'
 );
 @use '../../scss/bitstyles/settings/typography' as settings-typography with (
-  $font-family-webfont: sans-serif
+  $webfont-family-name: 'FakeFont'
 );
 
 //


### PR DESCRIPTION
Fixes #559 

The following changes are contained in this pull request:
- Font-file location is now set by a variable
- Updates tests to use a different  webfont name instead of a standard `sans-serif`

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
