### PR TITLE
[#612] Update atoms/content documentation

### DIFF
--- a/scss/bitstyles/atoms/avatar/avatar.stories.mdx
+++ b/scss/bitstyles/atoms/avatar/avatar.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Avatar
 
-A user’s visual representation — a photograph (or other image) that will represent them in the UI. The image will be cropped to a circle, and span edge-to-edge regardless of aspect ratio & size.
+A user’s visual representation — an image that will represent them in your UI. The image is cropped to a circle, and spans edge-to-edge regardless of aspect ratio & size (so you can use non-square images if necessary).
 
 <Canvas>
   <Story name="Avatar">
@@ -16,33 +16,10 @@ A user’s visual representation — a photograph (or other image) that will rep
   </Story>
 </Canvas>
 
-Commonly, the username will be displayed to one side:
+Avatars are available at `m` and `l` sizes by default:
 
 <Canvas isColumn>
-  <Story name="Avatar with name (left-to-right)">
-    {`
-      <div class="u-flex u-items-center">
-        <div class="a-avatar u-flex u-items-center">
-          <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
-        </div>
-        <span class="u-margin-s-left">Username</span>
-      </div>
-    `}
-  </Story>
-  <Story name="Avatar with name (right-to-left)">
-    {`
-      <div class="u-flex u-items-center">
-        <span class="u-margin-s-right">Username</span>
-        <div class="a-avatar">
-          <img src="https://placekitten.com/100/100" width="46" height="46" alt="Username’s avatar" />
-        </div>
-      </div>
-    `}
-  </Story>
-</Canvas>
-
-<Canvas isColumn>
-  <Story name="Avatar - medium">
+  <Story name="a-avatar--m">
     {`
       <div class="u-flex u-items-center">
         <div class="a-avatar a-avatar--m u-flex u-items-center">
@@ -52,7 +29,7 @@ Commonly, the username will be displayed to one side:
       </div>
     `}
   </Story>
-  <Story name="Avatar - large">
+  <Story name="a-avatar--l">
     {`
       <div class="u-flex u-items-center">
         <div class="a-avatar a-avatar--l u-flex u-items-center">
@@ -63,3 +40,14 @@ Commonly, the username will be displayed to one side:
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available avatar sizes can be customized with `$bitstyles-avatar-sizes`:
+
+```scss
+$sizes: (
+  'm': size.get('xl'),
+  'l': size.get('xl') + size.get('m')
+);
+```

--- a/scss/bitstyles/atoms/avatar/avatar.stories.mdx
+++ b/scss/bitstyles/atoms/avatar/avatar.stories.mdx
@@ -48,6 +48,6 @@ The available avatar sizes can be customized with `$bitstyles-avatar-sizes`:
 ```scss
 $sizes: (
   'm': size.get('xl'),
-  'l': size.get('xl') + size.get('m')
+  'l': size.get('xl') + size.get('m'),
 );
 ```

--- a/scss/bitstyles/atoms/badge/_badge.scss
+++ b/scss/bitstyles/atoms/badge/_badge.scss
@@ -10,6 +10,11 @@
   padding: settings.$padding-vertical settings.$padding-horizontal;
   border-radius: layout.$border-radius-round;
   white-space: nowrap;
+
+  .#{setup.$namespace}a-badge__button {
+    margin-right: -#{size.get('s')};
+    margin-left: size.get('xs');
+  }
 }
 
 @each $variant in (settings.$variants) {
@@ -22,9 +27,4 @@
     background-color: palette.get($variant, settings.$background-color);
     color: palette.get($variant, settings.$color);
   }
-}
-
-.#{setup.$namespace}a-badge__button {
-  margin-right: -#{size.get('s')};
-  margin-left: size.get('xs');
 }

--- a/scss/bitstyles/atoms/badge/badge.stories.mdx
+++ b/scss/bitstyles/atoms/badge/badge.stories.mdx
@@ -102,7 +102,7 @@ The available variants can be specified with `$bitstyles-badge-variants`, where 
 $variants: ('gray', 'danger', 'brand-1', 'brand-2', 'positive');
 ```
 
-The keys from those colors that will be used are specified with the `$bitstyles-badge-color` and `$bitstyles-badge-background-color`, and are applied to all variants. With the following settings, the `gray` variant will have color `gray` value `80`, with background color `gray` value `10`. The `danger` variant will have color `danger` with value `80` and background-color `danger` at value `10` etc,
+The keys from those colors that will be used are specified with the `$bitstyles-badge-color` and `$bitstyles-badge-background-color`, and are applied to all variants. With the following settings, the `gray` variant will have color `gray` value `80`, with background color `gray` value `10`. The `danger` variant will have color `danger` with value `80` and background-color `danger` at value `10` etc.
 
 ```scss
 $color: '80';

--- a/scss/bitstyles/atoms/badge/badge.stories.mdx
+++ b/scss/bitstyles/atoms/badge/badge.stories.mdx
@@ -5,40 +5,41 @@ import icons from '../../../../assets/images/icons.svg';
 
 # Badge
 
-Display tags and other filters or categorization.
+Display tags, filters, or categorization.
 
 <Canvas>
   <Story name="Badge">
     {`
-      <span class="a-badge a-badge--gray u-h6 u-font-medium">badge</span>
+      <span class="a-badge a-badge--gray u-h6 u-font-medium">Urgent</span>
+      <span class="a-badge a-badge--gray u-h6 u-font-medium">In progress</span>
     `}
   </Story>
 </Canvas>
 
-Various colours are available, based on the colors you specify in your palette. Here, they’re displayed in a list (there are often multiple tags etc. so this is very common).
+By default `gray`, `brand-1`, `brand-2`, and `danger` colors are available (see [Customization](#customization) section below). Here, they’re displayed in a list (there are often multiple tags or filters so this is very common).
 
 <Canvas>
   <Story name="Badge — color variants">
     {`
       <ul class="a-list-reset u-flex">
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--gray u-h6 u-font-medium">badge</span>
+          <span class="a-badge a-badge--gray u-h6 u-font-medium">gray</span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--brand-1 u-h6 u-font-medium">badge</span>
+          <span class="a-badge a-badge--brand-1 u-h6 u-font-medium">brand-1</span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--brand-2 u-h6 u-font-medium">badge</span>
+          <span class="a-badge a-badge--brand-2 u-h6 u-font-medium">brand-2</span>
         </li>
         <li class="u-margin-s-right">
-          <span class="a-badge a-badge--danger u-h6 u-font-medium">badge</span>
+          <span class="a-badge a-badge--danger u-h6 u-font-medium">danger</span>
         </li>
       </ul>
     `}
   </Story>
 </Canvas>
 
-When used as filters, you’ll want the badges to be removable — you can add a button to do that:
+You may want the badges to be removable, for example when used as part of a filter interface. You can add a button to do that (be sure to provide text for users’ AT):
 
 <Canvas>
   <Story name="Badge — with buttons">
@@ -92,3 +93,25 @@ When used as filters, you’ll want the badges to be removable — you can add a
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available variants can be specified with `$bitstyles-badge-variants`, where the strings you pass must match colors in your color palette:
+
+```scss
+$variants: ('gray', 'danger', 'brand-1', 'brand-2', 'positive');
+```
+
+The keys from those colors that will be used are specified with the `$bitstyles-badge-color` and `$bitstyles-badge-background-color`, and are applied to all variants. With the following settings, the `gray` variant will have color `gray` value `80`, with background color `gray` value `10`. The `danger` variant will have color `danger` with value `80` and background-color `danger` at value `10` etc,
+
+```scss
+$color: '80';
+$background-color: '10';
+```
+
+Padding can be specified with `$bitstyles-badge-padding-horizontal` and ``$bitstyles-badge-padding-vertical`:
+
+```scss
+$padding-vertical: size.get('xxs');
+$padding-horizontal: size.get('m');
+```

--- a/scss/bitstyles/atoms/bordered-header/bordered-header.stories.mdx
+++ b/scss/bitstyles/atoms/bordered-header/bordered-header.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Bordered Header
 
-Creates equally-sized horizontal lines to the left & right of the text within the element. The text is centered and the lines are of equal length.
+Creates a vertically-centered horizontal line to the right of any content in the element.
 
 <Canvas>
   <Story name="Bordered header">
@@ -13,3 +13,12 @@ Creates equally-sized horizontal lines to the left & right of the text within th
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The space between the text and the border can be specified, and the border styles:
+
+```scss
+$gutter: size.get('m');
+$border: size.get('xxxs') solid palette.get('gray', '10');
+```

--- a/scss/bitstyles/atoms/card/card.stories.mdx
+++ b/scss/bitstyles/atoms/card/card.stories.mdx
@@ -11,19 +11,19 @@ A content wrapper that sections and subtly highlights a chunk of content. For la
     {`
     <div class="u-grid u-grid-cols-3@m u-gap-m">
       <article class="a-card">
-        <h3>Standard card</h3>
+        <h3 class="u-h4">Standard card</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
       <article class="a-card">
-        <h3>Standard card</h3>
+        <h3 class="u-h4">Standard card</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
       <article class="a-card">
-        <h3>Standard card</h3>
+        <h3 class="u-h4">Standard card</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
@@ -63,7 +63,7 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
         <div class="a-card__header a-flash a-flash--danger">
           Something happened
         </div>
-        <h3>Card with header</h3>
+        <h3 class="u-h4">Card with header</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
@@ -77,7 +77,7 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
       <div class="a-card-l__header a-flash a-flash--danger">
         Something happened
       </div>
-      <h3>Large card with header</h3>
+      <h3 class="u-h4">Large card with header</h3>
       <ul class="a-list-reset">
         <li>User one changed date to 01.01.2021 [5 mins ago]</li>
       </ul>
@@ -88,13 +88,13 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
 
 ## Responsive
 
-The `.a-card` classes are available at `m` and `l` breakpoints by default, including all the sizes of card.
+The `.a-card` classes are available at `m` and `l` breakpoints by default, including all the sizes of card, so you can apply card styling based on viewport size.
 
 <Canvas>
   <Story name="Card [m breakpoint]">
     {`
       <article class="a-card@m">
-        <h3>Recent activity (a-card@m)</h3>
+        <h3 class="u-h4">Recent activity (a-card@m)</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
@@ -104,7 +104,7 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default, inclu
   <Story name="Card [l breakpoint]">
     {`
       <article class="a-card@l">
-        <h3>Recent activity (a-card@l)</h3>
+        <h3 class="u-h4">Recent activity (a-card@l)</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
@@ -114,7 +114,7 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default, inclu
   <Story name="Card-L [m breakpoint]">
     {`
       <article class="a-card-l@m">
-        <h3>Recent activity (a-card@m)</h3>
+        <h3 class="u-h4">Recent activity (a-card@m)</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
@@ -124,7 +124,7 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default, inclu
   <Story name="Card-L [l breakpoint]">
     {`
       <article class="a-card-l@l">
-        <h3>Recent activity (a-card@l)</h3>
+        <h3 class="u-h4">Recent activity (a-card@l)</h3>
         <ul class="a-list-reset">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>

--- a/scss/bitstyles/atoms/content/content.stories.mdx
+++ b/scss/bitstyles/atoms/content/content.stories.mdx
@@ -8,7 +8,7 @@ A content wrapper that ensures content is a readable width, has spacing at the s
 
 Content will span the full width of the viewport, up to a maximum set by Sass variables (see [Customization](#customization) below). This means that in small viewports your content will use all the available width, and in larger viewports it will stop growing once it reaches the given limit.
 
-By default this class is available at several sizes, which refer to the max-width that’s enforced: `xs`, `s`, `m`,`l`, and  `full`. The padding to the sides of the element is set at increasingly larger sizes based on viewport size for all those content-sizes: `base`, `l`, and `xl` (note that’s not dependent on the content-size, but the viewport size).
+By default this class is available at several sizes, which refer to the max-width that’s enforced: `xs`, `s`, `m`,`l`, and `full`. The padding to the sides of the element is set at increasingly larger sizes based on viewport size for all those content-sizes: `base`, `l`, and `xl` (note that’s not dependent on the content-size, but the viewport size).
 
 <Canvas isColumn>
   <Story name="a-content">
@@ -77,7 +77,7 @@ $max-width: (
   's': 35rem,
   'm': 65rem,
   'l': 85rem,
-  'full': 100%
+  'full': 100%,
 );
 ```
 
@@ -85,10 +85,10 @@ The padding that’s applied to all the sizes, and at which breakpoints, can be 
 
 ```scss
 $padding: (
-  'base':  size.get('m'),
+  'base': size.get('m'),
   'l': size.get('l'),
-  'xl': size.get('xl')
-)
+  'xl': size.get('xl'),
+);
 ```
 
 The default size that’s applied when only the base class `a-content` is used defaults to size `m`, but can be set using `$bitstyles-content-max-width-base`:

--- a/scss/bitstyles/atoms/content/content.stories.mdx
+++ b/scss/bitstyles/atoms/content/content.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Content
 
-A content wrapper that ensures content is a readable width, has spacing at the sides of the viewport so content will not touch the edge, and is always centered.
+A content wrapper that ensures content is at readable width, has spacing at the sides of the viewport so content will not touch the edge, and is always centered.
 
 Content will span the full width of the viewport, up to a maximum set by Sass variables (see [Customization](#customization) below). This means that in small viewports your content will use all the available width, and in larger viewports it will stop growing once it reaches the given limit.
 

--- a/scss/bitstyles/atoms/content/content.stories.mdx
+++ b/scss/bitstyles/atoms/content/content.stories.mdx
@@ -4,22 +4,95 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Content
 
-A content wrapper to ensure content is a readable width, and has space to the sides of the viewport.
+A content wrapper that ensures content is a readable width, has spacing at the sides of the viewport so content will not touch the edge, and is always centered.
 
-This class ensures there is always whitespace at the sides of the viewport, so any content inside will never touch the edge.
+Content will span the full width of the viewport, up to a maximum set by Sass variables (see [Customization](#customization) below). This means that in small viewports your content will use all the available width, and in larger viewports it will stop growing once it reaches the given limit.
 
-Content will span the full width of the viewport, up to a maximum set by `$bitstyles-content-max-width`. This means that in small viewports your content will use all the available width. In larger viewports your content will stop growing once it reaches the limit of what is comfortably readable, and not keep growing infintely.
+By default this class is available at several sizes, which refer to the max-width that’s enforced: `xs`, `s`, `m`,`l`, and  `full`. The padding to the sides of the element is set at increasingly larger sizes based on viewport size for all those content-sizes: `base`, `l`, and `xl` (note that’s not dependent on the content-size, but the viewport size).
 
-Whatever the size of the viewport, content will remain centered.
-
-If this class is used on an element with less than viewport-width, the above conditions will be relative to its parent element instead of the viewport.
-
-<Canvas>
-  <Story name="Content">
+<Canvas isColumn>
+  <Story name="a-content">
     {`
-      <div class="a-content">
-        <p>Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.</p>
+      <div class="u-bg-gray-5 u-padding-l-x">
+        <div class="a-content u-bg-white">
+          <p><b>a-content</b> Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.</p>
+        </div>
+      </div>
+    `}
+  </Story>
+  <Story name="a-content--xs">
+    {`
+      <div class="u-bg-gray-5 u-padding-l-x">
+        <div class="a-content a-content--xs u-bg-white">
+          <p><b>a-content--xs</b> Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.</p>
+        </div>
+      </div>
+    `}
+  </Story>
+  <Story name="a-content--s">
+    {`
+      <div class="u-bg-gray-5 u-padding-l-x">
+        <div class="a-content a-content--s u-bg-white">
+          <p><b>a-content--s</b> Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.</p>
+        </div>
+      </div>
+    `}
+  </Story>
+  <Story name="a-content--m">
+    {`
+      <div class="u-bg-gray-5 u-padding-l-x">
+        <div class="a-content a-content--m u-bg-white">
+          <p><b>a-content--m</b> Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.</p>
+        </div>
+      </div>
+    `}
+  </Story>
+  <Story name="a-content--l">
+    {`
+      <div class="u-bg-gray-5 u-padding-l-x">
+        <div class="a-content a-content--l u-bg-white">
+          <p><b>a-content--l</b> Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.</p>
+        </div>
+      </div>
+    `}
+  </Story>
+  <Story name="a-content--full">
+    {`
+      <div class="u-bg-gray-5 u-padding-l-x">
+        <div class="a-content a-content--full u-bg-white">
+          <p><b>a-content--full</b> Jelly cake marshmallow. Pie cotton candy chupa chups marzipan liquorice cheesecake wafer. Gummies cheesecake oat cake sugar plum icing cupcake tiramisu bonbon. Cotton candy chupa chups tootsie roll chupa chups cotton candy liquorice jelly gingerbread. Pastry gummi bears liquorice tart cotton candy marshmallow. Ice cream cotton candy chocolate cake cookie. Bonbon candy jelly-o sugar plum cotton candy carrot cake icing ice cream. Sweet chocolate marzipan. Candy canes danish cake carrot cake bonbon. Gummi bears sesame snaps tart bear claw pie chocolate bar. Ice cream candy canes sugar plum cookie. Macaroon biscuit biscuit carrot cake liquorice. Muffin pudding gingerbread powder jelly-o chocolate bar powder jelly beans toffee.</p>
+        </div>
       </div>
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available content-sizes and their classnames can be customized by overriding the `$bitstyles-content-max-width` Sass map:
+
+```scss
+$max-width: (
+  'xs': 25rem,
+  's': 35rem,
+  'm': 65rem,
+  'l': 85rem,
+  'full': 100%
+);
+```
+
+The padding that’s applied to all the sizes, and at which breakpoints, can be customized using `$bitstyles-content-padding`:
+
+```scss
+$padding: (
+  'base':  size.get('m'),
+  'l': size.get('l'),
+  'xl': size.get('xl')
+)
+```
+
+The default size that’s applied when only the base class `a-content` is used defaults to size `m`, but can be set using `$bitstyles-content-max-width-base`:
+
+```scss
+$max-width-base: 'm';
+```

--- a/scss/bitstyles/atoms/dl/dl.stories.mdx
+++ b/scss/bitstyles/atoms/dl/dl.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # dl (Description list)
 
-A list of term/description pairs, used to display any set of key-value pairs. It’s totally valid to have multiple descriptions for a single term though — this can handle glossaries or dictionaries, where a single entry can have multiple values.
+A list of term/description pairs, used to display any set of key-value pairs. It’s also valid to have multiple descriptions for a single term — this can handle glossaries or dictionaries, where a single entry can have multiple values.
 
 <Canvas isColumn>
   <Story name="dl">

--- a/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
+++ b/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
@@ -146,7 +146,7 @@ The dropdown defaults to left-top-aligned, but can be aligned to any edges using
 
 ## Customization
 
-The visual appearnce & layout of the dropdowns can be customized:
+The visual appearance & layout of the dropdowns can be customized:
 
 ```scss
 $max-height: 20rem;

--- a/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
+++ b/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Dropdown
 
-A floating container for a list of links.
+A floating container shown on clicking a button (use JS for this), to show some small extra content such as a list of links. In smaller viewports, the dropdown will be disaplyed using the full width available.
 
 ## Left alignment (default)
 
@@ -32,10 +32,12 @@ A floating container for a list of links.
   </Story>
 </Canvas>
 
-## Right alignment
+## Alignment
+
+The dropdown defaults to left-top-aligned, but can be aligned to any edges using the modifier classes. Note that in smaller viewports, all left/right alignment is removed and the dropdown will be displayed at the full available width.
 
 <Canvas>
-  <Story name="Dropdown--right" inline={false} height="20rem">
+  <Story name="a-dropdown--right" inline={false} height="20rem">
     {`
       <div class="u-relative" style="height: 10rem; width: 100%">
         <ul class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset">
@@ -56,12 +58,7 @@ A floating container for a list of links.
       </div>
     `}
   </Story>
-</Canvas>
-
-## Top alignment
-
-<Canvas>
-  <Story name="Dropdown--top" inline={false} height="20rem">
+  <Story name="a-dropdown--top" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
         <ul class="a-dropdown a-dropdown--top u-overflow-y-auto a-list-reset">
@@ -82,12 +79,7 @@ A floating container for a list of links.
       </div>
     `}
   </Story>
-</Canvas>
-
-## Top-right alignment
-
-<Canvas>
-  <Story name="Dropdown--top dropdown--right" inline={false} height="20rem">
+  <Story name="a-dropdown--top a-dropdown--right" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
         <ul class="a-dropdown a-dropdown--top a-dropdown--right u-overflow-y-auto a-list-reset">
@@ -108,16 +100,7 @@ A floating container for a list of links.
       </div>
     `}
   </Story>
-</Canvas>
-
-## Full-width
-
-Sometimes you need your dropdown to fill the width of the container.
-
-### Full-width bottom
-
-<Canvas>
-  <Story name="Dropdown--bottom dropdown--full" inline={false} height="20rem">
+  <Story name="a-dropdown--bottom dropdown--full" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
         <ul class="a-dropdown a-dropdown--full-width u-overflow-y-auto a-list-reset">
@@ -138,12 +121,7 @@ Sometimes you need your dropdown to fill the width of the container.
       </div>
     `}
   </Story>
-</Canvas>
-
-## Full-width top
-
-<Canvas>
-  <Story name="Dropdown--top dropdown--full" inline={false} height="20rem">
+  <Story name="a-dropdown--top dropdown--full" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
         <ul class="a-dropdown a-dropdown--top a-dropdown--full-width u-overflow-y-auto a-list-reset">
@@ -165,3 +143,43 @@ Sometimes you need your dropdown to fill the width of the container.
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The visual appearnce & layout of the dropdowns can be customized:
+
+```scss
+$max-height: 20rem;
+$border-radius: size.get('xs');
+$border: 2px solid palette.get('brand-2', '100');
+$background-color: palette.get('white', '100');
+$box-shadow: shadow.to-box-shadow(
+  shadow.generate(
+    $color: rgba(palette.get('brand-2', '80'), 0.05),
+    $offset: size.get('m'),
+    $blur-radius: size.get('l'),
+  )
+);
+```
+
+The border and spacing above and below the separators used to divide the contents of your dropdowns (see the `<li role="separator"></li>` in the examples above) can also be customized:
+
+```scss
+$separator-border: 1px solid palette.get('gray', '1');
+$separator-spacing: size.get('xxs');
+```
+
+By default the dropdown will fade in and out respectively when the `is-on-screen` and `is-off-screen` classes are applied, but this can customized too. Be sure to update the `$will-change` value to reflect the properties you specify in the `$transition` value.
+
+```scss
+$transition: opacity 0.12s ease-in;
+$will-change: opacity;
+$states: (
+  "off-screen": (
+    "opacity": 0
+  ),
+  "on-screen": (
+    "opacity": 1
+  )
+);
+```

--- a/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
+++ b/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
@@ -175,11 +175,11 @@ By default the dropdown will fade in and out respectively when the `is-on-screen
 $transition: opacity 0.12s ease-in;
 $will-change: opacity;
 $states: (
-  "off-screen": (
-    "opacity": 0
+  'off-screen': (
+    'opacity': 0,
   ),
-  "on-screen": (
-    "opacity": 1
-  )
+  'on-screen': (
+    'opacity': 1,
+  ),
 );
 ```

--- a/scss/bitstyles/atoms/flash/flash.stories.mdx
+++ b/scss/bitstyles/atoms/flash/flash.stories.mdx
@@ -6,9 +6,9 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 A flash informs the user of a global or important event, such as a successful (or unsuccessful!) login, server error, network connection issues etc. When used inside a discrete block of UI like a [card](/docs/atoms-card--card), Flashes are also useful for more context-specific event notifications.
 
-Flashes come in several variants, which use color **and html** attributes to indicate severity. By default you have `brand-1`, `positive`, `warning`, and `danger`, which use those colors from the global color palette. See the [Customization](#customization) section below for details on how to change those default.
+Flashes come in several variants, which use color **and html** attributes to indicate severity. By default you have `brand-1`, `positive`, `warning`, and `danger`, which use those colors from the global color palette. See the [Customization](#customization) section below for details on how to change those defaults.
 
-Examples here show the content of the flashes within a [content](/docs/atoms-content-content) wrapper to produce standard spacing, and restrict the content width so it aligns with other page content. You need not use these if it doesn’t fit design requirements.
+Examples here show the content of the flashes within a [content](/docs/atoms-content-content) wrapper to produce standard spacing, and restrict the content width so it aligns with other page content. You don't need to use these if it doesn’t fit your design requirements.
 
 <Canvas isColumn>
   <Story name="a-flash--brand-1">

--- a/scss/bitstyles/atoms/flash/flash.stories.mdx
+++ b/scss/bitstyles/atoms/flash/flash.stories.mdx
@@ -4,10 +4,14 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Flash
 
-Inform the user of a global or important event, such as may happen after a page reload. There are several variants, which use color and html attributes to indicate severity.
+A flash informs the user of a global or important event, such as a successful (or unsuccessful!) login, server error, network connection issues etc. When used inside a discrete block of UI like a [card](/docs/atoms-card--card), Flashes are also useful for more context-specific event notifications.
+
+Flashes come in several variants, which use color **and html** attributes to indicate severity. By default you have `brand-1`, `positive`, `warning`, and `danger`, which use those colors from the global color palette. See the [Customization](#customization) section below for details on how to change those default.
+
+Examples here show the content of the flashes within a [content](/docs/atoms-content-content) wrapper to produce standard spacing, and restrict the content width so it aligns with other page content. You need not use these if it doesn’t fit design requirements.
 
 <Canvas isColumn>
-  <Story name="Flash (brand-1)">
+  <Story name="a-flash--brand-1">
     {`
       <div class="u-padding-l-y a-flash--brand-1" aria-live="polite">
         <div class="a-content">
@@ -16,7 +20,7 @@ Inform the user of a global or important event, such as may happen after a page 
       </div>
     `}
   </Story>
-  <Story name="Flash (positive)">
+  <Story name="a-flash--positive">
     {`
       <div class="u-padding-l-y a-flash--positive" aria-live="polite">
         <div class="a-content">
@@ -25,7 +29,7 @@ Inform the user of a global or important event, such as may happen after a page 
       </div>
     `}
   </Story>
-  <Story name="Flash (warning)">
+  <Story name="a-flash--warning">
     {`
       <div class="u-padding-l-y a-flash--warning" aria-live="polite">
         <div class="a-content">
@@ -34,7 +38,7 @@ Inform the user of a global or important event, such as may happen after a page 
       </div>
     `}
   </Story>
-  <Story name="Flash (danger)">
+  <Story name="a-flash--danger">
     {`
       <div class="u-padding-l-y a-flash--danger" role="alert">
         <div class="a-content">
@@ -44,3 +48,18 @@ Inform the user of a global or important event, such as may happen after a page 
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available variants can be specified with `$bitstyles-flash-variants`, where the strings you pass must match colors in your color palette:
+
+```scss
+$variants: ('brand-1', 'positive', 'danger', 'warning');
+```
+
+The keys from those colors that will be used are specified with the `$bitstyles-flash-color` and `$bitstyles-flash-background-color`, and are applied to all variants. With the following settings, the `positive` variant will have color `positive` value `90`, with background color `positive` value `10`. The `danger` variant will have color `danger` with value `90` and background-color `danger` at value `10` etc,
+
+```scss
+$color: '90';
+$background-color: '10';
+```

--- a/scss/bitstyles/atoms/icon/icon.stories.mdx
+++ b/scss/bitstyles/atoms/icon/icon.stories.mdx
@@ -7,59 +7,57 @@ import icons from '../../../../assets/images/icons.svg';
 
 ## SVG icon system
 
-Icons are implemented using inline SVG where possible (see example markup). They must be accompanied by some machine-readable text for accessibility & SEO purposes. If there is to be no such text visible (e.g. based on design mockups), provide an alternative next to the `<svg>` element using a `<span class="u-sr-only">` containing descriptive text.
+Icons are best implemented using inline SVG (see the examples below). However they’re rendered, they must be accompanied by some machine-readable text for accessibility & SEO. If there is to be no such text visible (e.g. from design mockups), use [`.u-sr-only`](/docs/utilities-sr-only--sr-only) to hide the span containing descriptive text.
 
-The base icon size inherits from the surrounding text i.e. `1em`.
+The base icon size inherits from the surrounding text i.e. `1em`. Other sizes available by default (`s`, `m`, `l`, and `xl`) are based on the global rem-based sizing map.
 
-<Canvas isColumn>
-  <Story name="Icon">
+<Canvas>
+  <Story name="a-icon">
     {`
       <svg width="16" height="16" class="a-icon" aria-hidden="true" focusable="false">
         <use xlink:href="${icons}#icon-plus"></use>
       </svg>
     `}
   </Story>
-  <Story name="Icon with adjacent text">
+  <Story name="a-icon--s">
     {`
-      <div class="u-flex u-items-center">
-        <svg width="16" height="16" class="a-icon u-margin-m-right" aria-hidden="true" focusable="false">
-          <use xlink:href="${icons}#icon-plus"></use>
-        </svg>
-        <span>This is standard-sized text</span>
-      </div>
-    `}
-  </Story>
-</Canvas>
-
-Use the modifier classes `a-icon--<size>` to override this e.g. `.a-icon--s`.
-
-<Canvas>
-  <Story name="Small icon">
-    {`
-      <svg width="16" height="16" class="a-icon a-icon--s" aria-hidden="true" focusable="false">
+      <svg width="6" height="6" class="a-icon a-icon--s" aria-hidden="true" focusable="false">
         <use xlink:href="${icons}#icon-plus"></use>
       </svg>
     `}
   </Story>
-  <Story name="Medium icon">
+  <Story name="a-icon--m">
     {`
-      <svg width="16" height="16" class="a-icon a-icon--m" aria-hidden="true" focusable="false">
+      <svg width="13" height="13" class="a-icon a-icon--m" aria-hidden="true" focusable="false">
         <use xlink:href="${icons}#icon-plus"></use>
       </svg>
     `}
   </Story>
-  <Story name="Large icon">
+  <Story name="a-icon--l">
     {`
       <svg width="16" height="16" class="a-icon a-icon--l" aria-hidden="true" focusable="false">
         <use xlink:href="${icons}#icon-plus"></use>
       </svg>
     `}
   </Story>
-  <Story name="X-Large icon">
+  <Story name="a-icon--xl">
     {`
-      <svg width="16" height="16" class="a-icon a-icon--xl" aria-hidden="true" focusable="false">
+      <svg width="22" height="2" class="a-icon a-icon--xl" aria-hidden="true" focusable="false">
         <use xlink:href="${icons}#icon-plus"></use>
       </svg>
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available sizes and their classnames can be customized using `$bitstyles-icon-sizes`:
+
+```scss
+$sizes: (
+  's':     size.get('xs'),
+  'm':     size.get('m'),
+  'l':     size.get('l'),
+  'xl':    size.get('l') + size.get('xs'),
+);
+```

--- a/scss/bitstyles/atoms/icon/icon.stories.mdx
+++ b/scss/bitstyles/atoms/icon/icon.stories.mdx
@@ -55,9 +55,9 @@ The available sizes and their classnames can be customized using `$bitstyles-ico
 
 ```scss
 $sizes: (
-  's':     size.get('xs'),
-  'm':     size.get('m'),
-  'l':     size.get('l'),
-  'xl':    size.get('l') + size.get('xs'),
+  's': size.get('xs'),
+  'm': size.get('m'),
+  'l': size.get('l'),
+  'xl': size.get('l') + size.get('xs'),
 );
 ```

--- a/scss/bitstyles/atoms/icon/icon.stories.mdx
+++ b/scss/bitstyles/atoms/icon/icon.stories.mdx
@@ -7,7 +7,7 @@ import icons from '../../../../assets/images/icons.svg';
 
 ## SVG icon system
 
-Icons are best implemented using inline SVG (see the examples below). However they’re rendered, they must be accompanied by some machine-readable text for accessibility & SEO. If there is to be no such text visible (e.g. from design mockups), use [`.u-sr-only`](/docs/utilities-sr-only--sr-only) to hide the span containing descriptive text.
+Icons are best implemented using inline SVG (see the examples below). Add a machine-readable text version of the icon next to it for accessibility (and SEO). the text can be made invisible (e.g. because of your design requirements) — use [`.u-sr-only`](/docs/utilities-sr-only--sr-only) to hide an element containing descriptive text.
 
 The base icon size inherits from the surrounding text i.e. `1em`. Other sizes available by default (`s`, `m`, `l`, and `xl`) are based on the global rem-based sizing map.
 

--- a/scss/bitstyles/atoms/link/link.stories.mdx
+++ b/scss/bitstyles/atoms/link/link.stories.mdx
@@ -4,9 +4,9 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Link
 
-Mimic the appearance of standard anchor by applying a classname. This allows other interactive elements (e.g. `<button>`) to visually match your links.
+Mimic the appearance of a standard anchor element by applying a classname. This allows other interactive elements (e.g. `<button>`) to visually match your links.
 
-This is a slightly bad practice — if it looks like a link, it should be a link — that’s sometimes necessary for technical reasons, generally when building a JS app. Actions triggered by javascript should not use anchor elements because no navigation occurs, instead they should use `button` elements, but sometimes that button needs to look like a link (examples are the trigger to displaying a modal, or a smaller de-emphasised cancel button next to your primary “OK” action).
+This is a slightly bad practice — if it looks like a link, it should be a link — that’s sometimes necessary for technical reasons, generally when building a JS app. Actions triggered by JavaScript should not use anchor elements because no navigation occurs, instead they should use `button` elements. But sometimes that button needs to look like a link (examples are the trigger to displaying a modal, or a smaller de-emphasised cancel button next to your primary “OK” action).
 
 <Canvas>
   <Story name="Link">

--- a/scss/bitstyles/atoms/link/link.stories.mdx
+++ b/scss/bitstyles/atoms/link/link.stories.mdx
@@ -4,14 +4,14 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Link
 
-Mimic the appearance of standard anchor elements. This allows other interactive elements (e.g. `<button>`) to visually match your links.
+Mimic the appearance of standard anchor by applying a classname. This allows other interactive elements (e.g. `<button>`) to visually match your links.
 
-This is generally a bad practice — if it looks like a link, it should be a link — but it’s sometimes necessary for technical reasons, especially when building a JS app e.g. an element shouldn’t be a link because no url change occurs (this could be when displaying a modal, or cancelling an action).
+This is a slightly bad practice — if it looks like a link, it should be a link — that’s sometimes necessary for technical reasons, generally when building a JS app. Actions triggered by javascript should not use anchor elements because no navigation occurs, instead they should use `button` elements, but sometimes that button needs to look like a link (examples are the trigger to displaying a modal, or a smaller de-emphasised cancel button next to your primary “OK” action).
 
 <Canvas>
   <Story name="Link">
     {`
-      <button class="a-link" type="button">I’m a button element</button>
+      <button class="a-link" type="button">A button element</button>
     `}
   </Story>
 </Canvas>

--- a/scss/bitstyles/atoms/topbar/topbar.stories.mdx
+++ b/scss/bitstyles/atoms/topbar/topbar.stories.mdx
@@ -20,7 +20,7 @@ Commonly used to contain site navigation, logo etc. this element spans the full 
 
 Common customizations for this atom include:
 
-- using the [content](/docs/atoms-content--a-content) atom to wrap the topbar’s content, and removing the horizontal padding here to ensure correct alignment with other content
+- using the [content](/docs/atoms-content--a-content) atom to wrap the topbar’s content, and removing the horizontal padding to ensure correct alignment with other content
 - making the topbar sticky (or fixed), so it stays in place when scrolling
 
 ```scss

--- a/scss/bitstyles/atoms/topbar/topbar.stories.mdx
+++ b/scss/bitstyles/atoms/topbar/topbar.stories.mdx
@@ -6,8 +6,6 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Commonly used to contain site navigation, logo etc. this element spans the full width available, and by default has a z-index that ensures it’s rendered above other content.
 
-Use utility classes to set colors.
-
 <Canvas>
   <Story name="Topbar">
     {`
@@ -17,3 +15,17 @@ Use utility classes to set colors.
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+Common customizations for this atom include:
+
+- using the [content](/docs/atoms-content--a-content) atom to wrap the topbar’s content, and removing the horizontal padding here to ensure correct alignment with other content
+- making the topbar sticky (or fixed), so it stays in place when scrolling
+
+```scss
+$position: relative;
+$vertical-padding: size.get('s');
+$horizontal-padding: size.get('m');
+$z-index: zindex.get(layout.$global-z, 'topbar');
+```

--- a/scss/bitstyles/ui/icons.stories.mdx
+++ b/scss/bitstyles/ui/icons.stories.mdx
@@ -179,8 +179,8 @@ By default, icons inherit their size from the surrounding text i.e. `width: 1em;
 - `.a-icon--xl`
 
 <Canvas>
-  <Story id="atoms-icon--small-icon" />
-  <Story id="atoms-icon--medium-icon" />
-  <Story id="atoms-icon--large-icon" />
-  <Story id="atoms-icon--x-large-icon" />
+  <Story id="atoms-icon--a-icon-s" />
+  <Story id="atoms-icon--a-icon-m" />
+  <Story id="atoms-icon--a-icon-l" />
+  <Story id="atoms-icon--a-icon-xl" />
 </Canvas>

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -687,6 +687,10 @@ table {
   border-radius: 9999rem;
   white-space: nowrap;
 }
+.bsa-badge .bsa-badge__button {
+  margin-right: -7.5rem;
+  margin-left: 5rem;
+}
 .bsa-badge--gray {
   --button-fg: #000;
   --button-bg: #000;
@@ -726,10 +730,6 @@ table {
   --button-bg-hover: #000;
   background-color: #000;
   color: #000;
-}
-.bsa-badge__button {
-  margin-right: -7.5rem;
-  margin-left: 5rem;
 }
 .bsa-bordered-header {
   display: grid;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -694,6 +694,10 @@ table {
   border-radius: 9999rem;
   white-space: nowrap;
 }
+.a-badge .a-badge__button {
+  margin-right: -0.6rem;
+  margin-left: 0.4rem;
+}
 .a-badge--gray {
   --button-fg: #2e2f47;
   --button-bg: #cfd0e9;
@@ -733,10 +737,6 @@ table {
   --button-bg-hover: #73b935;
   background-color: #eef6e6;
   color: #73b935;
-}
-.a-badge__button {
-  margin-right: -0.6rem;
-  margin-left: 0.4rem;
 }
 .a-bordered-header {
   display: grid;


### PR DESCRIPTION
Fixes #612 

The following changes are contained in this pull request:

- Updates the atoms’ docs in storybook to reflect the current available settings, and the defaults
- DRIVE-BY fixes an issue with buttons in badges

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Update IDs of linked stories who’s name has changed