### PR TITLE
[#583] add utility font family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,11 @@
 - `u-font` classes can now be customized by overriding the `$bitstyles-font-weight-values` and `$bitstyles-font-style-values` variables. They can be made available at different breakpoints by overriding the `$bitstyles-font-weight-breakpoints` and `$bitstyles-font-style-breakpoints` variables
 - `u-text` classes can now be customized by overriding the `$bitstyles-text-values` variable. They can be made available at different breakpoints by overriding the `$bitstyles-text-breakpoints` variable
 - You can now override the font styles for `input-text`s, `selects`, and `buttons`.
+- New `u-font` classes to specify font-family. Defaults to `u-font-header` and `u-font-body`, which apply the respective font stack as specified in `settings/typography`. This can be overridden using `$bitstyles-font-family-values`, and can be made responsive by specifying breakpoints in `$bitstyles-font-family-breakpoints`
 
 ### Fixed
 
 - The height of inputs, selects, and `.a-button`s now matches regardless of the border-width
-
-### Fixed
-
 - Modals now only show scrollbars (on OSes/configs where scrollbars are shown) when they’re needed
 
 ### Breaking

--- a/scss/bitstyles/utilities/font/_font.scss
+++ b/scss/bitstyles/utilities/font/_font.scss
@@ -33,3 +33,19 @@
     );
   }
 }
+
+@include directional-properties.output-properties(
+  $property-name: 'font-family',
+  $classname-root: 'font',
+  $values: settings.$family-values
+);
+
+@each $breakpoint in settings.$family-breakpoints {
+  @include media-query.media-query($breakpoint) {
+    @include directional-properties.output-properties(
+      $property-name: 'font-family',
+      $classname-root: 'font',
+      $values: settings.$family-values
+    );
+  }
+}

--- a/scss/bitstyles/utilities/font/_settings.scss
+++ b/scss/bitstyles/utilities/font/_settings.scss
@@ -12,3 +12,8 @@ $style-values: (
   'not-italic': normal
 ) !default;
 $style-breakpoints: () !default;
+$family-values: (
+  'header': typography.$font-family-header,
+  'body': typography.$font-family-body
+) !default;
+$family-breakpoints: () !default;

--- a/scss/bitstyles/utilities/font/font.stories.mdx
+++ b/scss/bitstyles/utilities/font/font.stories.mdx
@@ -50,6 +50,23 @@ Using bolded italics is normally not needed or wanted, and we’re not providing
   </Story>
 </Canvas>
 
+## Font-family
+
+Specify font-family on an element. Defaults to the `header` and `body` font-stacks specified in `settings/_typography`.
+
+<Canvas isColumn>
+  <Story name="font-header">
+    {`
+      <p class="u-bg-background u-font-header"><span class="u-fg-brand-2">u-font-header</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</p>
+    `}
+  </Story>
+  <Story name="font-body">
+    {`
+      <p class="u-bg-background u-font-body"><span class="u-fg-brand-2">u-font-body</span> Pastry marzipan gummi bears lollipop pie pie carrot cake dessert. Pie liquorice marshmallow muffin sweet roll gingerbread candy canes. Tiramisu cotton candy bonbon gingerbread brownie pastry. Croissant apple pie croissant halvah lollipop chocolate cake candy canes liquorice marshmallow.</p>
+    `}
+  </Story>
+</Canvas>
+
 ## Customization
 
 The available font-weights and font-styles can be customized by overriding the `$bitstyles-font-weight-values` and `$bitstyles-font-weight-values` Sass variables respectively:
@@ -65,6 +82,10 @@ $bitstyles-font-style-values: (
   'italic': italic,
   'not-italic': normal
 );
+$bitstyles-font-family-values: (
+  'header': typography.$font-family-header,
+  'body': typography.$font-family-body
+);
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-font-weight-breakpoints` and ``$bitstyles-font-style-breakpoints` Sass variables respectively:
@@ -72,4 +93,5 @@ The breakpoints these classes are available at can be customized by overriding t
 ```scss
 $bitstyles-font-weight-breakpoints: ();
 $bitstyles-font-style-breakpoints: ();
+$bitstyles-font-family-breakpoints: ();
 ```

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1732,6 +1732,16 @@ table {
 .bs-u-font-not-italic {
   font-style: normal;
 }
+.bs-u-font-header {
+  font-family: FakeFont, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
+}
+.bs-u-font-body {
+  font-family: FakeFont, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
+}
 .bs-u-gap-100 {
   gap: 100rem;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2018,6 +2018,16 @@ table {
 .u-font-not-italic {
   font-style: normal;
 }
+.u-font-header {
+  font-family: Nunito, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
+}
+.u-font-body {
+  font-family: Nunito, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
+}
 .u-gap-xs {
   gap: 0.4rem;
 }


### PR DESCRIPTION
Fixes #583 

The following changes are contained in this pull request:
- Adds new `u-font` classes for spcifying font-family. Defaults to just header & body font-stacks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
