### PR TITLE
[#558] Rename link variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `img` and `iframe` now default to `display: block`. Use the utility class `u-inline` if you need to replace the old behavior
 - The default margin for paragraphs is now `0`. Use the `$margin-paragraph` variable in typography settings to change this, or use margin utility classes on the HTML elements
 - Variable names for links have changed — the word `link` is now omitted, resulting in e.g. `$color-link` becoming `$color`, `$link-color`, or `$bitstyles-link-color`, and `$color-link-hover` becoming `$color-hover`, `$link-color-hover`, or `$bitstyles-link-color-hover`, depending on how you use bitstyles
+- Variable names for breakpoints have changed — the word `breakpoint` is now omittted, resulting in e.g. `$breakpoint-boundary-width` becoming `$boundary-width`, `$breakpoints-boundary-width`, or `$bitstyles-breakpoint-boundary-width`, depending on how you use bitstyles
 
 ## [[3.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0) - 2021-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# Unreleased
+## Unreleased
+
+### Added
+
+- There are now variables to specify the `color`, `text-decoration`, `background-color`, and `box-shadow` of links in each state
 
 ### Added
 
@@ -9,6 +13,7 @@
 ### Fixed
 
 - The `border-width` and `border-style` are no longer hardcoded in the dropdown separator styles. The existing default value for the `$separator-border` variable already set those properties, so you so not need to change anything unless you override that variable in your project. This fixes the issue of an invalid `border` property when your build does not get automatically fixed by the build tools (in the case of bitstyles, postcss was correcting the border property)
+- Link variables can all now be overridden using any of the four import/use methods
 
 ### Changed
 
@@ -19,6 +24,7 @@
 
 - `img` and `iframe` now default to `display: block`. Use the utility class `u-inline` if you need to replace the old behavior
 - The default margin for paragraphs is now `0`. Use the `$margin-paragraph` variable in typography settings to change this, or use margin utility classes on the HTML elements
+- Variable names for links have changed — the word `link` is now omitted, resulting in e.g. `$color-link` becoming `$color`, `$link-color`, or `$bitstyles-link-color`, and `$color-link-hover` becoming `$color-hover`, `$link-color-hover`, or `$bitstyles-link-color-hover`, depending on how you use bitstyles
 
 ## [[3.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0) - 2021-11-17
 

--- a/scss/bitstyles.import.scss
+++ b/scss/bitstyles.import.scss
@@ -1,1 +1,1 @@
-@forward "bitstyles" as bitstyles-*;
+@forward 'bitstyles' as bitstyles-*;

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -7,6 +7,7 @@
 @forward 'bitstyles/settings/layout' as layout-*;
 @forward 'bitstyles/settings/setup' as setup-*;
 @forward 'bitstyles/settings/typography' as typography-*;
+@forward 'bitstyles/settings/link' as link-*;
 
 //
 // Forwards: Base settings /////////////////////////////////////

--- a/scss/bitstyles/settings/_breakpoints.scss
+++ b/scss/bitstyles/settings/_breakpoints.scss
@@ -1,13 +1,13 @@
-$breakpoint-boundary-width:    0.0625em !default;
-$breakpoint-s-m-boundary:      30em !default;
-$breakpoint-m-l-boundary:      55em !default;
-$breakpoint-l-xl-boundary:     95em !default;
+$boundary-width:    0.0625em !default;
+$s-m-boundary:      30em !default;
+$m-l-boundary:      55em !default;
+$l-xl-boundary:     95em !default;
 
 $breakpoints: (
-  's':                  'screen and (max-width: #{$breakpoint-s-m-boundary - $breakpoint-boundary-width})',
-  'm':                  'screen and (min-width: #{$breakpoint-s-m-boundary})',
-  'l':                  'screen and (min-width: #{$breakpoint-m-l-boundary})',
-  'xl':                 'screen and (min-width: #{$breakpoint-l-xl-boundary})',
+  's':                  'screen and (max-width: #{$s-m-boundary - $boundary-width})',
+  'm':                  'screen and (min-width: #{$s-m-boundary})',
+  'l':                  'screen and (min-width: #{$m-l-boundary})',
+  'xl':                 'screen and (min-width: #{$l-xl-boundary})',
   'hidpi':              '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)',
   'landscape':          'all and (orientation:landscape)',
   'portrait':           'all and (orientation:portrait)',

--- a/scss/bitstyles/settings/_link.scss
+++ b/scss/bitstyles/settings/_link.scss
@@ -1,11 +1,33 @@
+@use './typography';
 @use '../tools/palette';
 @use 'animation';
 
-$background-color-link: none !default;
-$color-link:            palette.get('brand-1', '80') !default;
-$color-link-visited:    palette.get('brand-1', '60') !default;
-$color-link-hover:      palette.get('brand-1', '100') !default;
-$background-color-link-hover: none !default;
-$link-transition: color animation.$transition-duration animation.$transition-easing !default;
-$text-decoration-link:       none !default;
-$text-decoration-link-hover: underline !default;
+//
+// Base styles /////////////////////////////////////////
+
+$transition: color animation.$transition-duration animation.$transition-easing !default;
+$font-weight: typography.$font-weight-medium !default;
+
+//
+// Base Colors /////////////////////////////////////////
+
+$color: palette.get('brand-1', '80') !default;
+$text-decoration: none !default;
+$background-color: none !default;
+$box-shadow: none !default;
+
+//
+// Visited /////////////////////////////////////////
+
+$color-visited: palette.get('brand-1', '60') !default;
+$text-decoration-visited: none !default;
+$background-color-visited: none !default;
+$box-shadow-visited: none !default;
+
+//
+// Hover /////////////////////////////////////////
+
+$color-hover: palette.get('brand-1', '100') !default;
+$text-decoration-hover: underline !default;
+$background-color-hover: none !default;
+$box-shadow-hover: none !default;

--- a/scss/bitstyles/tools/_link.scss
+++ b/scss/bitstyles/tools/_link.scss
@@ -1,5 +1,4 @@
 @use '../settings/link';
-@use '../settings/typography';
 
 // Link
 //
@@ -8,26 +7,29 @@
 
 @mixin link {
   padding: 0;
-  font-weight: typography.$font-weight-medium;
-  color: link.$color-link;
-  text-decoration: link.$text-decoration-link;
+  font-weight: link.$font-weight;
+  color: link.$color;
+  text-decoration: link.$text-decoration;
   text-decoration-skip-ink: auto;
   cursor: pointer;
-  background: link.$background-color-link;
+  background-color: link.$background-color;
   border: 0;
-  box-shadow: none;
-  transition: link.$link-transition;
+  box-shadow: link.$box-shadow;
+  transition: link.$transition;
   -webkit-appearance: none; // stylelint-disable-line property-no-vendor-prefix
 
   &:visited {
-    color: link.$color-link-visited;
+    color: link.$color-visited;
+    text-decoration: link.$text-decoration-visited;
+    background-color: link.$background-color-visited;
+    box-shadow: link.$box-shadow-visited;
   }
 
   &:hover,
   &:focus {
-    color: link.$color-link-hover;
-    text-decoration: link.$text-decoration-link-hover;
-    background: link.$background-color-link-hover;
-    box-shadow: none;
+    color: link.$color-hover;
+    text-decoration: link.$text-decoration-hover;
+    background-color: link.$background-color-hover;
+    box-shadow: link.$box-shadow-hover;
   }
 }

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -162,12 +162,12 @@ img {
 a {
   padding: 0;
   font-weight: 600;
-  color: #000;
+  color: red;
   text-decoration: none;
   -webkit-text-decoration-skip: ink;
   text-decoration-skip-ink: auto;
   cursor: pointer;
-  background: none;
+  background-color: none;
   border: 0;
   box-shadow: none;
   transition: color 75ms ease-out;
@@ -175,12 +175,15 @@ a {
 }
 a:visited {
   color: #000;
+  text-decoration: none;
+  background-color: none;
+  box-shadow: none;
 }
 a:focus,
 a:hover {
   color: #000;
   text-decoration: underline;
-  background: none;
+  background-color: none;
   box-shadow: none;
 }
 figcaption {
@@ -1360,12 +1363,12 @@ table {
 .bsa-link {
   padding: 0;
   font-weight: 600;
-  color: #000;
+  color: red;
   text-decoration: none;
   -webkit-text-decoration-skip: ink;
   text-decoration-skip-ink: auto;
   cursor: pointer;
-  background: none;
+  background-color: none;
   border: 0;
   box-shadow: none;
   transition: color 75ms ease-out;
@@ -1373,12 +1376,15 @@ table {
 }
 .bsa-link:visited {
   color: #000;
+  text-decoration: none;
+  background-color: none;
+  box-shadow: none;
 }
 .bsa-link:focus,
 .bsa-link:hover {
   color: #000;
   text-decoration: underline;
-  background: none;
+  background-color: none;
   box-shadow: none;
 }
 .bsa-list-reset {

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -167,7 +167,7 @@ a {
   -webkit-text-decoration-skip: ink;
   text-decoration-skip-ink: auto;
   cursor: pointer;
-  background: none;
+  background-color: none;
   border: 0;
   box-shadow: none;
   transition: color 75ms ease-in-out;
@@ -175,12 +175,15 @@ a {
 }
 a:visited {
   color: #666eff;
+  text-decoration: none;
+  background-color: none;
+  box-shadow: none;
 }
 a:focus,
 a:hover {
   color: #000dff;
   text-decoration: underline;
-  background: none;
+  background-color: none;
   box-shadow: none;
 }
 figcaption {
@@ -1379,7 +1382,7 @@ table {
   -webkit-text-decoration-skip: ink;
   text-decoration-skip-ink: auto;
   cursor: pointer;
-  background: none;
+  background-color: none;
   border: 0;
   box-shadow: none;
   transition: color 75ms ease-in-out;
@@ -1387,12 +1390,15 @@ table {
 }
 .a-link:visited {
   color: #666eff;
+  text-decoration: none;
+  background-color: none;
+  box-shadow: none;
 }
 .a-link:focus,
 .a-link:hover {
   color: #000dff;
   text-decoration: underline;
-  background: none;
+  background-color: none;
   box-shadow: none;
 }
 .a-list-reset {

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -71,6 +71,7 @@ $bitstyles-typography-webfont-family-name: 'FakeFont';
 $bitstyles-typography-webfont-base-url: './';
 $bitstyles-typography-margin-heading: 10rem;
 $bitstyles-typography-margin-paragraph: 10rem;
+$bitstyles-link-color: #f00;
 
 //
 // Base settings /////////////////////////////////////

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -2,7 +2,7 @@
 // Global settings /////////////////////////////////////
 
 $bitstyles-animation-transition-easing: ease-out;
-$bitstyles-breakpoints-breakpoint-boundary-width: 10em;
+$bitstyles-breakpoints-boundary-width: 10em;
 $bitstyles-color-palette-black: #f00;
 $bitstyles-color-palette-grays-hint-color: #f00;
 $bitstyles-color-palette-color-palette: (

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -71,6 +71,7 @@ $bitstyles-typography-webfont-family-name: 'FakeFont';
 $bitstyles-typography-webfont-base-url: './';
 $bitstyles-typography-margin-heading: 10rem;
 $bitstyles-typography-margin-paragraph: 10rem;
+$bitstyles-link-color: #f00;
 
 //
 // Base settings /////////////////////////////////////
@@ -177,6 +178,7 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/settings/layout';
 @import '../../scss/bitstyles/settings/setup';
 @import '../../scss/bitstyles/settings/typography';
+@import '../../scss/bitstyles/settings/link';
 
 //
 // Generic ////////////////////////////////////

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -2,7 +2,7 @@
 // Global settings /////////////////////////////////////
 
 $bitstyles-animation-transition-easing: ease-out;
-$bitstyles-breakpoints-breakpoint-boundary-width: 10em;
+$bitstyles-breakpoints-boundary-width: 10em;
 $bitstyles-color-palette-black: #f00;
 $bitstyles-color-palette-grays-hint-color: #f00;
 $bitstyles-color-palette-color-palette: (

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -71,6 +71,7 @@
   $typography-webfont-base-url: './',
   $typography-margin-heading: 10rem,
   $typography-margin-paragraph: 10rem,
+  $link-color: #f00,
   // base
   $figure-font-style: bold,
   $forms-fieldset-padding: 10rem,

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -2,7 +2,7 @@
 @use '../../scss/bitstyles' with (
   // global settings
   $animation-transition-easing: ease-out,
-  $breakpoints-breakpoint-boundary-width: 10em,
+  $breakpoints-boundary-width: 10em,
   $color-palette-black: #f00,
   $color-palette-grays-hint-color: #f00,
   $color-palette-color-palette: (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -83,6 +83,9 @@
   $margin-heading: 10rem,
   $margin-paragraph: 10rem,
 );
+@use '../../scss/bitstyles/settings/link' as settings-link with (
+  $color: #f00,
+);
 
 //
 // Generic ////////////////////////////////////

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -5,7 +5,7 @@
   $transition-easing: ease-out
 );
 @use '../../scss/bitstyles/settings/breakpoints' with (
-  $breakpoint-boundary-width: 10em
+  $boundary-width: 10em
 );
 @use '../../scss/bitstyles/settings/color-palette' with (
   $grays-hint-color: #f00,


### PR DESCRIPTION
Fixes #558 

The following changes are contained in this pull request:

- Renames the link variables so they make more sense within the Sass module system, and fit the naming scheme for other modules
- More properties are now set by variables
- Fixes the missing imports & forwards that was breaking some link overrides
- Corrected naming of breakpoints variables to match the scheme, and avoid duplication of the module name in the variable names

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
