### PR TITLE
[#586] variables to set color background color of html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `u-overflow` classes are now also available for `scroll`, `hidden`, and `auto` by default, and can be set by overriding `$bitstyles-overflow-values`
 - You can now override the font styles for `input-text`s, `selects`, and `buttons`.
 - New `u-font` classes to specify font-family. Defaults to `u-font-header` and `u-font-body`, which apply the respective font stack as specified in `settings/typography`. This can be overridden using `$bitstyles-font-family-values`, and can be made responsive by specifying breakpoints in `$bitstyles-font-family-breakpoints`
+- Color & background-color of the `html` element can now be specified using `$bitstyles-html-color` and `$bitstyles-html-background-color`, and default to the `text` and `background` colors specified in your global color-palette
 
 ### Fixed
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -14,6 +14,7 @@
 
 @forward 'bitstyles/base/figure/settings' as figure-*;
 @forward 'bitstyles/base/forms/settings' as forms-*;
+@forward 'bitstyles/base/html/settings' as html-*;
 @forward 'bitstyles/base/input-checkbox/settings' as input-checkbox-*;
 @forward 'bitstyles/base/input-radio/settings' as input-radio-*;
 @forward 'bitstyles/base/input-text/settings' as input-text-*;
@@ -89,6 +90,7 @@
 @use 'bitstyles/base/figure';
 @use 'bitstyles/base/font-face';
 @use 'bitstyles/base/forms';
+@use 'bitstyles/base/html';
 @use 'bitstyles/base/images';
 @use 'bitstyles/base/input-checkbox';
 @use 'bitstyles/base/input-radio';

--- a/scss/bitstyles/base/html/_html.scss
+++ b/scss/bitstyles/base/html/_html.scss
@@ -1,0 +1,12 @@
+@use '../../settings/typography';
+@use './settings';
+
+/* stylelint-disable selector-max-type */
+html {
+  font-family: typography.$font-family-body;
+  line-height: typography.$line-height-base;
+  color: settings.$color;
+  -webkit-text-size-adjust: 100%; // stylelint-disable-line property-no-vendor-prefix
+  background: settings.$background-color;
+}
+/* stylelint-enable selector-max-type */

--- a/scss/bitstyles/base/html/_index.import.scss
+++ b/scss/bitstyles/base/html/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-html-*;
+@forward 'html';

--- a/scss/bitstyles/base/html/_index.scss
+++ b/scss/bitstyles/base/html/_index.scss
@@ -1,0 +1,2 @@
+@forward 'settings';
+@forward 'html';

--- a/scss/bitstyles/base/html/_settings.scss
+++ b/scss/bitstyles/base/html/_settings.scss
@@ -1,0 +1,4 @@
+@use '../../tools/palette';
+
+$color: palette.get('text') !default;
+$background-color: palette.get('background') !default;

--- a/scss/bitstyles/base/html/html.stories.mdx
+++ b/scss/bitstyles/base/html/html.stories.mdx
@@ -1,0 +1,16 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Base/Html" />
+
+# HTML
+
+Applies some basic styles to the HTML element, to cascade down the DOM.
+
+## Customization
+
+The foreground and background colors can be specified:
+
+```scss
+$bitstyles-html-color: palette.get('text');
+$bitstyles-html-background-color: palette.get('background');
+```

--- a/scss/bitstyles/base/typography/_index.scss
+++ b/scss/bitstyles/base/typography/_index.scss
@@ -1,17 +1,7 @@
 @use '../../settings/typography';
-@use '../../tools/palette';
-@use '../../tools/size';
 @use '../../tools/typography' as typography-tools;
 
 /* stylelint-disable selector-max-type */
-html {
-  font-family: typography.$font-family-body;
-  line-height: typography.$line-height-base;
-  color: palette.get('text');
-  -webkit-text-size-adjust: 100%; // stylelint-disable-line property-no-vendor-prefix
-  background: palette.get('background');
-}
-
 h1,
 h2,
 h3,

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -243,6 +243,15 @@ label {
 [type='color'] {
   height: calc(1.5em + 7.5rem);
 }
+html {
+  font-family: FakeFont, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
+  line-height: 1.5;
+  color: red;
+  -webkit-text-size-adjust: 100%;
+  background: #000;
+}
 img {
   height: auto;
   max-width: 100%;
@@ -577,15 +586,6 @@ textarea:disabled {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath d='M6.64 34.23a5.57 5.57 0 017.87-7.89l35.41 35.57 35.57-35.57a5.57 5.57 0 017.87 7.89L53.94 73.66a5.58 5.58 0 01-7.88 0z'/%3E%3C/svg%3E");
     border-color: #000;
   }
-}
-html {
-  font-family: FakeFont, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
-    Segoe UI Symbol;
-  line-height: 1.5;
-  color: #000;
-  -webkit-text-size-adjust: 100%;
-  background: #000;
 }
 h1,
 h2,

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -243,6 +243,15 @@ label {
 [type='color'] {
   height: calc(1.5em + 0.6rem);
 }
+html {
+  font-family: Nunito, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
+  line-height: 1.5;
+  color: #333;
+  -webkit-text-size-adjust: 100%;
+  background: #f7f8ff;
+}
 img {
   height: auto;
   max-width: 100%;
@@ -578,15 +587,6 @@ textarea:disabled {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='%2373758d' d='M6.64 34.23a5.57 5.57 0 017.87-7.89l35.41 35.57 35.57-35.57a5.57 5.57 0 017.87 7.89L53.94 73.66a5.58 5.58 0 01-7.88 0z'/%3E%3C/svg%3E");
     border-color: #ccc;
   }
-}
-html {
-  font-family: Nunito, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-    helvetica, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
-    Segoe UI Symbol;
-  line-height: 1.5;
-  color: #333;
-  -webkit-text-size-adjust: 100%;
-  background: #f7f8ff;
 }
 h1,
 h2,

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -78,6 +78,7 @@ $bitstyles-link-color: #f00;
 
 $bitstyles-figure-font-style: bold;
 $bitstyles-forms-fieldset-padding: 10rem;
+$bitstyles-html-color: red;
 $bitstyles-input-checkbox-border-radius: 10rem;
 $bitstyles-input-radio-border-radius: 10rem;
 $bitstyles-input-text-border-radius: 10rem;

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -78,6 +78,7 @@ $bitstyles-link-color: #f00;
 
 $bitstyles-figure-font-style: bold;
 $bitstyles-forms-fieldset-padding: 10rem;
+$bitstyles-html-color: red;
 $bitstyles-input-checkbox-border-radius: 10rem;
 $bitstyles-input-radio-border-radius: 10rem;
 $bitstyles-input-text-border-radius: 10rem;
@@ -199,6 +200,7 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/base/figure';
 @import '../../scss/bitstyles/base/font-face';
 @import '../../scss/bitstyles/base/forms';
+@import '../../scss/bitstyles/base/html';
 @import '../../scss/bitstyles/base/images';
 @import '../../scss/bitstyles/base/input-checkbox';
 @import '../../scss/bitstyles/base/input-radio';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -75,6 +75,7 @@
   // base
   $figure-font-style: bold,
   $forms-fieldset-padding: 10rem,
+  $html-color: red,
   $input-checkbox-border-radius: 10rem,
   $input-radio-border-radius: 10rem,
   $input-text-border-radius: 10rem,

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -105,6 +105,9 @@
 @use '../../scss/bitstyles/base/forms' with (
   $fieldset-padding: 10rem
 );
+@use '../../scss/bitstyles/base/html' with (
+  $color: red
+);
 @use '../../scss/bitstyles/base/images';
 @use '../../scss/bitstyles/base/input-checkbox' with (
   $border-radius: 10rem


### PR DESCRIPTION
Fixes #586 

The following changes are contained in this pull request:
- `html` styles are now split out from the typography base styles
- color & background color on the `html` element can now be specified with sass variables

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
