### PR TITLE
[#574] modal scrollbars when external mouse is connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - `u-font` classes can now be customized by overriding the `$bitstyles-font-weight-values` and `$bitstyles-font-style-values` variables. They can be made available at different breakpoints by overriding the `$bitstyles-font-weight-breakpoints` and `$bitstyles-font-style-breakpoints` variables
 - `u-text` classes can now be customized by overriding the `$bitstyles-text-values` variable. They can be made available at different breakpoints by overriding the `$bitstyles-text-breakpoints` variable
 
+### Fixed
+
+- Modals now only show scrollbars (on OSes/configs where scrollbars are shown) when they’re needed
+
 ### Breaking
 
 - All utility classes which had a double dash in their classname (`--`) now only have a single dash. You’ll need to rename all these classes to use single dashes e.g. `.u-bg--brand-1` becomes `.u-bg-brand-1`

--- a/scss/bitstyles/organisms/modal/_modal.scss
+++ b/scss/bitstyles/organisms/modal/_modal.scss
@@ -36,7 +36,7 @@
   width: calc(100% - 2 * #{settings.$padding});
   height: auto;
   max-height: calc(100vh - 2 * #{settings.$padding});
-  overflow: scroll;
+  overflow: auto;
   -webkit-overflow-scrolling: touch;
   background-color: settings.$background-color;
   transform: translate(-50%, -50%);

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1427,7 +1427,7 @@ table {
   width: calc(100% - 20rem);
   height: auto;
   max-height: calc(100vh - 20rem);
-  overflow: scroll;
+  overflow: auto;
   -webkit-overflow-scrolling: touch;
   background-color: #000;
   transform: translate(-50%, -50%);

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -1441,7 +1441,7 @@ table {
   width: calc(100% - 1.6rem);
   height: auto;
   max-height: calc(100vh - 1.6rem);
-  overflow: scroll;
+  overflow: auto;
   -webkit-overflow-scrolling: touch;
   background-color: #fff;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
Fixes #574

The following changes are contained in this pull request:
- Modals now only show scrollbars (on OSes/configs where scrollbars are shown) when they’re needed

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)

### Looks like 

|before|after|
|--|--|
|<img width="961" alt="Screenshot 2022-01-03 at 17 01 00" src="https://user-images.githubusercontent.com/2479422/147952376-17049934-c9e3-42ca-bef6-bb97805e8b3e.png">|<img width="961" alt="Screenshot 2022-01-03 at 17 00 50" src="https://user-images.githubusercontent.com/2479422/147952398-6ceffa91-18c3-46fc-87ff-e6cc6b0910ab.png">|
