### PR TITLE
[#597] Renaming directional-properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Renames `tools/_directional-properties.scss` -> `tools/_properties.scss`, so any imports of those files will need to be updated to reflect that
+- Renames `output-properties()` -> `output()`
+- Renames `output-directional-properties()` -> `output-directional()`
+
 ## [[4.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v4.0.0) - 2021-12-20
 
 ### Added

--- a/scss/bitstyles/atoms/card/_card.scss
+++ b/scss/bitstyles/atoms/card/_card.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use 'sass:math';
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
 @mixin card($padding) {
@@ -30,15 +30,15 @@
 @each $size, $padding-size in settings.$sizes {
   $size-name: modifier-name($size);
 
-  @include directional-properties.output-block(
-    $object-level: 'a',
+  @include properties.output-block(
+    $classname-prefix: 'a',
     $classname-root: 'card#{$size-name}'
   ) {
     @include card($padding-size);
   }
 
-  @include directional-properties.output-block(
-    $object-level: 'a',
+  @include properties.output-block(
+    $classname-prefix: 'a',
     $classname-root: 'card#{$size-name}__header'
   ) {
     @include card__header($padding-size);
@@ -50,16 +50,16 @@
     @each $size, $padding-size in settings.$sizes {
       $size-name: modifier-name($size);
 
-      @include directional-properties.output-block(
-        $object-level: 'a',
+      @include properties.output-block(
+        $classname-prefix: 'a',
         $classname-root: 'card#{$size-name}',
         $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
       ) {
         @include card($padding-size);
       }
 
-      @include directional-properties.output-block(
-        $object-level: 'a',
+      @include properties.output-block(
+        $classname-prefix: 'a',
         $classname-root: 'card#{$size-name}__header',
         $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
       ) {

--- a/scss/bitstyles/tools/_properties.scss
+++ b/scss/bitstyles/tools/_properties.scss
@@ -56,6 +56,36 @@
 }
 
 /*
+ * Outputs a classname with CSS properties, intended for CSS properties that do not have directional variants.
+ *
+ * @param $property-name The name of the CSS property to be specified e.g. `margin`
+ * @param $classname-root The root name to use for the class, normally matches the CSS property to avoid confusion e.g. `margin`
+ * @param $values A map of name/value pairs, where the name will form part of the classname, and the value will be output as the value for the current CSS property e.g. ('m': 1rem, 'l': 2rem)
+ * @param $breakpoint-suffix [optional] Pass the suffix to use in the classname to denote the breakpoint you’re outputting these classes for. If you’re using a character that needs to be escaped, remember to double-escape it e.g. `\\\@m`
+ */
+@mixin output(
+  $property-name,
+  $classname-root,
+  $values,
+  $breakpoint-suffix: ''
+) {
+  @each $alias, $value in $values {
+    $classname: get-classname(
+      (
+        setup.$namespace,
+        'u',
+        $classname-root,
+        $alias
+      )
+    );
+
+    .#{$classname}#{$breakpoint-suffix} {
+      #{$property-name}: $value;
+    }
+  }
+}
+
+/*
  * Outputs a classname with CSS properties, intended for directional CSS properties i.e. those which accept `-top`, `-right` etc. suffixes.
  *
  * @param $property-name The name of the CSS property to be specified e.g. `margin`
@@ -64,7 +94,7 @@
  * @param $directions A map of name/value pairs, where the name will form part of the classname, and the list of values will be form part of the CSS property e.g. ('left': ('left'), 'x': ('left', 'right'))
  * @param $breakpoint-suffix [optional] Pass the suffix to use in the classname to denote the breakpoint you’re outputting these classes for. If you’re using a character that needs to be escaped, remember to double-escape it e.g. `\\\@m`
  */
-@mixin output-directional-properties(
+ @mixin output-directional(
   $property-name,
   $classname-root,
   $values,
@@ -95,44 +125,21 @@
 }
 
 /*
- * Outputs a classname with CSS properties, intended for CSS properties that do not have directional variants.
+ * Outputs a classname that applies a block of properties that you pass in.
  *
- * @param $property-name The name of the CSS property to be specified e.g. `margin`
+ * @param $classname-prefix [optional] Pass a prefix for your classname e.g. to denote the layer of CSS it belongs to
  * @param $classname-root The root name to use for the class, normally matches the CSS property to avoid confusion e.g. `margin`
- * @param $values A map of name/value pairs, where the name will form part of the classname, and the value will be output as the value for the current CSS property e.g. ('m': 1rem, 'l': 2rem)
  * @param $breakpoint-suffix [optional] Pass the suffix to use in the classname to denote the breakpoint you’re outputting these classes for. If you’re using a character that needs to be escaped, remember to double-escape it e.g. `\\\@m`
  */
-@mixin output-properties(
-  $property-name,
-  $classname-root,
-  $values,
-  $breakpoint-suffix: ''
-) {
-  @each $alias, $value in $values {
-    $classname: get-classname(
-      (
-        setup.$namespace,
-        'u',
-        $classname-root,
-        $alias
-      )
-    );
-
-    .#{$classname}#{$breakpoint-suffix} {
-      #{$property-name}: $value;
-    }
-  }
-}
-
 @mixin output-block(
-  $object-level,
+  $classname-prefix,
   $classname-root,
   $breakpoint-suffix: ''
 ) {
   $classname: get-classname(
     (
       setup.$namespace,
-      $object-level,
+      $classname-prefix,
       $classname-root,
     )
   );

--- a/scss/bitstyles/tools/_properties.scss
+++ b/scss/bitstyles/tools/_properties.scss
@@ -94,7 +94,7 @@
  * @param $directions A map of name/value pairs, where the name will form part of the classname, and the list of values will be form part of the CSS property e.g. ('left': ('left'), 'x': ('left', 'right'))
  * @param $breakpoint-suffix [optional] Pass the suffix to use in the classname to denote the breakpoint you’re outputting these classes for. If you’re using a character that needs to be escaped, remember to double-escape it e.g. `\\\@m`
  */
- @mixin output-directional(
+@mixin output-directional(
   $property-name,
   $classname-root,
   $values,

--- a/scss/bitstyles/utilities/bg/_bg.scss
+++ b/scss/bitstyles/utilities/bg/_bg.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'background-color',
   $classname-root: 'bg',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint in settings.$breakpoints {
   @include media-query.get($breakpoint) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'background-color',
       $classname-root: 'bg',
       $values: settings.$values

--- a/scss/bitstyles/utilities/border/_border.scss
+++ b/scss/bitstyles/utilities/border/_border.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-directional-properties(
+@include properties.output-directional(
   $property-name: 'border',
   $classname-root: 'border',
   $values: settings.$values,
@@ -11,7 +11,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-directional-properties(
+    @include properties.output-directional(
       $property-name: 'border',
       $classname-root: 'border',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/col-span/_col-span.scss
+++ b/scss/bitstyles/utilities/col-span/_col-span.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'grid-column',
   $classname-root: 'col-span',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'grid-column',
       $classname-root: 'col-span',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/col-start/_col-start.scss
+++ b/scss/bitstyles/utilities/col-start/_col-start.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'grid-column-start',
   $classname-root: 'col-start',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'grid-column-start',
       $classname-root: 'col-start',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/display/_display.scss
+++ b/scss/bitstyles/utilities/display/_display.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'display',
   $classname-root: null,
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'display',
       $classname-root: null,
       $values: settings.$values,

--- a/scss/bitstyles/utilities/fg/_fg.scss
+++ b/scss/bitstyles/utilities/fg/_fg.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'color',
   $classname-root: 'fg',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'color',
       $classname-root: 'fg',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/flex/_flex.scss
+++ b/scss/bitstyles/utilities/flex/_flex.scss
@@ -1,23 +1,23 @@
 @use 'settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'flex-wrap',
   $classname-root: 'flex',
   $values: settings.$wrap
 );
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'flex-direction',
   $classname-root: 'flex',
   $values: settings.$direction
 );
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'flex-grow',
   $classname-root: 'flex-grow',
   $values: settings.$grow
 );
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'flex-shrink',
   $classname-root: 'flex-shrink',
   $values: settings.$shrink
@@ -25,25 +25,25 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'flex-wrap',
       $classname-root: 'flex',
       $values: settings.$wrap,
       $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
     );
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'flex-direction',
       $classname-root: 'flex',
       $values: settings.$direction,
       $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
     );
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'flex-grow',
       $classname-root: 'flex-grow',
       $values: settings.$grow,
       $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
     );
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'flex-shrink',
       $classname-root: 'flex-shrink',
       $values: settings.$shrink,

--- a/scss/bitstyles/utilities/font/_font.scss
+++ b/scss/bitstyles/utilities/font/_font.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'font-weight',
   $classname-root: 'font',
   $values: settings.$weight-values
@@ -10,7 +10,7 @@
 
 @each $breakpoint in settings.$weight-breakpoints {
   @include media-query.get($breakpoint) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'font-weight',
       $classname-root: 'font',
       $values: settings.$weight-values
@@ -18,7 +18,7 @@
   }
 }
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'font-style',
   $classname-root: 'font',
   $values: settings.$style-values
@@ -26,7 +26,7 @@
 
 @each $breakpoint in settings.$style-breakpoints {
   @include media-query.get($breakpoint) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'font-style',
       $classname-root: 'font',
       $values: settings.$style-values
@@ -34,7 +34,7 @@
   }
 }
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'font-family',
   $classname-root: 'font',
   $values: settings.$family-values
@@ -42,7 +42,7 @@
 
 @each $breakpoint in settings.$family-breakpoints {
   @include media-query.media-query($breakpoint) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'font-family',
       $classname-root: 'font',
       $values: settings.$family-values

--- a/scss/bitstyles/utilities/gap/_gap.scss
+++ b/scss/bitstyles/utilities/gap/_gap.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'gap',
   $classname-root: 'gap',
   $values: settings.$sizes
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'gap',
       $classname-root: 'gap',
       $values: settings.$sizes,

--- a/scss/bitstyles/utilities/grid-cols/_grid-cols.scss
+++ b/scss/bitstyles/utilities/grid-cols/_grid-cols.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'grid-template-columns',
   $classname-root: 'grid-cols',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'grid-template-columns',
       $classname-root: 'grid-cols',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/items/_items.scss
+++ b/scss/bitstyles/utilities/items/_items.scss
@@ -1,8 +1,8 @@
 @use 'settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'align-items',
   $classname-root: 'items',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'align-items',
       $classname-root: 'items',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/justify/_justify.scss
+++ b/scss/bitstyles/utilities/justify/_justify.scss
@@ -1,8 +1,8 @@
 @use 'settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'justify-content',
   $classname-root: 'justify',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'justify-content',
       $classname-root: 'justify',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/margin/_margin.scss
+++ b/scss/bitstyles/utilities/margin/_margin.scss
@@ -1,15 +1,15 @@
 @use 'sass:map';
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-directional-properties(
+@include properties.output-directional(
   $property-name: 'margin',
   $classname-root: 'margin',
   $values: map.get(settings.$sizes, 'positive'),
   $directions: settings.$directions
 );
-@include directional-properties.output-directional-properties(
+@include properties.output-directional(
   $property-name: 'margin',
   $classname-root: 'margin-neg',
   $values: map.get(settings.$sizes, 'negative'),
@@ -18,14 +18,14 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-directional-properties(
+    @include properties.output-directional(
       $property-name: 'margin',
       $classname-root: 'margin',
       $values: map.get(settings.$sizes, 'positive'),
       $directions: settings.$directions,
       $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
     );
-    @include directional-properties.output-directional-properties(
+    @include properties.output-directional(
       $property-name: 'margin',
       $classname-root: 'margin-neg',
       $values: map.get(settings.$sizes, 'negative'),

--- a/scss/bitstyles/utilities/overflow/_overflow.scss
+++ b/scss/bitstyles/utilities/overflow/_overflow.scss
@@ -1,9 +1,9 @@
 @use 'sass:map';
 @use 'settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 
 @each $property, $values in settings.$values {
-  @include directional-properties.output-properties(
+  @include properties.output(
     $property-name: $property,
     $classname-root: $property,
     $values: $values,

--- a/scss/bitstyles/utilities/padding/_padding.scss
+++ b/scss/bitstyles/utilities/padding/_padding.scss
@@ -1,9 +1,9 @@
 @use 'sass:map';
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-directional-properties(
+@include properties.output-directional(
   $property-name: 'padding',
   $classname-root: 'padding',
   $values: map.get(settings.$sizes, 'positive'),
@@ -12,7 +12,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-directional-properties(
+    @include properties.output-directional(
       $property-name: 'padding',
       $classname-root: 'padding',
       $values: map.get(settings.$sizes, 'positive'),

--- a/scss/bitstyles/utilities/row-start/_row-start.scss
+++ b/scss/bitstyles/utilities/row-start/_row-start.scss
@@ -1,8 +1,8 @@
 @use './settings.scss';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'grid-row-start',
   $classname-root: 'row-start',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'grid-row-start',
       $classname-root: 'row-start',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/self/_self.scss
+++ b/scss/bitstyles/utilities/self/_self.scss
@@ -1,8 +1,8 @@
 @use 'settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'align-self',
   $classname-root: 'self',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'align-self',
       $classname-root: 'self',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/text/_index.scss
+++ b/scss/bitstyles/utilities/text/_index.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'text-align',
   $classname-root: 'text',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'text-align',
       $classname-root: 'text',
       $values: settings.$values,

--- a/scss/bitstyles/utilities/z-index/_z-index.scss
+++ b/scss/bitstyles/utilities/z-index/_z-index.scss
@@ -1,8 +1,8 @@
 @use './settings';
-@use '../../tools/directional-properties';
+@use '../../tools/properties';
 @use '../../tools/media-query';
 
-@include directional-properties.output-properties(
+@include properties.output(
   $property-name: 'z-index',
   $classname-root: 'z',
   $values: settings.$values
@@ -10,7 +10,7 @@
 
 @each $breakpoint-alias in settings.$breakpoints {
   @include media-query.get($breakpoint-alias) {
-    @include directional-properties.output-properties(
+    @include properties.output(
       $property-name: 'z-index',
       $classname-root: 'z',
       $values: settings.$values,


### PR DESCRIPTION
Fixes #597

The following changes are contained in this pull request

Renames:
    - `tools/_directional-properties.scss` -> `tools/_properties.scss`
    - `output-properties()` -> `output()`
    - `output-directional-properties()` -> `output-directional()`

The result is that the three different generators are accessed as follows (examples show old -> new):

`directional-properties.output-directional-properties()` -> `properties.output-directional()`
`directional-properties.output-properties()` -> `properties.output()`
`directional-properties.output-block()` -> `properties.output-block()`

Delete if not applicable:

- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
