### PR TITLE
[#588] allow sidebar organism to change sides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - New helper function `shadow.generate()` to generate multi-layered “natural” shadows based on the color and distances you give
 - Two functions (`shadow.to-box-shadow()` and `shadow.to-drop-shadow()`) for translating those shadows (which are specified in Sass' list format) into either CSS `box-shadow` format, or CSS filter `drop-shadow` format. Not necessary for the shadows accessed using `shadows.get()`
 - New `u-shadow` and `u-drop-shadow` utility classes to set box-shadows and drop-shadows respectively
+- The smallscreen version of the Sidebar organism can now be positioned to the left or right side of the screen by overriding `$bitstyles-sidebar-small-location` (defaults to `left`)
 
 ### Fixed
 

--- a/scss/bitstyles/organisms/sidebar/_settings.scss
+++ b/scss/bitstyles/organisms/sidebar/_settings.scss
@@ -4,8 +4,8 @@
 $large-width: 15rem !default;
 $small-width: 80vw !default;
 $small-location: left !default;
-$small-box-shadow:
-  size.get('m') 0 size.get('l') rgba(palette.get('brand-1', '100'), 10%),
+$small-box-shadow: size.get('m') 0 size.get('l')
+    rgba(palette.get('brand-1', '100'), 10%),
   size.get('l') 0 size.get('m') rgba(palette.get('gray', '90'), 7%),
   0 0 size.get('xl') rgba(palette.get('gray', '90'), 10%) !default;
 $will-change: transform !default;

--- a/scss/bitstyles/organisms/sidebar/_settings.scss
+++ b/scss/bitstyles/organisms/sidebar/_settings.scss
@@ -3,8 +3,9 @@
 
 $large-width: 15rem !default;
 $small-width: 80vw !default;
-$small-box-shadow: size.get('m') 0 size.get('l')
-    rgba(palette.get('brand-1', '100'), 10%),
+$small-location: left !default;
+$small-box-shadow:
+  size.get('m') 0 size.get('l') rgba(palette.get('brand-1', '100'), 10%),
   size.get('l') 0 size.get('m') rgba(palette.get('gray', '90'), 7%),
   0 0 size.get('xl') rgba(palette.get('gray', '90'), 10%) !default;
 $will-change: transform !default;

--- a/scss/bitstyles/organisms/sidebar/_sidebar.scss
+++ b/scss/bitstyles/organisms/sidebar/_sidebar.scss
@@ -11,7 +11,7 @@
   z-index: 1;
   top: 0;
   bottom: 0;
-  left: 0;
+  #{settings.$small-location}: 0;
   width: settings.$small-width;
   box-shadow: settings.$small-box-shadow;
 

--- a/scss/bitstyles/organisms/sidebar/_sidebar.scss
+++ b/scss/bitstyles/organisms/sidebar/_sidebar.scss
@@ -6,6 +6,7 @@
   width: settings.$large-width;
 }
 
+/* stylelint-disable declaration-empty-line-before */
 .#{setup.$namespace}o-sidebar--small {
   position: fixed;
   z-index: 1;
@@ -32,3 +33,4 @@
     }
   }
 }
+/* stylelint-enable declaration-empty-line-before */

--- a/scss/bitstyles/organisms/sidebar/_sidebar.scss
+++ b/scss/bitstyles/organisms/sidebar/_sidebar.scss
@@ -6,14 +6,13 @@
   width: settings.$large-width;
 }
 
-/* stylelint-disable declaration-empty-line-before */
 .#{setup.$namespace}o-sidebar--small {
   position: fixed;
   z-index: 1;
   top: 0;
   bottom: 0;
   #{settings.$small-location}: 0;
-  width: settings.$small-width;
+  width: settings.$small-width; /* stylelint-disable-line declaration-empty-line-before */
   box-shadow: settings.$small-box-shadow;
 
   @include media-query.get('motion-ok') {
@@ -33,4 +32,3 @@
     }
   }
 }
-/* stylelint-enable declaration-empty-line-before */

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -362,8 +362,7 @@ The location can be either `left` or `right`, to specify which side of the scree
 
 ```scss
 $small-location: left;
-$small-box-shadow:
-  size.get('m') 0 size.get('l') rgba(palette.get('brand-1', '100'), 0.1),
+$small-box-shadow: size.get('m') 0 size.get('l') rgba(palette.get('brand-1', '100'), 0.1),
   size.get('l') 0 size.get('m') rgba(palette.get('gray', '90'), 0.07),
   0 0 size.get('xl') rgba(palette.get('gray', '90'), 0.1);
 ```
