### PR TITLE
[#587] variable to specify default value for palette get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - You can now override the font styles for `input-text`s, `selects`, and `buttons`.
 - New `u-font` classes to specify font-family. Defaults to `u-font-header` and `u-font-body`, which apply the respective font stack as specified in `settings/typography`. This can be overridden using `$bitstyles-font-family-values`, and can be made responsive by specifying breakpoints in `$bitstyles-font-family-breakpoints`
 - Color & background-color of the `html` element can now be specified using `$bitstyles-html-color` and `$bitstyles-html-background-color`, and default to the `text` and `background` colors specified in your global color-palette
+- Default key-name to return when asking for a color without specifying it (e.g. `palette.get('white')`) can now be set using `$bitstyles-color-palette-default-key`
 
 ### Fixed
 

--- a/scss/bitstyles/settings/_color-palette.scss
+++ b/scss/bitstyles/settings/_color-palette.scss
@@ -109,3 +109,5 @@ $color-palette: (
     $percentages: $color-mix-percentages
   ),
 ) !default;
+
+$default-key: '100' !default;

--- a/scss/bitstyles/tools/_palette.scss
+++ b/scss/bitstyles/tools/_palette.scss
@@ -8,19 +8,19 @@
 //
 // @param {String} $color  Base colour within the palette
 //
-// @param {String} $percent   Optional. Percentage of the color to mix with white. Defaults to `100%` (fuly the specified color, no white)
+// @param {String} $key   Optional. Percentage of the color to mix with white. Defaults to `100%` (fuly the specified color, no white)
 //
 
-@function get($color, $percent: '100') {
+@function get($color, $key: color-palette.$default-key) {
   @if map.has-key(color-palette.$color-palette, $color) {
     $palette: map.get(color-palette.$color-palette, $color);
 
-    @if map.has-key($palette, $percent) {
-      @return map.get($palette, $percent);
+    @if map.has-key($palette, $key) {
+      @return map.get($palette, $key);
     }
 
     @else {
-      @error 'Oops! Color/percentage ‘#{$color}/#{$percent}’ does not exist.';
+      @error 'Oops! Color/name pair ‘#{$color}/#{$key}’ does not exist.';
     }
   }
 

--- a/scss/bitstyles/tools/_palette.scss
+++ b/scss/bitstyles/tools/_palette.scss
@@ -8,7 +8,7 @@
 //
 // @param {String} $color  Base colour within the palette
 //
-// @param {String} $key   Optional. Percentage of the color to mix with white. Defaults to `100%` (fuly the specified color, no white)
+// @param {String} $key   Optional. Key/name of the color to select from the sass map. Defaults to `100`, but that can be specified using `$bitstyles-color-palette-default-key`.
 //
 
 @function get($color, $key: color-palette.$default-key) {


### PR DESCRIPTION
Fixes #587 

The following changes are contained in this pull request:
- Default key-name to return when asking for a color without specifying it (e.g. `palette.get('white')`) can now be set using `$bitstyles-color-palette-default-key`

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
