### PR TITLE
[#487] Add customisation guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,40 @@
 - Renames `output-properties()` -> `output()`
 - Renames `output-directional-properties()` -> `output-directional()`
 
+### Breaking
+
+- If you were overriding `bitstyles-padding-values` and providing your sizes nested inside a `positive` key, you will need to remove that, and provide the values directly e.g.
+
+  ```scss
+  $sizes: (
+    'positive': (
+      '0': 0,
+      'xxs': size.get('xxs'),
+      'xs': size.get('xs'),
+      's': size.get('s'),
+      'm': size.get('m'),
+      'l': size.get('l'),
+      'xl': size.get('xl'),
+      'xxl': size.get('xxl'),
+    ),
+  );
+  ```
+
+  becomes
+
+  ```scss
+  $sizes: (
+    '0': 0,
+    'xxs': size.get('xxs'),
+    'xs': size.get('xs'),
+    's': size.get('s'),
+    'm': size.get('m'),
+    'l': size.get('l'),
+    'xl': size.get('xl'),
+    'xxl': size.get('xxl'),
+  );
+  ```
+
 ## [[4.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v4.0.0) - 2021-12-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "style-loader": "^3.3.1",
     "stylelint": "^14.4.0",
     "stylelint-config-bitcrowd": "^5.1.0",
+    "typescript": "^4.5.5",
     "webpack": "^5.68.0"
   },
   "files": [

--- a/scss/bitstyles/settings/typography.stories.mdx
+++ b/scss/bitstyles/settings/typography.stories.mdx
@@ -95,7 +95,7 @@ The default webfont is Nunito. If you wish to keep using it, there’s nothing y
 
 Rather than applying a webfont directly in CSS or Sass, it’s good practice to provide a _font stack_ so there’s a fallback that’s similar to the webfont you want to use (but may not download in time or ever).
 
-There are two stacks provided, one for the heading font-family, another for the body font-family. These both apply “Nunito” as the prefered font, and several fallback fonts that have good legibility for app UIs. Look to the [Customization](#customization) section below for details on how to change this.
+There are two stacks provided, one for the heading font-family, another for the body font-family. These both apply “Nunito” as the preferred font, and several fallback fonts that have good legibility for app UIs. Look to the [Customization](#customization) section below for details on how to change this.
 
 For the default setup:
 

--- a/scss/bitstyles/utilities/absolute-center/absolute-center.stories.mdx
+++ b/scss/bitstyles/utilities/absolute-center/absolute-center.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Absolute Center
 
-Centers an element vertically & horizontally, relative to its closest non-statically positioned parent element (non-static most-likely means `relative`, but also `absolute` or `fixed`).
+Centers an element vertically & horizontally, relative to its closest non-statically positioned parent element (non-static most likely means `relative`, but also `absolute` or `fixed`).
 
 As this class makes use of absolute positioning, the element is no longer in the document flow and has no width or height as far as the parent element is concerned — the parent element must instead provide the dimensions for the `.u-absolute-center` to align to.
 

--- a/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
+++ b/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
@@ -6,7 +6,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Enforce an aspect ratio on this element and its contents.
 
-The aspect-ratio element takes 100% of its parent element’s width, then the height is set so the element will maintain the specified ratio. The default ratios inclue 1:1 (square), and 16:9 (common for video content). See the [Customization](#customization) section below for details how to change that.
+The aspect-ratio element takes 100% of its parent element’s width, then the height is set so the element will maintain the specified ratio. The default ratios include 1:1 (square), and 16:9 (common for video content). See the [Customization](#customization) section below for details how to change that.
 
 <Canvas>
   <Story name="aspect-ratio-1-1">

--- a/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
+++ b/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
@@ -6,20 +6,20 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Enforce an aspect ratio on this element and its contents.
 
-The aspect-ratio element takes 100% of its parent element’s width, then the height is set so the element will maintain the specified ratio. The default ratios inclue 1:1 (square), and 16:9 (common for video content).
+The aspect-ratio element takes 100% of its parent element’s width, then the height is set so the element will maintain the specified ratio. The default ratios inclue 1:1 (square), and 16:9 (common for video content). See the [Customization](#customization) section below for details how to change that.
 
 <Canvas>
   <Story name="aspect-ratio-1-1">
     {`
-      <div class="u-aspect-ratio-1-1 u-bg-brand-2 u-relative">
-        <div class="u-absolute-center u-text-center">1:1 <span class="u-block">(try resizing)</span></div>
+      <div class="u-aspect-ratio-1-1 u-bg-brand-2 u-relative" style="min-width:10rem">
+        <div class="u-absolute-center u-text-center">1:1</div>
       </div>
     `}
   </Story>
   <Story name="aspect-ratio-16-9">
     {`
-      <div class="u-aspect-ratio-16-9 u-bg-brand-2 u-relative">
-        <div class="u-absolute-center u-text-center">16:9 <span class="u-block">(try resizing)</span></div>
+      <div class="u-aspect-ratio-16-9 u-bg-brand-2 u-relative" style="min-width:10rem">
+        <div class="u-absolute-center u-text-center">16:9</div>
       </div>
     `}
   </Story>
@@ -27,17 +27,19 @@ The aspect-ratio element takes 100% of its parent element’s width, then the he
 
 # Customization
 
-Available aspect ratios can be customized by overriding the Sass map `$bitstyles-aspect-ratios`, for each providing the name for the class as the key, and a sass map containing `width` and `height`:
+Available aspect ratios can be customized by overriding the Sass map `$bitstyles-aspect-ratio-values`, for each providing the name for the class as the key, and a sass map containing `width` and `height`:
 
 ```scss
-$bitstyles-aspect-ratios: (
-  '16-9': (
-    'width': 16,
-    'height': 9,
+@use '~bitstyles/scss/bitstyles/utilities/aspect-ratio' with (
+  $values: (
+    '16-9': (
+      'width': 16,
+      'height': 9,
+    ),
+    '1-1': (
+      'width': 1,
+      'height': 1,
+    )
   ),
-  '1-1': (
-    'width': 1,
-    'height': 1,
-  )
 );
 ```

--- a/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
+++ b/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
@@ -6,18 +6,9 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Enforce an aspect ratio on this element and its contents.
 
-The aspect-ratio element takes 100% of its parent element’s width, then the height is set so the element will maintain the specified ratio. The default ratios inclue 1:1, and 16:9. These are defined in the Sass map `$bitstyles-aspect-ratios` under the keys `width` and `height` e.g.
+The aspect-ratio element takes 100% of its parent element’s width, then the height is set so the element will maintain the specified ratio. The default ratios inclue 1:1 (square), and 16:9 (common for video content).
 
-```scss
-$bitstyles-aspect-ratios: (
-  '16-9': (
-    'width': 16,
-    'height': 9,
-  ),
-);
-```
-
-<Canvas isColumn>
+<Canvas>
   <Story name="aspect-ratio-1-1">
     {`
       <div class="u-aspect-ratio-1-1 u-bg-brand-2 u-relative">
@@ -33,3 +24,20 @@ $bitstyles-aspect-ratios: (
     `}
   </Story>
 </Canvas>
+
+# Customization
+
+Available aspect ratios can be customized by overriding the Sass map `$bitstyles-aspect-ratios`, for each providing the name for the class as the key, and a sass map containing `width` and `height`:
+
+```scss
+$bitstyles-aspect-ratios: (
+  '16-9': (
+    'width': 16,
+    'height': 9,
+  ),
+  '1-1': (
+    'width': 1,
+    'height': 1,
+  )
+);
+```

--- a/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
+++ b/scss/bitstyles/utilities/aspect-ratio/aspect-ratio.stories.mdx
@@ -39,7 +39,7 @@ Available aspect ratios can be customized by overriding the Sass map `$bitstyles
     '1-1': (
       'width': 1,
       'height': 1,
-    )
-  ),
+    ),
+  )
 );
 ```

--- a/scss/bitstyles/utilities/bg/bg.stories.mdx
+++ b/scss/bitstyles/utilities/bg/bg.stories.mdx
@@ -89,7 +89,7 @@ The available background-colors can be customized by overriding the `$bitstyles-
     'gray-20': palette.get('gray', '20'),
     'gray-10': palette.get('gray', '10'),
     'gray-5': palette.get('gray', '5'),
-  ),
+  )
 );
 ```
 
@@ -97,6 +97,9 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/bg' with (
-  $bitstyles-bg-breakpoints: ('m', 'l'),
+  $bitstyles-bg-breakpoints: (
+    'm',
+    'l',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/bg/bg.stories.mdx
+++ b/scss/bitstyles/utilities/bg/bg.stories.mdx
@@ -4,7 +4,20 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # bg (BackGround color)
 
-Define which background colours you require in the `$background-colors` Sass list, using the colours as defined in `$bitstyles-palette`.
+Applies a background-color to the element. Default colors are
+
+- `black-80`
+- `background`
+- `white`
+- `brand-2`
+- `gray-90`
+- `gray-80`
+- `gray-50`
+- `gray-20`
+- `gray-10`
+- `gray-5`
+
+See the [customization](#customization) section below for details on how to change available colors.
 
 <Canvas>
   <Story name="black-80">
@@ -61,25 +74,29 @@ Define which background colours you require in the `$background-colors` Sass lis
 
 ## Customization
 
-The available background-colors can be customized by overriding the `$bitstyles-bg-values` Sass variable:
+The available background-colors can be customized by overriding the `$bitstyles-bg-values` Sass variable. Use the `palette.get()` function to maintain consistency throughout your project:
 
 ```scss
-$bitstyles-bg-values: (
-  'black-80': palette.get('black', '80'),
-  'background': palette.get('background'),
-  'white': palette.get('white'),
-  'brand-2': palette.get('brand-2', '100'),
-  'gray-90': palette.get('gray', '90'),
-  'gray-80': palette.get('gray', '80'),
-  'gray-50': palette.get('gray', '50'),
-  'gray-20': palette.get('gray', '20'),
-  'gray-10': palette.get('gray', '10'),
-  'gray-5': palette.get('gray', '5'),
+@use '~bitstyles/scss/bitstyles/utilities/bg' with (
+  $values: (
+    'black-80': palette.get('black', '80'),
+    'background': palette.get('background'),
+    'white': palette.get('white'),
+    'brand-2': palette.get('brand-2', '100'),
+    'gray-90': palette.get('gray', '90'),
+    'gray-80': palette.get('gray', '80'),
+    'gray-50': palette.get('gray', '50'),
+    'gray-20': palette.get('gray', '20'),
+    'gray-10': palette.get('gray', '10'),
+    'gray-5': palette.get('gray', '5'),
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-bg-breakpoints`:
 
 ```scss
-$bitstyles-bg-breakpoints: ('m', 'l');
+@use '~bitstyles/scss/bitstyles/utilities/bg' with (
+  $bitstyles-bg-breakpoints: ('m', 'l'),
+);
 ```

--- a/scss/bitstyles/utilities/border/border.stories.mdx
+++ b/scss/bitstyles/utilities/border/border.stories.mdx
@@ -4,7 +4,14 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Border
 
-Apply a border with the specified color and direction.
+Apply a border with the specified color, and on the specified side of the element.
+
+Default colors available are:
+
+- `gray-70`
+- `gray-10`
+
+All colors are available on `top`, `right`, `bottom`, `left`, `x`, and `y` directions. By default these classes are not available at any breakpoints. See the [customization](#customization) section for details on how you can change those settings.
 
 ## Gray-10
 
@@ -85,3 +92,39 @@ Apply a border with the specified color and direction.
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available border properties can be customized by overriding the `$bitstyles-border-values` Sass map. Provide complete `border` shorthand properties (including border-width, border-style, and border-color), using colors from your global color palette:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/border' with (
+  $values: (
+    'gray-70': 1px solid palette.get('gray', '70'),
+    'gray-10': 1px solid palette.get('gray', '10'),
+  ),
+);
+```
+
+To make these classes available at breakpoints, override `$bitstyles-border-breakpoints`, providing the name(s) of breakpoints defined in your global breakpoint settings:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/border' with (
+  $breakpoints: ('m'),
+);
+```
+
+You can also redefine which directions of border are output by overriding the `$bitstyles-border-directions` Sass map. Provide the name to be used for each class, and a Sass list of the border directions that should be included:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/border' with (
+  $directions: (
+    'top-and-right': (
+      'top', 'right',
+    ),
+    '∏': (
+      'top', 'right', 'left',
+    ),
+  ),
+);
+```

--- a/scss/bitstyles/utilities/border/border.stories.mdx
+++ b/scss/bitstyles/utilities/border/border.stories.mdx
@@ -11,7 +11,7 @@ Default colors available are:
 - `gray-70`
 - `gray-10`
 
-All colors are available on `top`, `right`, `bottom`, `left`, `x`, and `y` directions. By default these classes are not available at any breakpoints. See the [customization](#customization) section for details on how you can change those settings.
+All colors are available on `top`, `right`, `bottom`, `left`, `x`, and `y` directions. By default these classes are not available at any breakpoint. See the [customization](#customization) section for details on how you can change those settings.
 
 ## Gray-10
 

--- a/scss/bitstyles/utilities/border/border.stories.mdx
+++ b/scss/bitstyles/utilities/border/border.stories.mdx
@@ -102,7 +102,7 @@ The available border properties can be customized by overriding the `$bitstyles-
   $values: (
     'gray-70': 1px solid palette.get('gray', '70'),
     'gray-10': 1px solid palette.get('gray', '10'),
-  ),
+  )
 );
 ```
 
@@ -110,7 +110,9 @@ To make these classes available at breakpoints, override `$bitstyles-border-brea
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/border' with (
-  $breakpoints: ('m'),
+  $breakpoints: (
+    'm',
+  )
 );
 ```
 
@@ -120,11 +122,14 @@ You can also redefine which directions of border are output by overriding the `$
 @use '~bitstyles/scss/bitstyles/utilities/border' with (
   $directions: (
     'top-and-right': (
-      'top', 'right',
+      'top',
+      'right',
     ),
     '∏': (
-      'top', 'right', 'left',
+      'top',
+      'right',
+      'left',
     ),
-  ),
+  )
 );
 ```

--- a/scss/bitstyles/utilities/box-shadow/box-shadow.stories.mdx
+++ b/scss/bitstyles/utilities/box-shadow/box-shadow.stories.mdx
@@ -23,22 +23,28 @@ Apply a CSS box-shadow to the element. By default this is selected from the stan
 The available box-shadows and their names can be customized by overriding the `$bitstyles-box-shadow-values` Sass variable. Use the `shadows.get()` helper from `tools/shadows` to access the shadows you’ve setup in your global design tokens (see `settings/shadows`), providing `css` as the format:
 
 ```scss
-$bitstyles-box-shadow-values: (
-  'default': shadows.get('default', 'box'),
+@use '~bitstyles/scss/bitstyles/utilities/box-shadow' with (
+  $values: (
+    'default': shadows.get('default', 'box'),
+  ),
 );
 ```
 
 You can also specify shadows directly, using the correct format for the CSS `box-shadow` property e.g.
 
 ```scss
-$bitstyles-box-shadow-values: (
-  'default': 0 0 1rem 0.5rem rgba(0, 0, 0, 0.2),
-  0 0 2rem 1rem rgba(0, 0, 0, 0.2),
+@use '~bitstyles/scss/bitstyles/utilities/box-shadow' with (
+  $values: (
+    'default': 0 0 1rem 0.5rem rgba(0, 0, 0, 0.2),
+    0 0 2rem 1rem rgba(0, 0, 0, 0.2),
+  ),
 );
 ```
 
-The breakpoints these classes are available at can be customized by overriding the `$bitstyles-box-shadows-breakpoints` variable:
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-box-shadows-breakpoints` variable, providing a list of breakpoint names from your globally-defined breakpoints:
 
 ```scss
-$bitstyles-box-shadow-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/box-shadow' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/box-shadow/box-shadow.stories.mdx
+++ b/scss/bitstyles/utilities/box-shadow/box-shadow.stories.mdx
@@ -26,7 +26,7 @@ The available box-shadows and their names can be customized by overriding the `$
 @use '~bitstyles/scss/bitstyles/utilities/box-shadow' with (
   $values: (
     'default': shadows.get('default', 'box'),
-  ),
+  )
 );
 ```
 
@@ -37,7 +37,7 @@ You can also specify shadows directly, using the correct format for the CSS `box
   $values: (
     'default': 0 0 1rem 0.5rem rgba(0, 0, 0, 0.2),
     0 0 2rem 1rem rgba(0, 0, 0, 0.2),
-  ),
+  )
 );
 ```
 
@@ -45,6 +45,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/box-shadow' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/col-span/col-span.stories.mdx
+++ b/scss/bitstyles/utilities/col-span/col-span.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Col-span
 
-For some layouts, you’ll want to allow some of the grid children a little more space. You can do this using `.u-col-span-2`, `.u-col-span-3` etc. By default these classes are available for sizes `1`, `2`, `3`, `4`, `5`, and `6`, see [customization](#customization) for details on how to change that.
+For some layouts, you’ll want to allow some of the grid children a little more space. You can do this using `.u-col-span-2`, `.u-col-span-3` … up to `.u-col-span-6`. See [customization](#customization) for details on how to change the available col-spans.
 
 <Canvas isColumn>
   <Story name="u-col-span-1">

--- a/scss/bitstyles/utilities/col-span/col-span.stories.mdx
+++ b/scss/bitstyles/utilities/col-span/col-span.stories.mdx
@@ -150,7 +150,7 @@ The available column-spans can be customized by overriding the `$bitstyles-col-s
     '5': span 5 / span 5,
     '6': span 6 / span 6,
     '7': span 7 / span 7,
-  ),
+  )
 );
 ```
 
@@ -158,6 +158,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/col-span' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/col-span/col-span.stories.mdx
+++ b/scss/bitstyles/utilities/col-span/col-span.stories.mdx
@@ -4,12 +4,24 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Col-span
 
-For some layouts, you’ll want to allow some of the grid children a little more space. You can do this using `.u-col-span-2` and `.u-col-span-3`. But note that using these classes can break the grid layout if the `span` class on the child is not applied at the same breakpoint as the grid.
+For some layouts, you’ll want to allow some of the grid children a little more space. You can do this using `.u-col-span-2`, `.u-col-span-3` etc. By default these classes are available for sizes `1`, `2`, `3`, `4`, `5`, and `6`, see [customization](#customization) for details on how to change that.
 
 <Canvas isColumn>
+  <Story name="u-col-span-1">
+    {`
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-1">Grid child 1, span 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
+      </ul>
+    `}
+  </Story>
   <Story name="u-col-span-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-2 u-padding-m u-bg-gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-2">Grid child 1, span 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -21,8 +33,44 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3 u-padding-m u-bg-gray-10 a-list-reset">
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-3">Grid child 1, span 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-col-span-4">
+    {`
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-4">Grid child 1, span 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-col-span-5">
+    {`
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-5">Grid child 1, span 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 5</li>
+        <li class="u-bg-background u-padding-m a-card">Grid child 6</li>
+      </ul>
+    `}
+  </Story>
+  <Story name="u-col-span-6">
+    {`
+      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-10 a-list-reset">
+        <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6">Grid child 1, span 6</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 4</li>
@@ -35,7 +83,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
 
 # Responsive col-span
 
-The `col-span` classes are also all available at `s`, `m`, and `xl` breakpoints.
+The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See the [customization](#customization) section below.
 
 <Canvas isColumn>
   <Story name="u-col-span-6@s">
@@ -90,21 +138,26 @@ The `col-span` classes are also all available at `s`, `m`, and `xl` breakpoints.
 
 ## Customization
 
-The available column-spans can be customized by overriding the `$bitstyles-col-span` Sass variable:
+The available column-spans can be customized by overriding the `$bitstyles-col-span-values` Sass map. Provide a name for the class as the key, and the span values you require. If you want to add some values (because you’ve defined you grid with more columns, for example), you’ll need to copy the the existing values in order to keep them — you can only override the whole map, not update or merge:
 
 ```scss
-$bitstyles-col-span: (
-  '1': span 1 / span 1,
-  '2': span 2 / span 2,
-  '3': span 3 / span 3,
-  '4': span 4 / span 4,
-  '5': span 5 / span 5,
-  '6': span 6 / span 6,
+@use '~bitstyles/scss/bitstyles/utilities/col-span' with (
+  $values: (
+    '1': span 1 / span 1,
+    '2': span 2 / span 2,
+    '3': span 3 / span 3,
+    '4': span 4 / span 4,
+    '5': span 5 / span 5,
+    '6': span 6 / span 6,
+    '7': span 7 / span 7,
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-col-span-breakpoints` variable:
 
 ```scss
-$bitstyles-col-span-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/col-span' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/col-start/col-start.stories.mdx
+++ b/scss/bitstyles/utilities/col-start/col-start.stories.mdx
@@ -142,7 +142,7 @@ The available start columns can be customized by overriding the `$bitstyles-col-
     '5': 5,
     '6': 6,
     '7': 7,
-  ),
+  )
 );
 ```
 
@@ -150,6 +150,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/col-start' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/col-start/col-start.stories.mdx
+++ b/scss/bitstyles/utilities/col-start/col-start.stories.mdx
@@ -6,7 +6,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Manually specify which column an element starts in.
 
-Auto-pplaced grid children following this one will be placed consecutively.
+Auto-placed grid children following this one will be placed consecutively.
 
 It’s common to use `.u-col-start-1` to force an element to start a new row. By default these classes are available for sizes `1`, `2`, `3`, `4`, `5`, and `6`, see [customization](#customization) for details on how to change that.
 

--- a/scss/bitstyles/utilities/col-start/col-start.stories.mdx
+++ b/scss/bitstyles/utilities/col-start/col-start.stories.mdx
@@ -4,11 +4,11 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Col-start
 
-Use these classes to specify which column an element should start in.
+Manually specify which column an element starts in.
 
-Manually placing items in a grid normally results in unwanted gaps, as the following automatically-placed grid children continue from where you placed it. You could avoid this by applying other col-start classes to every grid child to manually place each one in the grid.
+Auto-pplaced grid children following this one will be placed consecutively.
 
-It’s common to use `.u-col-start-1` to force an element to start a new row — the following grid children will continue afterwards.
+It’s common to use `.u-col-start-1` to force an element to start a new row. By default these classes are available for sizes `1`, `2`, `3`, `4`, `5`, and `6`, see [customization](#customization) for details on how to change that.
 
 <Canvas isColumn>
   <Story name="u-col-start-1">
@@ -87,7 +87,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row —
 
 ## Responsive col-start
 
-The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by default.
+The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by default. See the [customization](#customization) section below.
 
 <Canvas isColumn>
   <Story name="u-col-start-1@s">
@@ -130,21 +130,26 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 
 ## Customization
 
-The available start columns can be customized by overriding the `$bitstyles-col-start` Sass variable:
+The available start columns can be customized by overriding the `$bitstyles-col-start-values` Sass map. Provide a name for the class as the key, and the col-start value you require. If you want to add some values (because you’ve defined you grid with more columns, for example), you’ll need to copy the the existing values in order to keep them — you can only override the whole map, not update or merge:
 
 ```scss
-$bitstyles-col-start: (
-  '1': 1,
-  '2': 2,
-  '3': 3,
-  '4': 4,
-  '5': 5,
-  '6': 6,
+@use '~bitstyles/scss/bitstyles/utilities/col-start' with (
+  $values: (
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6,
+    '7': 7,
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-col-start-breakpoints` variable:
 
 ```scss
-$bitstyles-col-start-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/col-start' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/display/display.stories.mdx
+++ b/scss/bitstyles/utilities/display/display.stories.mdx
@@ -299,7 +299,7 @@ The available display types can be customized by overriding the `$bitstyles-disp
     'flex': flex,
     'inline-flex': inline-flex,
     'hidden': none,
-  ),
+  )
 );
 ```
 
@@ -307,6 +307,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/display' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/display/display.stories.mdx
+++ b/scss/bitstyles/utilities/display/display.stories.mdx
@@ -4,9 +4,9 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Display
 
-Apply display types to an element. These are often paired with [flex](/docs/utilities-flex--flex-with-grow-1-child) or [grid](/docs/utilities-grid--u-grid) classes, or used to show/hide content based on viewport size (see below).
+Specify display properties of an element. These are often paired with [flex](/docs/utilities-flex--flex-with-grow-1-child) or [grid](/docs/utilities-grid--u-grid) classes, or used to show/hide content based on viewport size (see [show/hide](#showhide) below).
 
-These classes are all available at breakpoints (see examples), resize your browser to see them in action.
+Default display values are `block`, `grid`,`flex`, `inline-flex`, and `hidden`, and the classes are all available at `s`, `m`, and `l` breakpoints — resize your browser to see them in action. See [customization](#customization) for details on how to change those settings.
 
 ## u-block
 
@@ -210,8 +210,6 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 
 ## u-inline-flex
 
-Largely the same as the block flex layouts above, except the `.u-inline-flex` does not expand to fill the block.
-
 See the documentation for [flex](/docs/utilities-flex--flex-with-grow-1-child) classes for more practical examples.
 
 <Canvas isColumn>
@@ -291,20 +289,24 @@ Another use is to add `.u-hidden` to “remove” an element from the page, then
 
 ## Customization
 
-The available display types can be customized by overriding the `$bitstyles-display-values` Sass variable:
+The available display types can be customized by overriding the `$bitstyles-display-values` Sass map. Provide a name for the class as the key, and the `display` property value:
 
 ```scss
-$bitstyles-display-values: (
-  'block': block,
-  'grid': grid,
-  'flex': flex,
-  'inline-flex': inline-flex,
-  'hidden': none,
+@use '~bitstyles/scss/bitstyles/utilities/display' with (
+  $values: (
+    'block': block,
+    'grid': grid,
+    'flex': flex,
+    'inline-flex': inline-flex,
+    'hidden': none,
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-display-breakpoints` variable:
 
 ```scss
-$bitstyles-display-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/display' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/drop-shadow/drop-shadow.stories.mdx
+++ b/scss/bitstyles/utilities/drop-shadow/drop-shadow.stories.mdx
@@ -23,13 +23,17 @@ Apply a drop-shadow to the elementusing CSS filters. By default this is selected
 The available drop-shadows and their names can be customized by overriding the `$bitstyles-drop-shadow-values` Sass variable. Use the `shadows.get()` helper from `tools/shadows` to access the shadows you’ve setup in your global design tokens (see `settings/shadows`), providing `filter` as the format (drop-shadows are applied using CSS filters):
 
 ```scss
-$bitstyles-drop-shadow-values: (
-  'default': shadows.get('default', 'drop'),
+@use '~bitstyles/scss/bitstyles/utilities/drop-shadow' with (
+  $values: (
+    'default': shadows.get('default', 'drop'),
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-drop-shadows-breakpoints` variable:
 
 ```scss
-$bitstyles-drop-shadow-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/drop-shadow' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/drop-shadow/drop-shadow.stories.mdx
+++ b/scss/bitstyles/utilities/drop-shadow/drop-shadow.stories.mdx
@@ -26,7 +26,7 @@ The available drop-shadows and their names can be customized by overriding the `
 @use '~bitstyles/scss/bitstyles/utilities/drop-shadow' with (
   $values: (
     'default': shadows.get('default', 'drop'),
-  ),
+  )
 );
 ```
 
@@ -34,6 +34,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/drop-shadow' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/fg/fg.stories.mdx
+++ b/scss/bitstyles/utilities/fg/fg.stories.mdx
@@ -52,7 +52,7 @@ The available display types can be customized by overriding the `$bitstyles-fg-v
     'gray-50': palette.get('gray', '50'),
     'gray-40': palette.get('gray', '40'),
     'gray-30': palette.get('gray', '30'),
-  ),
+  )
 );
 ```
 
@@ -60,6 +60,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/fg' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/fg/fg.stories.mdx
+++ b/scss/bitstyles/utilities/fg/fg.stories.mdx
@@ -41,7 +41,7 @@ Specify the `color` property of an element.
 
 ## Customization
 
-The available display types can be customized by overriding the `$bitstyles-fg-values` Sass map. Provide a name for the class, and use the `palette.get()` helper from `tools/palette` to access colors from your golbal color palette:
+The available display types can be customized by overriding the `$bitstyles-fg-values` Sass map. Provide a name for the class, and use the `palette.get()` helper from `tools/palette` to access colors from your global color palette:
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/fg' with (

--- a/scss/bitstyles/utilities/fg/fg.stories.mdx
+++ b/scss/bitstyles/utilities/fg/fg.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # fg (ForeGround color)
 
-Define which foreground colours you require in the `$foreground-colors` Sass list, using the colours as defined in `$bitstyles-palette`.
+Specify the `color` property of an element.
 
 <Canvas>
   <Story name="brand-1">
@@ -41,21 +41,25 @@ Define which foreground colours you require in the `$foreground-colors` Sass lis
 
 ## Customization
 
-The available display types can be customized by overriding the `$bitstyles-fg-values` Sass variable:
+The available display types can be customized by overriding the `$bitstyles-fg-values` Sass map. Provide a name for the class, and use the `palette.get()` helper from `tools/palette` to access colors from your golbal color palette:
 
 ```scss
-$bitstyles-fg-values: (
-  'brand-1': palette.get('brand-1', '100'),
-  'brand-2': palette.get('brand-2', '100'),
-  'warning': palette.get('warning', '100'),
-  'gray-50': palette.get('gray', '50'),
-  'gray-40': palette.get('gray', '40'),
-  'gray-30': palette.get('gray', '30'),
+@use '~bitstyles/scss/bitstyles/utilities/fg' with (
+  $values: (
+    'brand-1': palette.get('brand-1', '100'),
+    'brand-2': palette.get('brand-2', '100'),
+    'warning': palette.get('warning', '100'),
+    'gray-50': palette.get('gray', '50'),
+    'gray-40': palette.get('gray', '40'),
+    'gray-30': palette.get('gray', '30'),
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-fg-breakpoints` variable:
 
 ```scss
-$bitstyles-fg-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/fg' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -1,14 +1,16 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Utilities/flex" />
+<Meta title="Utilities/flex/flex" />
 
 # Flex
+
+Apply `flex-direction`, `flex-wrap`, `flex-shrink`, and `flex-grow` properties to an element. By default these classes are available at the `m` breakpoint. See the [customization](#customization) section for details on how to chnage that.
 
 **Resize your viewport** to best view these examples, or view the examples in the canvas instead of here in the docs.
 
 **Some of these examples will cause horizontal scrollbars** at some viewport widths. That’s deliberate and important — your approach to dealing with that issue will depend on your content, but probably `.u-flex-wrap` will be among the first places to look (see below).
 
-Flex has become the prefered method for laying out app UI, and in many cases also for content in an article/content context. Probably the only instance that’s not true is when you can assume browser support for CSS Grid, which gives developers control over layout in two axis. These flex layout classes cover the most common usecases, they should be extended as needed.
+Flex has become the prefered method for laying out app UI, and in many cases also for content in an article/content context. Probably the only instance that’s not true is when you can assume browser support for CSS Grid, which gives developers control over layout in two axis. These flex layout classes cover the most common usecases; they should be extended as needed.
 
 ## Basic flex layout
 
@@ -376,3 +378,32 @@ Flex defaults to laying out children in horizontal rows. To layout items vertica
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available values for `flex-direction`, `flex-wrap`, `flex-grow`, and `flex-shrink` and their names can be customized by overriding the `$bitstyles-flex-direction`, `$bitstyles-flex-wrap`, `$bitstyles-flex-grow`, and `$bitstyles-flex-shrink` Sass maps respectively:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/flex' with (
+  $direction: (
+    'row': row,
+  ),
+  $wrap: (
+    'nowrap': nowrap,
+  ),
+  $grow: (
+    '100': 100,
+  ),
+  $shrink: (
+    '100': 100,
+  ),
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-flex-breakpoints` variable:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/flex' with (
+  $breakpoints: ('m', 'xl'),
+);
+```

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Utilities/flex/flex" />
+<Meta title="Utilities/flex" />
 
 # Flex
 

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -10,7 +10,7 @@ Apply `flex-direction`, `flex-wrap`, `flex-shrink`, and `flex-grow` properties t
 
 **Some of these examples will cause horizontal scrollbars** at some viewport widths. That’s deliberate and important — your approach to dealing with that issue will depend on your content, but probably `.u-flex-wrap` will be among the first places to look (see below).
 
-Flex has become the prefered method for laying out app UI, and in many cases also for content in an article/content context. Probably the only instance that’s not true is when you can assume browser support for CSS Grid, which gives developers control over layout in two axis. These flex layout classes cover the most common usecases; they should be extended as needed.
+Flex has become the preferred method for laying out app UI, and in many cases also for content in an article/content context. Probably the only instance that’s not true is when you can assume browser support for CSS Grid, which gives developers control over layout in two axis. These flex layout classes cover the most common usecases; they should be extended as needed.
 
 ## Basic flex layout
 

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -396,7 +396,7 @@ The available values for `flex-direction`, `flex-wrap`, `flex-grow`, and `flex-s
   ),
   $shrink: (
     '100': 100,
-  ),
+  )
 );
 ```
 
@@ -404,6 +404,9 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/flex' with (
-  $breakpoints: ('m', 'xl'),
+  $breakpoints: (
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/font/font.stories.mdx
+++ b/scss/bitstyles/utilities/font/font.stories.mdx
@@ -6,7 +6,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Set font properties of an element.
 
-By default these classes are not provided at any breakpoints, but see [customization](#customization) for details on how to change that.
+By default these classes are not provided at any breakpoint, but see [customization](#customization) for details on how to change that.
 
 ## Font Weight
 

--- a/scss/bitstyles/utilities/font/font.stories.mdx
+++ b/scss/bitstyles/utilities/font/font.stories.mdx
@@ -6,9 +6,11 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Set font properties of an element.
 
+By default these classes are not provided at any breakpoints, but see [customization](#customization) for details on how to change that.
+
 ## Font Weight
 
-The Nunito font provided has no `light` font-weight, so in the following list you’ll see no difference to `font-normal`.
+Note: the Nunito font provided has no `light` font-weight, so in the following list you’ll see no difference to `font-normal`.
 
 <Canvas isColumn>
   <Story name="font-light">
@@ -69,29 +71,33 @@ Specify font-family on an element. Defaults to the `header` and `body` font-stac
 
 ## Customization
 
-The available font-weights and font-styles can be customized by overriding the `$bitstyles-font-weight-values` and `$bitstyles-font-weight-values` Sass variables respectively:
+The available font-weights and font-styles can be customized by overriding the `$bitstyles-font-weight-values`, `$bitstyles-font-style-values`, and `$bitstyles-font-family-values` Sass maps respectively. Provide the name to be used for the class, and the value for that CSS property:
 
 ```scss
-$bitstyles-font-weight-values: (
-  'light': typography.$font-weight-light,
-  'normal': typography.$font-weight-normal,
-  'medium': typography.$font-weight-medium,
-  'bold': typography.$font-weight-bold,
-);
-$bitstyles-font-style-values: (
-  'italic': italic,
-  'not-italic': normal,
-);
-$bitstyles-font-family-values: (
-  'header': typography.$font-family-header,
-  'body': typography.$font-family-body,
+@use '~bitstyles/scss/bitstyles/utilities/font' with (
+  $weight-values: (
+    'light': typography.$font-weight-light,
+    'normal': typography.$font-weight-normal,
+    'medium': typography.$font-weight-medium,
+    'bold': typography.$font-weight-bold,
+  ),
+  $style-values: (
+    'italic': italic,
+    'not-italic': normal,
+  ),
+  $family-values: (
+    'header': typography.$font-family-header,
+    'body': typography.$font-family-body,
+  ),
 );
 ```
 
-The breakpoints these classes are available at can be customized by overriding the `$bitstyles-font-weight-breakpoints` and ``$bitstyles-font-style-breakpoints` Sass variables respectively:
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-font-weight-breakpoints`, `$bitstyles-font-style-breakpoints`, and `$bitstyles-font-family-breakpoints` Sass lists respectively:
 
 ```scss
-$bitstyles-font-weight-breakpoints: ();
-$bitstyles-font-style-breakpoints: ();
-$bitstyles-font-family-breakpoints: ();
+@use '~bitstyles/scss/bitstyles/utilities/font' with (
+  $bitstyles-font-weight-breakpoints: ('m'),
+  $bitstyles-font-style-breakpoints: ('l'),
+  $bitstyles-font-family-breakpoints: ('s'),
+);
 ```

--- a/scss/bitstyles/utilities/font/font.stories.mdx
+++ b/scss/bitstyles/utilities/font/font.stories.mdx
@@ -88,7 +88,7 @@ The available font-weights and font-styles can be customized by overriding the `
   $family-values: (
     'header': typography.$font-family-header,
     'body': typography.$font-family-body,
-  ),
+  )
 );
 ```
 
@@ -96,8 +96,14 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/font' with (
-  $bitstyles-font-weight-breakpoints: ('m'),
-  $bitstyles-font-style-breakpoints: ('l'),
-  $bitstyles-font-family-breakpoints: ('s'),
+  $bitstyles-font-weight-breakpoints: (
+    'm',
+  ),
+  $bitstyles-font-style-breakpoints: (
+    'l',
+  ),
+  $bitstyles-font-family-breakpoints: (
+    's',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/gap/gap.stories.mdx
+++ b/scss/bitstyles/utilities/gap/gap.stories.mdx
@@ -4,7 +4,9 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Gap
 
-The gap classes specify gaps on your grid elements — space between each grid item, but no space around them (you need to handle the space outside yourself).
+Specify the `gap` property of an element. This applies to flex and grid layouts, though right now the flex version is not as well supported. Use auto-prefixer to ensure the older `grid-gap` version of the property is used in your final CSS.
+
+By default, available sizes are `xs`, `s`, `m`, and `l`, and the classes are available at the `m` and `xl` breakpoints. See the [customization](#customization) section below for details on how to change those settings.
 
 <Canvas>
   <Story name="u-gap-s">
@@ -47,8 +49,6 @@ The gap classes specify gaps on your grid elements — space between each grid i
 
 ### Responsive gaps
 
-Gap classes are available at `m` and `xl` breakpoints using the suffix on the class e.g. `u-gap-l@m`.
-
 <Canvas isColumn>
   <Story name="u-gap-s@m">
     {`
@@ -78,16 +78,24 @@ Gap classes are available at `m` and `xl` breakpoints using the suffix on the cl
 
 ## Customization
 
-Sizes `s`, `m`, and `l` are available by default. This can be customized by overriding `$bitstyles-gap-sizes` e.g.
+The available sizes can be customized by overriding `$bitstyles-gap-sizes`. Provide the name to be used for the class as the key, and the size of gap. Note that if you want to keep the existing values, you’ll need to copy them.
 
 ```scss
-$bitstyles-gap-sizes: (
-  'my-gap-size': 5rem,
+@use '~bitstyles/scss/bitstyles/utilities/gap' with (
+  $sizes: (
+    'xs': size.get('xs'),
+    's': size.get('s'),
+    'm': size.get('l'),
+    'l': size.get('xl'),
+    'xl': 5rem,
+  ),
 );
 ```
 
-The breakpoints these classes are available at can be customised too, by changing the named breakpoints:
+The breakpoints these classes are available at can be customised by overriding `$bitstyles-gap-breakpoints` Sass list:
 
 ```scss
-$bitstyles-gap-breakpoints: ('m', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/gap' with (
+  $bitstyles-gap-breakpoints: ('m', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/gap/gap.stories.mdx
+++ b/scss/bitstyles/utilities/gap/gap.stories.mdx
@@ -88,7 +88,7 @@ The available sizes can be customized by overriding `$bitstyles-gap-sizes`. Prov
     'm': size.get('l'),
     'l': size.get('xl'),
     'xl': 5rem,
-  ),
+  )
 );
 ```
 
@@ -96,6 +96,9 @@ The breakpoints these classes are available at can be customised by overriding `
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/gap' with (
-  $bitstyles-gap-breakpoints: ('m', 'xl'),
+  $bitstyles-gap-breakpoints: (
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
+++ b/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
@@ -4,11 +4,13 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Grid
 
-A responsive CSS grid system. Grids can be nested as much as you need.
+Specify the number of columns on a grid element.
+
+By default grids of `2`, `3`, `4`, and `6` columns are provided, and they are available at the `s`, `m`, `l`, and `xl` breakpoints. See [customization](#customization) for details on how to change those settings.
 
 Giving an element the base class `.u-grid` alone will not create the columns you probably want — see the example below. The grid children have some space between them, but otherwise they behave like block elements.
 
-The grid classes are only rarely used without the [gap](/docs/utilities-gap--u-gap-m) utilities, as you normally want some space between items, and gap achieves that with no mathematics required.
+The grid classes are only rarely used without the [gap](/docs/utilities-gap--u-gap-m) utilities, as you normally want some space between items.
 
 <Canvas>
   <Story name="u-grid">
@@ -142,23 +144,24 @@ Column classes are available at `s`, `m`, and `xl` breakpoints using the suffix 
 
 ## Customization
 
-The available grid column counts can be customized by overriding the `$bitstyles-grid-template-columns` Sass variable. This accepts everything you can use with the CSS `grid-template-columns` property:
+The available grid column counts can be customized by overriding the `$bitstyles-grid-cols-values` Sass map. Provide the name for the class as the key, and the value for the `grid-template-columns` property as the value:
 
 ```scss
-$bitstyles-grid-template-columns: (
-  '2': repeat(2, minmax(0, 1fr)),
-  '3': repeat(3, minmax(0, 1fr)),
-  '4': repeat(4, minmax(0, 1fr)),
-  '6': repeat(6, minmax(0, 1fr)),
-  'magazine': 20rem,
-  1fr,
-  10%,
-  2fr,
+@use '~bitstyles/scss/bitstyles/utilities/grid-cols' with (
+  $values: (
+    '2': repeat(2, minmax(0, 1fr)),
+    '3': repeat(3, minmax(0, 1fr)),
+    '4': repeat(4, minmax(0, 1fr)),
+    '6': repeat(6, minmax(0, 1fr)),
+    'magazine': 20rem, 1fr, 10%, 2fr,
+  ),
 );
 ```
 
-The breakpoints these classes are available at can be customized by overriding the `$bitstyles-grid-template-columns-breakpoints` variable:
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-grid-cols-breakpoints` variable:
 
 ```scss
-$bitstyles-grid-template-columns-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/grid-cols' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
+++ b/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
@@ -153,8 +153,11 @@ The available grid column counts can be customized by overriding the `$bitstyles
     '3': repeat(3, minmax(0, 1fr)),
     '4': repeat(4, minmax(0, 1fr)),
     '6': repeat(6, minmax(0, 1fr)),
-    'magazine': 20rem, 1fr, 10%, 2fr,
-  ),
+    'magazine': 20rem,
+    1fr,
+    10%,
+    2fr,
+  )
 );
 ```
 
@@ -162,6 +165,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/grid-cols' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -185,7 +185,7 @@ Customize the available align-items values by overriding the `$bitstyles-items-v
     'start': flex-start,
     'stretch': stretch,
     'baseline': baseline,
-  ),
+  )
 );
 ```
 
@@ -193,6 +193,8 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/items' with (
-  $breakpoints: ('m'),
+  $breakpoints: (
+    'm',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Utilities/items" />
+<Meta title="Utilities/flex/items" />
+<Meta title="Utilities/grid/items" />
 
 # Align-items
 

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -7,7 +7,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Specify `align-items` property on an element.
 
-Available with `center`, `flex-start`, and `flex-end` values by default, and at the `m` breakpoint. See [customizaiton](#customization) below for details on how change the settings.
+Available with `center`, `flex-start`, and `flex-end` values by default, and at the `m` breakpoint. See [customization](#customization) below for details on how change the settings.
 
 Flex and Grid share many alignment properties. The `item` classes will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
 

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -1,7 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-<Meta title="Utilities/flex/items" />
-<Meta title="Utilities/grid/items" />
+<Meta title="Utilities/flex" />
 
 # Align-items
 

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -5,7 +5,11 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Align-items
 
-Flex and Grid share many alignment properties. These will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
+Specify `align-items` property on an element.
+
+Available with `center`, `flex-start`, and `flex-end` values by default, and at the `m` breakpoint. See [customizaiton](#customization) below for details on how change the settings.
+
+Flex and Grid share many alignment properties. The `item` classes will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
 
 The `u-items-` classes set `align-items` to the respective direction(s) on the main axis (`center`, `flex-start`, `flex-end`):
 
@@ -171,20 +175,24 @@ These classes are all available at the `m` breakpoint.
 
 ## Customization
 
-The available align-items values can be customized by overriding the `$bitstyles-items` Sass variable:
+Customize the available align-items values by overriding the `$bitstyles-items-values` Sass map. Provide the name to be used for the class as the key, and the favlue for the `align-items` property:
 
 ```scss
-$bitstyles-items: (
-  'center': center,
-  'end': flex-end,
-  'start': flex-start,
-  'stretch': stretch,
-  'baseline': baseline,
+@use '~bitstyles/scss/bitstyles/utilities/items' with (
+  $values: (
+    'center': center,
+    'end': flex-end,
+    'start': flex-start,
+    'stretch': stretch,
+    'baseline': baseline,
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-items-breakpoints` variable:
 
 ```scss
-$bitstyles-items-breakpoints: ('m');
+@use '~bitstyles/scss/bitstyles/utilities/items' with (
+  $breakpoints: ('m'),
+);
 ```

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -4,6 +4,10 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Justify
 
+Specify `justify-content` property on an element.
+
+Available with `between`, `start`, and `end` values by default, and at the `m` breakpoint. See [customizaiton](#customization) below for details on how change the settings.
+
 Flex and Grid share many alignment properties. These will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
 
 The `u-justify-` classes set set `justify-content` to align flex children to the respective different edges on the cross-axis. This only affects layout when the combined elements are smaller than the available cross-axis:
@@ -92,18 +96,22 @@ These classes are available at the `m` breakpoint.
 
 ## Customization
 
-The available justify-content values can be customized by overriding the `$bitstyles-justify` Sass variable:
+Customize the available justify-content values by overriding the `$bitstyles-justify-values` Sass map. Provide the name to be used for the class as the key, and the favlue for the `justify-content` property:
 
 ```scss
-$bitstyles-justify: (
-  'between': space-between,
-  'end': flex-end,
-  'start': flex-start,
+@use '~bitstyles/scss/bitstyles/utilities/justify' with (
+  $values: (
+    'between': space-between,
+    'end': flex-end,
+    'start': flex-start,
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-justify-breakpoints` variable:
 
 ```scss
-$bitstyles-justify-breakpoints: ('m');
+@use '~bitstyles/scss/bitstyles/utilities/justify' with (
+  $breakpoints: ('m'),
+);
 ```

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -6,7 +6,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Specify `justify-content` property on an element.
 
-Available with `between`, `start`, and `end` values by default, and at the `m` breakpoint. See [customizaiton](#customization) below for details on how change the settings.
+Available with `between`, `start`, and `end` values by default, and at the `m` breakpoint. See [customization](#customization) below for details on how change the settings.
 
 Flex and Grid share many alignment properties. These will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
 

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -104,7 +104,7 @@ Customize the available justify-content values by overriding the `$bitstyles-jus
     'between': space-between,
     'end': flex-end,
     'start': flex-start,
-  ),
+  )
 );
 ```
 
@@ -112,6 +112,8 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/justify' with (
-  $breakpoints: ('m'),
+  $breakpoints: (
+    'm',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/margin/margin.stories.mdx
+++ b/scss/bitstyles/utilities/margin/margin.stories.mdx
@@ -6,30 +6,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Apply margins of a specified size and direction to an element.
 
-With default configuration, the margins are available in sizes `0`, `xxs`, `xs`, `s`, `m`, `l`, `xl`, with negative-margin variations of each. This can be configured by overriding `$bitstyles-margin-sizes` e.g.
-
-```scss
-$bitstyles-margin-sizes: (
-  'positive': (
-    '0': 0,
-    'xxs': size.get('xxs'),
-    'xs': size.get('xs'),
-    's': size.get('s'),
-    'm': size.get('m'),
-    'l': size.get('l'),
-    'xl': size.get('xl'),
-    'auto': auto,
-  ),
-  'negative': (
-    'xxs': -#{size.get('xxs')},
-    'xs': -#{size.get('xs')},
-    's': -#{size.get('s')},
-    'm': -#{size.get('m')},
-    'l': -#{size.get('l')},
-    'xl': -#{size.get('xl')},
-  ),
-);
-```
+With default configuration, the margins are available in sizes `0`, `xxs`, `xs`, `s`, `m`, `l`, `xl`, with negative-margin variations of each. They are provided at the `s` and `m` breakpoints. See [customization](#customization) below for details on how to change that.
 
 ## Margin sizes
 
@@ -143,36 +120,6 @@ $bitstyles-margin-sizes: (
 
 Every margin size (negative and positive) is also available directed at the single sides `top`, `right`, `bottom`, `left`, and the double directions `x` and `y`.
 
-This can be customised by overriding `$bitstyles-margin-directions` e.g.
-
-```scss
-$bitstyles-margin-directions: (
-  '': null,
-  'top': (
-    'top',
-  ),
-  'right': (
-    'right',
-  ),
-  'bottom': (
-    'bottom',
-  ),
-  'left': (
-    'left',
-  ),
-  'x': (
-    'right',
-    'left',
-  ),
-  'y': (
-    'top',
-    'bottom',
-  ),
-);
-```
-
-The `'': null` entry is needed to render the margin classes with no directional modifiers.
-
 <Canvas>
   <Story id="utilities-margin--margin-xl" />
   <Story name="margin-xl-top">
@@ -221,13 +168,7 @@ The `'': null` entry is needed to render the margin classes with no directional 
 
 ## Responsive margins
 
-All the margins are also available at the `@s` and `@m` breakpoint suffixes. To customise this, override `$bitstyles-margin-breakpoints` e.g.
-
-```scss
-$bitstyles-margin-breakpoints: ('s', 'm');
-```
-
-If you remove `base`, margin classes will not be output without a breakpoint.
+All the margins are also available at the `@s` and `@m` breakpoint suffixes.
 
 <Canvas>
   <Story name="margin-xl@s">
@@ -245,3 +186,57 @@ If you remove `base`, margin classes will not be output without a breakpoint.
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+Available margin-sizes can be configured by overriding the `$bitstyles-margin-sizes` Sass map. Provide the name to be used for the class as the key, and the value for the property as the value. If you want to keey the existing values, you’ll need to copy the default configuration as you cannot merge or update the existing map.
+
+The `positive` and `negative` keys are required for each group you want to define (e.g. if you have no negative margins, that key is not required).
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/margin' with (
+  $bitstyles-margin-sizes: (
+    'positive': (
+      '0': 0,
+      'xxs': size.get('xxs'),
+      'xs': size.get('xs'),
+      's': size.get('s'),
+      'm': size.get('m'),
+      'l': size.get('l'),
+      'xl': size.get('xl'),
+      'auto': auto,
+    ),
+    'negative': (
+      'xxs': -#{size.get('xxs')},
+      'xs': -#{size.get('xs')},
+      's': -#{size.get('s')},
+      'm': -#{size.get('m')},
+      'l': -#{size.get('l')},
+      'xl': -#{size.get('xl')},
+    ),
+  )
+);
+```
+
+To customise the breakpoints these classes are available at, override `$bitstyles-margin-breakpoints` e.g.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/margin' with (
+  $breakpoints: ('s', 'm'),
+);
+```
+
+Directions can be customised by overriding the `$bitstyles-margin-directions` Sass map. Provide the name for the direction as the key, and the list of directions. Note that if you want to keep the existing directions, you’ll need to copy the existing configurations — the map cannot be updated, only overrwritten.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/margin' with (
+  $directions: (
+    '': null,
+    'top-and-right': (
+      'top', 'right',
+    ),
+  ),
+);
+```
+
+The `'': null` entry is needed to render the margin classes with no directional modifiers e.g. `u-margin-m`, `u-margin-l`.

--- a/scss/bitstyles/utilities/margin/margin.stories.mdx
+++ b/scss/bitstyles/utilities/margin/margin.stories.mdx
@@ -222,7 +222,10 @@ To customise the breakpoints these classes are available at, override `$bitstyle
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/margin' with (
-  $breakpoints: ('s', 'm'),
+  $breakpoints: (
+    's',
+    'm',
+  )
 );
 ```
 
@@ -233,9 +236,10 @@ Directions can be customised by overriding the `$bitstyles-margin-directions` Sa
   $directions: (
     '': null,
     'top-and-right': (
-      'top', 'right',
+      'top',
+      'right',
     ),
-  ),
+  )
 );
 ```
 

--- a/scss/bitstyles/utilities/margin/margin.stories.mdx
+++ b/scss/bitstyles/utilities/margin/margin.stories.mdx
@@ -71,6 +71,8 @@ With default configuration, the margins are available in sizes `0`, `xxs`, `xs`,
 
 ## Negative margin sizes
 
+Apply the prefix `neg` to the margin size to apply the negative version of the margin.
+
 <Canvas>
   <Story name="margin-neg-xxs">
     {`

--- a/scss/bitstyles/utilities/margin/margin.stories.mdx
+++ b/scss/bitstyles/utilities/margin/margin.stories.mdx
@@ -231,7 +231,7 @@ To customise the breakpoints these classes are available at, override `$bitstyle
 );
 ```
 
-Directions can be customised by overriding the `$bitstyles-margin-directions` Sass map. Provide the name for the direction as the key, and the list of directions. Note that if you want to keep the existing directions, you’ll need to copy the existing configurations — the map cannot be updated, only overrwritten.
+Directions can be customised by overriding the `$bitstyles-margin-directions` Sass map. Provide the name for the direction as the key, and the list of directions. Note that if you want to keep the existing directions, you’ll need to copy the existing configurations — the map cannot be updated, only overwritten.
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/margin' with (

--- a/scss/bitstyles/utilities/overflow/overflow.stories.mdx
+++ b/scss/bitstyles/utilities/overflow/overflow.stories.mdx
@@ -66,6 +66,6 @@ Available overflow values can be customized by overriding the `$bitstyles-overfl
     'overflow-y': (
       'hidden': hidden,
     ),
-  ),
+  )
 );
 ```

--- a/scss/bitstyles/utilities/overflow/overflow.stories.mdx
+++ b/scss/bitstyles/utilities/overflow/overflow.stories.mdx
@@ -4,6 +4,10 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Overflow
 
+Specify the `overflow` property on an element.
+
+By default `hidden`, `auto`, and `scroll` values are available, at all directions, x, and y. See the [customization](#customization) section for details on how to change that.
+
 <Canvas>
   <Story name="u-overflow-hidden">
     {`
@@ -48,3 +52,20 @@ Commonly we want to limit the height or width of an element, and allow scrolling
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+Available overflow values can be customized by overriding the `$bitstyles-overflow-values` Sass list. Provide the name for the class and the property as the key, and a Sass map of classname/property value pairs.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/overflow' with (
+  $values: (
+    'overflow': (
+      'hidden': hidden,
+    ),
+    'overflow-y': (
+      'hidden': hidden,
+    ),
+  ),
+);
+```

--- a/scss/bitstyles/utilities/padding/_index.scss
+++ b/scss/bitstyles/utilities/padding/_index.scss
@@ -7,7 +7,7 @@
 @include properties.output-directional(
   $property-name: 'padding',
   $classname-root: 'padding',
-  $values: map.get(settings.$sizes, 'positive'),
+  $values: settings.$sizes,
   $directions: settings.$directions
 );
 
@@ -16,7 +16,7 @@
     @include properties.output-directional(
       $property-name: 'padding',
       $classname-root: 'padding',
-      $values: map.get(settings.$sizes, 'positive'),
+      $values: settings.$sizes,
       $directions: settings.$directions,
       $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
     );

--- a/scss/bitstyles/utilities/padding/_settings.scss
+++ b/scss/bitstyles/utilities/padding/_settings.scss
@@ -1,16 +1,14 @@
 @use '../../tools/size';
 
 $sizes: (
-  'positive': (
-    '0': 0,
-    'xxs': size.get('xxs'),
-    'xs': size.get('xs'),
-    's': size.get('s'),
-    'm': size.get('m'),
-    'l': size.get('l'),
-    'xl': size.get('xl'),
-    'xxl': size.get('xxl'),
-  ),
+  '0': 0,
+  'xxs': size.get('xxs'),
+  'xs': size.get('xs'),
+  's': size.get('s'),
+  'm': size.get('m'),
+  'l': size.get('l'),
+  'xl': size.get('xl'),
+  'xxl': size.get('xxl'),
 ) !default;
 $breakpoints: ('m', 'l') !default;
 $directions: (

--- a/scss/bitstyles/utilities/padding/padding.stories.mdx
+++ b/scss/bitstyles/utilities/padding/padding.stories.mdx
@@ -147,7 +147,7 @@ The available sizes can be configured by overriding `$bitstyles-padding-sizes` S
     'l': size.get('l'),
     'xl': size.get('xl'),
     'xxl': size.get('xl'),
-  ),
+  )
 );
 ```
 

--- a/scss/bitstyles/utilities/padding/padding.stories.mdx
+++ b/scss/bitstyles/utilities/padding/padding.stories.mdx
@@ -6,21 +6,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Apply padding of a specified size and direction to an element.
 
-With default configuration, the padding classes are available in sizes `0`, `xs`, `s`, `m`, `l`, `xl`, `xxl`. This can be configured by overriding `$bitstyles-padding-sizes` e.g.
-
-```scss
-$bitstyles-padding-sizes: (
-  'positive': (
-    '0': 0,
-    'xs': size.get('xs'),
-    's': size.get('s'),
-    'm': size.get('m'),
-    'l': size.get('l'),
-    'xl': size.get('xl'),
-    'xxl': size.get('xl'),
-  ),
-);
-```
+With default configuration, the padding classes are available in sizes `0`, `xs`, `s`, `m`, `l`, `xl`, `xxl`, and at the `m` and `l` breakpoints.
 
 ## Padding sizes
 
@@ -80,36 +66,6 @@ $bitstyles-padding-sizes: (
 
 Every padding size is also available directed at the single sides `top`, `right`, `bottom`, `left`, and the double directions `x` and `y`.
 
-This can be customised by overriding `$bitstyles-padding-directions` e.g.
-
-```scss
-$bitstyles-padding-directions: (
-  '': null,
-  'top': (
-    'top',
-  ),
-  'right': (
-    'right',
-  ),
-  'bottom': (
-    'bottom',
-  ),
-  'left': (
-    'left',
-  ),
-  'x': (
-    'right',
-    'left',
-  ),
-  'y': (
-    'top',
-    'bottom',
-  ),
-);
-```
-
-The `'': null` entry is needed to render the padding classes with no directional modifiers.
-
 <Canvas>
   <Story id="utilities-padding--padding-xl" />
   <Story name="padding-xl-top">
@@ -158,13 +114,7 @@ The `'': null` entry is needed to render the padding classes with no directional
 
 ## Responsive padding
 
-All the padding classes are also available at the `@m` and `@l` breakpoint suffixes. To customise this, override `$bitstyles-padding-breakpoints` e.g.
-
-```scss
-$bitstyles-padding-breakpoints: ('m', 'l');
-```
-
-If you remove `base`, padding classes will not be output without a breakpoint.
+All the padding classes are also available at the `@m` and `@l` breakpoint suffixes.
 
 <Canvas>
   <Story name="padding-xl@m">
@@ -182,3 +132,44 @@ If you remove `base`, padding classes will not be output without a breakpoint.
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The available sizes can be configured by overriding `$bitstyles-padding-sizes` Sass map, providing the classname as the key, and the size as value:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/padding' with (
+  $sizes: (
+    '0': 0,
+    'xs': size.get('xs'),
+    's': size.get('s'),
+    'm': size.get('m'),
+    'l': size.get('l'),
+    'xl': size.get('xl'),
+    'xxl': size.get('xl'),
+  ),
+);
+```
+
+The directions can be customised by overriding `$bitstyles-padding-directions`. Provide the name of the class as the key, and a list of directions to apply the padding to. You’ll need to copy in the default directions if you want to keep those values.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/padding' with (
+  $directions: (
+    '': null,
+    'top-and-right': (
+      'top', 'right',
+    )
+  ),
+);
+```
+
+The `'': null` entry is needed to render the padding classes with no directional modifiers.
+
+To customise the breakpoints these classes are all available at, override `$bitstyles-padding-breakpoints` with a list of the breakpoint names from the global settings.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/padding' with (
+  $breakpoints: ('m', 'l'),
+);
+```

--- a/scss/bitstyles/utilities/padding/padding.stories.mdx
+++ b/scss/bitstyles/utilities/padding/padding.stories.mdx
@@ -158,9 +158,10 @@ The directions can be customised by overriding `$bitstyles-padding-directions`. 
   $directions: (
     '': null,
     'top-and-right': (
-      'top', 'right',
-    )
-  ),
+      'top',
+      'right',
+    ),
+  )
 );
 ```
 
@@ -170,6 +171,9 @@ To customise the breakpoints these classes are all available at, override `$bits
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/padding' with (
-  $breakpoints: ('m', 'l'),
+  $breakpoints: (
+    'm',
+    'l',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/row-start/row-start.stories.mdx
+++ b/scss/bitstyles/utilities/row-start/row-start.stories.mdx
@@ -4,7 +4,9 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Row-start
 
-Use these classes to specify which row an element should start in.
+Specify which row an element should start in.
+
+By default, rows `1`, `2`, `3`, `4`, `5`, and `6` are available. These classes can be applied at `s`, `m`, `xl` breakpoints. See [customization](#customization) if you need to change that configuration.
 
 It’s common to use `.u-row-start-1` to force an element to be placed in the first row even if it follows another grid-item that’s been placed at the end of that row (so they are both placed in the first row despite their source-order).
 
@@ -128,21 +130,25 @@ The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 
 ## Customization
 
-The available start rows can be customized by overriding the `$bitstyles-row-start` Sass variable:
+The available start rows can be customized by overriding the `$bitstyles-row-start-values` Sass map. Provide the classname as the key, and the value to be used as the property value.
 
 ```scss
-$bitstyles-row-start: (
-  '1': 1,
-  '2': 2,
-  '3': 3,
-  '4': 4,
-  '5': 5,
-  '6': 6,
+@use '~bitstyles/scss/bitstyles/utilities/row-start' with (
+  $values: (
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6,
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-row-start-breakpoints` variable:
 
 ```scss
-$bitstyles-row-start-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/row-start' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/row-start/row-start.stories.mdx
+++ b/scss/bitstyles/utilities/row-start/row-start.stories.mdx
@@ -141,7 +141,7 @@ The available start rows can be customized by overriding the `$bitstyles-row-sta
     '4': 4,
     '5': 5,
     '6': 6,
-  ),
+  )
 );
 ```
 
@@ -149,6 +149,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/row-start' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/self/self.stories.mdx
+++ b/scss/bitstyles/utilities/self/self.stories.mdx
@@ -4,6 +4,10 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Align-self
 
+Specify the `align-self` property of an element.
+
+The `flex-end` value is provided with default configuration, and is also available at the `m` breakpoint. See [customization](#customization) for details on how to change that.
+
 Flex and Grid share many alignment properties. These will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
 
 ## End
@@ -58,16 +62,20 @@ The classes are available at the `m` breakpoint.
 
 ## Customization
 
-The available align-self values can be customized by overriding the `$bitstyles-self` Sass variable:
+The available align-self values can be customized by overriding the `$bitstyles-self-values` Sass map. Provide the classname as the key, and the property value:
 
 ```scss
-$bitstyles-self: (
-  'end': flex-end,
+@use '~bitstyles/scss/bitstyles/utilities/self' with (
+  $values: (
+    'end': flex-end,
+  ),
 );
 ```
 
 The breakpoints these classes are available at can be customized by overriding the `$bitstyles-self-breakpoints` variable:
 
 ```scss
-$bitstyles-self-breakpoints: ('m');
+@use '~bitstyles/scss/bitstyles/utilities/self' with (
+  $breakpoints: ('m'),
+);
 ```

--- a/scss/bitstyles/utilities/self/self.stories.mdx
+++ b/scss/bitstyles/utilities/self/self.stories.mdx
@@ -68,7 +68,7 @@ The available align-self values can be customized by overriding the `$bitstyles-
 @use '~bitstyles/scss/bitstyles/utilities/self' with (
   $values: (
     'end': flex-end,
-  ),
+  )
 );
 ```
 
@@ -76,6 +76,8 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/self' with (
-  $breakpoints: ('m'),
+  $breakpoints: (
+    'm',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/sr-only/sr-only.stories.mdx
+++ b/scss/bitstyles/utilities/sr-only/sr-only.stories.mdx
@@ -6,9 +6,9 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 ## Hide an element visually, while leaving it readable & accessible by search engines & screenreaders
 
-Use this to give more complete & understandable labels for UI and to help explain connections between content that may otherwise only be visually apparent e.g. visually display only 'next' on a button, but use `.u-sr-only` to hide a span containing a more descriptive or specific label (see the markup below).
+Use this to give more complete & understandable labels for UI and to help explain connections between content that may otherwise only be visually apparent e.g. visually display only “next” on a button, but use `.u-sr-only` to hide a span containing a more descriptive or specific label (see the markup below).
 
-Available at every breakpoint set in `$bitstyles-sr-only-breakpoints`.
+Available at no breakpoints by default, see [customization](#customization) for details on how to change that.
 
 <Canvas>
   <Story name="sr-only">
@@ -20,3 +20,13 @@ Available at every breakpoint set in `$bitstyles-sr-only-breakpoints`.
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+The class can be made available at various breakpoints by overriding the `$bitstyles-sr-only-breakpoints` Sass list, and including the names of breakpoints from the global breakpoints list:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/sr-only' with (
+  $breakpoints: ('m'),
+);
+```

--- a/scss/bitstyles/utilities/sr-only/sr-only.stories.mdx
+++ b/scss/bitstyles/utilities/sr-only/sr-only.stories.mdx
@@ -27,6 +27,8 @@ The class can be made available at various breakpoints by overriding the `$bitst
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/sr-only' with (
-  $breakpoints: ('m'),
+  $breakpoints: (
+    'm',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/text/text.stories.mdx
+++ b/scss/bitstyles/utilities/text/text.stories.mdx
@@ -48,7 +48,7 @@ The available text-align values can be customized by overriding the `$bitstyles-
     'right': right,
     'center': center,
     'justify': justify,
-  ),
+  )
 );
 ```
 
@@ -56,6 +56,8 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/text' with (
-  $breakpoints: ('m'),
+  $breakpoints: (
+    'm',
+  )
 );
 ```

--- a/scss/bitstyles/utilities/text/text.stories.mdx
+++ b/scss/bitstyles/utilities/text/text.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Text
 
-Set text-align properties on an element. Default values available are: `left`, `right`, `center`, and `justify`. These classes are not available at any breakpoints by default. See the [customization](#customization) section for details on how to change the configuration.
+Set text-align properties on an element. Default values available are: `left`, `right`, `center`, and `justify`. These classes are not available at any breakpoint by default. See the [customization](#customization) section for details on how to change the configuration.
 
 <Canvas isColumn>
   <Story name="u-text-left">

--- a/scss/bitstyles/utilities/text/text.stories.mdx
+++ b/scss/bitstyles/utilities/text/text.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Text
 
-Set text-align properties on an element.
+Set text-align properties on an element. Default values available are: `left`, `right`, `center`, and `justify`. These classes are not available at any breakpoints by default. See the [customization](#customization) section for details on how to change the configuration.
 
 <Canvas isColumn>
   <Story name="u-text-left">
@@ -42,16 +42,20 @@ Set text-align properties on an element.
 The available text-align values can be customized by overriding the `$bitstyles-text-values` Sass variable:
 
 ```scss
-$bitstyles-text-values: (
-  'left': left,
-  'right': right,
-  'center': center,
-  'justify': justify,
+@use '~bitstyles/scss/bitstyles/utilities/text' with (
+  $values: (
+    'left': left,
+    'right': right,
+    'center': center,
+    'justify': justify,
+  ),
 );
 ```
 
-The breakpoints these classes are available at can be customized by overriding the `$bitstyles-text-breakpoints` variable:
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-text-breakpoints` list, providing the names of the breakpoints from the global breakpoints list.
 
 ```scss
-$bitstyles-text-breakpoints: ('m');
+@use '~bitstyles/scss/bitstyles/utilities/text' with (
+  $breakpoints: ('m'),
+);
 ```

--- a/scss/bitstyles/utilities/z-index/z-index.stories.mdx
+++ b/scss/bitstyles/utilities/z-index/z-index.stories.mdx
@@ -4,7 +4,11 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Z (z-index)
 
-Sets the z-index. By default, only `.u-z-1` is available. Note that you need to set a position other than the default `static` (probably either using `u-relative`, or by using component-level custom CSS to set `position: absolute`, `sticky`, or `fixed`), as otherwise CSS `z-index` has no effect.
+Sets the z-index property.
+
+By default, only `.u-z-1` is available. Note that you need to set a position other than the default `static` (probably either using `u-relative`, or by using component-level custom CSS to set `position: absolute`, `sticky`, or `fixed`), as otherwise CSS `z-index` has no effect.
+
+Not available at any breakpoints when using the default configuration. See [customization](#customization) for details on how to change the configuration.
 
 <Canvas>
   <Story name="z">
@@ -16,17 +20,21 @@ Sets the z-index. By default, only `.u-z-1` is available. Note that you need to 
 
 ## Customization
 
-The available z-indexes can be customized by overriding the `$bitstyles-z-index` variable:
+The available z-indexes can be customized by overriding the `$bitstyles-z-index-values` map. Provide the name to be used for the class as the key, and the value:
 
 ```scss
-$bitstyles-z-index: (
-  '1': 1,
-  'modal': 10,
+@use '~bitstyles/scss/bitstyles/utilities/z-index' with (
+  $values: (
+    '1': 1,
+    'modal': 10,
+  ),
 );
 ```
 
-The breakpoints these classes are available at can be customized by overriding the `$bitstyles-z-index-breakpoints` variable:
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-z-index-breakpoints` list, providing the names of breakpoints from the global list of breakpoints:
 
 ```scss
-$bitstyles-z-index-breakpoints: ('s', 'm', 'xl');
+@use '~bitstyles/scss/bitstyles/utilities/z-index' with (
+  $breakpoints: ('s', 'm', 'xl'),
+);
 ```

--- a/scss/bitstyles/utilities/z-index/z-index.stories.mdx
+++ b/scss/bitstyles/utilities/z-index/z-index.stories.mdx
@@ -8,7 +8,7 @@ Sets the z-index property.
 
 By default, only `.u-z-1` is available. Note that you need to set a position other than the default `static` (probably either using `u-relative`, or by using component-level custom CSS to set `position: absolute`, `sticky`, or `fixed`), as otherwise CSS `z-index` has no effect.
 
-Not available at any breakpoints when using the default configuration. See [customization](#customization) for details on how to change the configuration.
+Not available at any breakpoint when using the default configuration. See [customization](#customization) for details on how to change the configuration.  
 
 <Canvas>
   <Story name="z">

--- a/scss/bitstyles/utilities/z-index/z-index.stories.mdx
+++ b/scss/bitstyles/utilities/z-index/z-index.stories.mdx
@@ -8,7 +8,7 @@ Sets the z-index property.
 
 By default, only `.u-z-1` is available. Note that you need to set a position other than the default `static` (probably either using `u-relative`, or by using component-level custom CSS to set `position: absolute`, `sticky`, or `fixed`), as otherwise CSS `z-index` has no effect.
 
-Not available at any breakpoint when using the default configuration. See [customization](#customization) for details on how to change the configuration.  
+Not available at any breakpoint when using the default configuration. See [customization](#customization) for details on how to change the configuration.
 
 <Canvas>
   <Story name="z">

--- a/scss/bitstyles/utilities/z-index/z-index.stories.mdx
+++ b/scss/bitstyles/utilities/z-index/z-index.stories.mdx
@@ -27,7 +27,7 @@ The available z-indexes can be customized by overriding the `$bitstyles-z-index-
   $values: (
     '1': 1,
     'modal': 10,
-  ),
+  )
 );
 ```
 
@@ -35,6 +35,10 @@ The breakpoints these classes are available at can be customized by overriding t
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/z-index' with (
-  $breakpoints: ('s', 'm', 'xl'),
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
 );
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -11060,6 +11060,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
 uglify-js@^3.1.4:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.1.tgz#9403dc6fa5695a6172a91bc983ea39f0f7c9086d"


### PR DESCRIPTION
Fixes #487 

The following changes are contained in this pull request:

Updates docs, and provides customisation guides for utility classes:

- aspect-ratios
- bg 
- border
- box-shadow
- col-span
- col-start
- display
- drop-shadow
- fg
- flex
- items
- font
- gap
- grid-cols
- items
- justify
- margin
- overflow
- items
- justify
- padding
- row-start
- self
- sr-only
- text
- z-index

Also drive-by:

- remove the `positive` key from padding class, it doesn’t make sense as `negative` can never be used
- Updates storybook, as the build was failing due to webpack & post-css versions not handling `:exports` directive. That added the eslint-storybook plugin, and updated to better handle webpack v5 (which we need for the colors exports to work)

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
