### PR TITLE
[#561] Add variable to handle margins in base/typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+### Added
+
+- Default margins for heading elements and paragraphs can now be specified with the `$margin-heading` and `$margin-paragraph` variables respectively
+
 ### Fixed
 
 - The `border-width` and `border-style` are no longer hardcoded in the dropdown separator styles. The existing default value for the `$separator-border` variable already set those properties, so you so not need to change anything unless you override that variable in your project. This fixes the issue of an invalid `border` property when your build does not get automatically fixed by the build tools (in the case of bitstyles, postcss was correcting the border property)
@@ -14,6 +18,7 @@
 ### Breaking
 
 - `img` and `iframe` now default to `display: block`. Use the utility class `u-inline` if you need to replace the old behavior
+- The default margin for paragraphs is now `0`. Use the `$margin-paragraph` variable in typography settings to change this, or use margin utility classes on the HTML elements
 
 ## [[3.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v3.0.0) - 2021-11-17
 

--- a/scss/bitstyles/base/typography/_index.scss
+++ b/scss/bitstyles/base/typography/_index.scss
@@ -18,7 +18,7 @@ h3,
 h4,
 h5,
 h6 {
-  margin: 0;
+  margin: typography.$margin-heading;
   font-family: typography.$font-family-header;
   font-weight: typography.$font-weight-bold;
   text-rendering: optimizeLegibility;
@@ -27,7 +27,7 @@ h6 {
 @include typography-tools.generate-font-sizes('', (html, h1, h2, h3, h4, h5, h6));
 
 p {
-  margin: 0 0 size.get('m');
+  margin: 0 0 typography.$margin-paragraph;
 }
 
 address {

--- a/scss/bitstyles/generic/_normalize.scss
+++ b/scss/bitstyles/generic/_normalize.scss
@@ -171,14 +171,6 @@ button:-moz-focusring,
 }
 
 /**
- * Correct the padding in Firefox.
- */
-
-fieldset {
-  padding: size.get('m');
-}
-
-/**
  * 1. Correct the text wrapping in Edge and IE.
  * 2. Correct the color inheritance from `fieldset` elements in IE.
  * 3. Remove the padding so developers are not caught out when they zero out

--- a/scss/bitstyles/settings/_typography.scss
+++ b/scss/bitstyles/settings/_typography.scss
@@ -48,6 +48,9 @@ $font-size-base: 18px !default;
 $line-height-base: 1.5 !default;
 $line-height-min: 1.25 !default;
 
+$margin-heading: 0 !default;
+$margin-paragraph: 0 !default;
+
 $font-sizes: (
   'base': (
     'html': $font-size-base-small,

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -592,7 +592,7 @@ h3,
 h4,
 h5,
 h6 {
-  margin: 0;
+  margin: 10rem;
   font-family: FakeFont, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
     helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
     Segoe UI Symbol;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -88,9 +88,6 @@ button::-moz-focus-inner {
 button:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
-fieldset {
-  padding: 0.8rem;
-}
 legend {
   box-sizing: border-box;
   display: table;
@@ -648,7 +645,7 @@ h6 {
   }
 }
 p {
-  margin: 0 0 0.8rem;
+  margin: 0;
 }
 address {
   font-style: normal;

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -69,6 +69,8 @@ $bitstyles-layout-size-base: 10rem;
 $bitstyles-setup-namespace: 'bs';
 $bitstyles-typography-webfont-family-name: 'FakeFont';
 $bitstyles-typography-webfont-base-url: './';
+$bitstyles-typography-margin-heading: 10rem;
+$bitstyles-typography-margin-paragraph: 10rem;
 
 //
 // Base settings /////////////////////////////////////

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -69,6 +69,8 @@ $bitstyles-layout-size-base: 10rem;
 $bitstyles-setup-namespace: 'bs';
 $bitstyles-typography-webfont-family-name: 'FakeFont';
 $bitstyles-typography-webfont-base-url: './';
+$bitstyles-typography-margin-heading: 10rem;
+$bitstyles-typography-margin-paragraph: 10rem;
 
 //
 // Base settings /////////////////////////////////////

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -69,6 +69,8 @@
   $setup-namespace: 'bs',
   $typography-webfont-family-name: 'FakeFont',
   $typography-webfont-base-url: './',
+  $typography-margin-heading: 10rem,
+  $typography-margin-paragraph: 10rem,
   // base
   $figure-font-style: bold,
   $forms-fieldset-padding: 10rem,

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -79,7 +79,9 @@
 );
 @use '../../scss/bitstyles/settings/typography' as settings-typography with (
   $webfont-family-name: 'FakeFont',
-  $webfont-base-url: './'
+  $webfont-base-url: './',
+  $margin-heading: 10rem,
+  $margin-paragraph: 10rem,
 );
 
 //


### PR DESCRIPTION
Fixes #561 

The following changes are contained in this pull request:
- Default margins for heading elements and paragraphs can now be specified with the `$margin-heading` and `$margin-paragraph` variables respectively
- The default margin for paragraphs is now `0`

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
