### PR TITLE
[#576] select remove half the border width from vertical padding

### DIFF
--- a/scss/bitstyles/atoms/button/_button.scss
+++ b/scss/bitstyles/atoms/button/_button.scss
@@ -1,7 +1,6 @@
 @use 'sass:math';
 @use './settings';
 @use '../../settings/setup';
-@use '../../settings/typography';
 
 .#{setup.$namespace}a-button {
   position: relative;
@@ -14,9 +13,8 @@
   padding: settings.$padding-vertical settings.$padding-horizontal;
   margin: 0;
   overflow: visible;
-  font: inherit;
-  font-weight: typography.$font-weight-normal;
-  line-height: typography.$line-height-min;
+  font: settings.$font;
+  font-weight: settings.$font-weight;
   text-align: center;
   text-decoration: none;
   white-space: nowrap;

--- a/scss/bitstyles/atoms/button/_settings.scss
+++ b/scss/bitstyles/atoms/button/_settings.scss
@@ -1,4 +1,5 @@
 @use '../../settings/animation';
+@use '../../settings/typography';
 @use '../../tools/palette';
 @use '../../tools/size';
 
@@ -7,7 +8,10 @@
 
 $padding-vertical: size.get('xs') !default;
 $padding-horizontal: size.get('m') !default;
+$border-width: size.get('xxxs') !default;
 $border-radius: size.get('xs') !default;
+$font: inherit !default;
+$font-weight: typography.$font-weight-normal !default;
 $transition:
   color animation.$transition-duration animation.$transition-easing,
   background-color animation.$transition-duration animation.$transition-easing,
@@ -20,7 +24,6 @@ $icon-spacing: size.get('s') !default;
 
 $color: palette.get('white') !default;
 $background-color: palette.get('brand-1', '80') !default;
-$border-width: size.get('xxxs') !default;
 $border-color: palette.get('brand-1', '80') !default;
 $box-shadow: 0 0 size.get('xs') rgba(palette.get('brand-1', '80'), 0.2) !default;
 

--- a/scss/bitstyles/base/input-checkbox/_settings.scss
+++ b/scss/bitstyles/base/input-checkbox/_settings.scss
@@ -6,13 +6,13 @@
 // Base styles ////////////////////////////////////////
 $border-radius: size.get('xxs') !default;
 $gap: size.get('xs') !default;
+$border-width: size.get('xxxs') !default;
 $size: size.get('m') !default;
 
 //
 // Base colors ////////////////////////////////////////
 $color: palette.get('black', '80') !default;
 $background-color: palette.get('white') !default;
-$border-width: size.get('xxxs') !default;
 $border-color: palette.get('black', '80') !default;
 
 //

--- a/scss/bitstyles/base/input-text/_input-text.scss
+++ b/scss/bitstyles/base/input-text/_input-text.scss
@@ -38,9 +38,8 @@ input {
 textarea {
   display: block;
   width: 100%;
-  padding: (settings.$padding - math.div(settings.$border-width, 2)) settings.$padding;
-  font: inherit;
-  line-height: typography.$line-height-min;
+  padding: settings.$padding-vertical settings.$padding-horizontal;
+  font: settings.$font;
   color: settings.$color;
   background-color: settings.$background;
   border: settings.$border-width solid settings.$border-color;

--- a/scss/bitstyles/base/input-text/_settings.scss
+++ b/scss/bitstyles/base/input-text/_settings.scss
@@ -5,9 +5,11 @@
 //
 // Base styles ////////////////////////////////////////
 
-$padding: size.get('xs') !default;
+$padding-vertical: size.get('xs') !default;
+$padding-horizontal: size.get('xs') !default;
 $border-radius: size.get('xs') !default;
 $border-width: size.get('xxxs') !default;
+$font: inherit !default;
 $placeholder-font-style: italic !default;
 $placeholder-font-weight: typography.$font-weight-normal !default;
 $placeholder-color: palette.get('gray', '50') !default;

--- a/scss/bitstyles/base/select/_select.scss
+++ b/scss/bitstyles/base/select/_select.scss
@@ -9,8 +9,7 @@
     width: 100%;
     padding: settings.$padding-vertical (settings.$padding-horizontal * 2) settings.$padding-vertical settings.$padding-horizontal;
     overflow: hidden;
-    font: inherit;
-    line-height: typography.$line-height-min;
+    font: settings.$font;
     color: settings.$color;
     text-overflow: ellipsis;
     cursor: pointer;

--- a/scss/bitstyles/base/select/_settings.scss
+++ b/scss/bitstyles/base/select/_settings.scss
@@ -8,6 +8,7 @@ $padding-vertical: size.get('xs') !default;
 $padding-horizontal: size.get('m') !default;
 $border-radius: size.get('xs') !default;
 $border-width: size.get('xxxs') !default;
+$font: inherit !default;
 
 //
 // Base appearance ////////////////////////////////////////

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -414,9 +414,8 @@ textarea::placeholder {
 textarea {
   display: block;
   width: 100%;
-  padding: 4.375rem 5rem;
+  padding: 5rem;
   font: inherit;
-  line-height: 1.25;
   color: #000;
   background-color: #000;
   border: 1.25rem solid #000;
@@ -532,7 +531,6 @@ textarea:disabled {
     padding: 5rem 20rem 5rem 10rem;
     overflow: hidden;
     font: inherit;
-    line-height: 1.25;
     color: #000;
     text-overflow: ellipsis;
     cursor: pointer;
@@ -751,7 +749,6 @@ table {
   overflow: visible;
   font: inherit;
   font-weight: 400;
-  line-height: 1.25;
   text-align: center;
   text-decoration: none;
   white-space: nowrap;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -415,9 +415,8 @@ textarea::placeholder {
 textarea {
   display: block;
   width: 100%;
-  padding: 0.35rem 0.4rem;
+  padding: 0.4rem;
   font: inherit;
-  line-height: 1.25;
   color: #333;
   background-color: #fff;
   border: 0.1rem solid #cfd0e9;
@@ -533,7 +532,6 @@ textarea:disabled {
     padding: 0.4rem 1.6rem 0.4rem 0.8rem;
     overflow: hidden;
     font: inherit;
-    line-height: 1.25;
     color: #5c5d75;
     text-overflow: ellipsis;
     cursor: pointer;
@@ -756,7 +754,6 @@ table {
   overflow: visible;
   font: inherit;
   font-weight: 400;
-  line-height: 1.25;
   text-align: center;
   text-decoration: none;
   white-space: nowrap;


### PR DESCRIPTION
Fixes #576

The following changes are contained in this pull request:

- Inputs, selects, and buttons all have same border/line-height/padding settings & CSS, so they always match height
- Adds variables for font styles, and makes the padding variables all match the same pattern

Delete if not applicable:

- [ ] Storybook documentation has been updated
- [ ] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