@@ -375,10 +374,10 @@ $will-change: transform;
 $transition: transform 0.12s ease-in;
 $states: (
   'off-screen': (
-    'transform': translateX(-100%)
+    'transform': translateX(-100%),
   ),
   'on-screen': (
-    'transform': none
-  )
+    'transform': none,
+  ),
 );
 ```

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -346,3 +346,39 @@ Uses a fullwidth dropdown to fit with no overlap.
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The width of the sidebar can be overridden for large and small screens:
+
+```scss
+$large-width: 15rem;
+$small-width: 80vw;
+```
+
+For the small-screen version, there are several more variables that set appearance and animations.
+
+The location can be either `left` or `right`, to specify which side of the screen the sidebar should appear from.
+
+```scss
+$small-location: left;
+$small-box-shadow:
+  size.get('m') 0 size.get('l') rgba(palette.get('brand-1', '100'), 0.1),
+  size.get('l') 0 size.get('m') rgba(palette.get('gray', '90'), 0.07),
+  0 0 size.get('xl') rgba(palette.get('gray', '90'), 0.1);
+```
+
+By default the sidebar will animate into view and back out, assuming the classes `.is-off-screen` and `.is-on-screen` will be applied using JS. The classnames and the styles to be applied can be overridden. Be sure to update the `$will-change` to reflect the property you’re transitioning. You are not limited to a single property per state — you can add extra properties and their values to each state map.
+
+```scss
+$will-change: transform;
+$transition: transform 0.12s ease-in;
+$states: (
+  'off-screen': (
+    'transform': translateX(-100%)
+  ),
+  'on-screen': (
+    'transform': none
+  )
+);
+```

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -367,7 +367,7 @@ $small-box-shadow: size.get('m') 0 size.get('l') rgba(palette.get('brand-1', '10
   0 0 size.get('xl') rgba(palette.get('gray', '90'), 0.1);
 ```
 
-By default the sidebar will animate into view and back out, assuming the classes `.is-off-screen` and `.is-on-screen` will be applied using JS. The classnames and the styles to be applied can be overridden. Be sure to update the `$will-change` to reflect the property you’re transitioning. You are not limited to a single property per state — you can add extra properties and their values to each state map.
+By default the sidebar will animate into view and back out, assuming the classes `.is-off-screen` and `.is-on-screen` will be applied using JS. The classnames and the styles to be applied can be overridden. Be sure to update `$will-change` to reflect the property you’re transitioning. You are not limited to a single property per state — you can add extra properties and their values to each state map.
 
 ```scss
 $will-change: transform;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1533,7 +1533,7 @@ table {
   z-index: 1;
   top: 0;
   bottom: 0;
-  left: 0;
+  right: 0;
   width: 80vw;
   box-shadow: 10rem 0 12.5rem rgba(0, 0, 0, 0.1),
     12.5rem 0 10rem rgba(0, 0, 0, 0.07), 0 0 20rem rgba(0, 0, 0, 0.1);

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -136,6 +136,7 @@ $bitstyles-topbar-vertical-padding: 10rem;
 $bitstyles-modal-padding: 10rem;
 $bitstyles-navbar-will-change: opacity;
 $bitstyles-sidebar-large-width: 1rem;
+$bitstyles-sidebar-small-location: right;
 $bitstyles-table-color-th: #f00;
 $bitstyles-ui-group-border-radius: 10rem;
 

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -136,6 +136,7 @@ $bitstyles-topbar-vertical-padding: 10rem;
 $bitstyles-modal-padding: 10rem;
 $bitstyles-navbar-will-change: opacity;
 $bitstyles-sidebar-large-width: 1rem;
+$bitstyles-sidebar-small-location: right;
 $bitstyles-table-color-th: #f00;
 $bitstyles-ui-group-border-radius: 10rem;
 

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -111,6 +111,7 @@
   $modal-padding: 10rem,
   $navbar-will-change: opacity,
   $sidebar-large-width: 1rem,
+  $sidebar-small-location: right,
   $table-color-th: #f00,
   $ui-group-border-radius: 10rem,
   // utilities

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -216,7 +216,8 @@
   $will-change: opacity
 );
 @use '../../scss/bitstyles/organisms/sidebar' with (
-  $large-width: 1rem
+  $large-width: 1rem,
+  $small-location: right,
 );
 @use '../../scss/bitstyles/organisms/notification-center';
 @use '../../scss/bitstyles/organisms/table' with (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -217,7 +217,7 @@
 );
 @use '../../scss/bitstyles/organisms/sidebar' with (
   $large-width: 1rem,
-  $small-location: right,
+  $small-location: right
 );
 @use '../../scss/bitstyles/organisms/notification-center';
 @use '../../scss/bitstyles/organisms/table' with (


### PR DESCRIPTION
Fixes #588

The following changes are contained in this pull request:
- Sidebar organism can be positioned on the left or right, specified using a variable

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
