### PR TITLE
[#634] Add utility: min-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Configuration of the border-radius utility class is now possible: `$bitstyles-border-radius-values`, `$bitstyles-border-radius-breakpoints`, `$bitstyles-border-radius-directions`
 - New `u-min-height` utility class
 - `u-height` utility class is now configurable using `$bitstyles-height-values` and `$bitstyles-height-breakpoints`
+- New `u-min-width` utility class
 
 ### Breaking
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -96,6 +96,7 @@
 @forward 'bitstyles/utilities/line-height' as line-height-*;
 @forward 'bitstyles/utilities/margin' as margin-*;
 @forward 'bitstyles/utilities/min-height' as min-height-*;
+@forward 'bitstyles/utilities/min-width' as min-width-*;
 @forward 'bitstyles/utilities/object-cover' as object-cover-*;
 @forward 'bitstyles/utilities/outline' as outline-*;
 @forward 'bitstyles/utilities/overflow' as overflow-*;

--- a/scss/bitstyles/utilities/min-height/_index.scss
+++ b/scss/bitstyles/utilities/min-height/_index.scss
@@ -1,6 +1,7 @@
 @forward './settings';
 @use './settings';
 @use '../../tools/properties';
+@use '../../tools/media-query';
 
 @include properties.output(
   $property-name: 'min-height',
@@ -9,9 +10,12 @@
 );
 
 @each $breakpoint-alias in settings.$breakpoints {
-  @include properties.output(
-    $property-name: 'min-height',
-    $classname-root: 'min-height',
-    $values: settings.$values
-  );
+  @include media-query.get($breakpoint-alias) {
+    @include properties.output(
+      $property-name: 'min-height',
+      $classname-root: 'min-height',
+      $values: settings.$values,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+  }
 }

--- a/scss/bitstyles/utilities/min-width/_index.import.scss
+++ b/scss/bitstyles/utilities/min-width/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-min-width-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/min-width/_index.scss
+++ b/scss/bitstyles/utilities/min-width/_index.scss
@@ -1,6 +1,7 @@
 @forward './settings';
 @use './settings';
 @use '../../tools/properties';
+@use '../../tools/media-query';
 
 @include properties.output(
   $property-name: 'min-width',
@@ -9,9 +10,12 @@
 );
 
 @each $breakpoint-alias in settings.$breakpoints {
-  @include properties.output(
-    $property-name: 'min-width',
-    $classname-root: 'min-width',
-    $values: settings.$values
-  );
+  @include media-query.get($breakpoint-alias) {
+    @include properties.output(
+      $property-name: 'min-width',
+      $classname-root: 'min-width',
+      $values: settings.$values,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+  }
 }

--- a/scss/bitstyles/utilities/min-width/_index.scss
+++ b/scss/bitstyles/utilities/min-width/_index.scss
@@ -1,0 +1,17 @@
+@forward './settings';
+@use './settings';
+@use '../../tools/properties';
+
+@include properties.output(
+  $property-name: 'min-width',
+  $classname-root: 'min-width',
+  $values: settings.$values
+);
+
+@each $breakpoint-alias in settings.$breakpoints {
+  @include properties.output(
+    $property-name: 'min-width',
+    $classname-root: 'min-width',
+    $values: settings.$values
+  );
+}

--- a/scss/bitstyles/utilities/min-width/_settings.scss
+++ b/scss/bitstyles/utilities/min-width/_settings.scss
@@ -1,0 +1,4 @@
+$values: (
+  '0': 0,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/min-width/min-width.stories.mdx
+++ b/scss/bitstyles/utilities/min-width/min-width.stories.mdx
@@ -1,0 +1,37 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/min-width" />
+
+# min-width
+
+Specify the `min-width` property of an element. Default configuration provides `min-width: 0` with no breakpoint variations. See [customization](#customization) for details on how to change that.
+
+<Canvas>
+  <Story name="u-min-width-0">
+    {`
+      <div class="u-min-width-0">u-min-width-0</div>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+Customize the available min-width by overriding the `$bitstyles-min-width-values` Sass map, providing the name to be used for the class, and the value to use.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/min-width' with (
+  $values: (
+    '10rem': 10rem,
+  )
+);
+```
+
+Available breakpoint variables can be specified by overriding the `$bitstyles-min-width-breakpoints` Sass list, providing a list of names of breakpoints taken from the global breakpoint list:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/min-width' with (
+  $breakpoints: (
+    'm',
+  )
+);
+```

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -2855,6 +2855,9 @@ table {
 .bs-u-min-height-1em {
   min-height: 1em;
 }
+.bs-u-min-width-0 {
+  min-width: 0;
+}
 .bsu-object-cover {
   display: block;
   height: 100%;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -2855,8 +2855,8 @@ table {
 .bs-u-min-height-1em {
   min-height: 1em;
 }
-.bs-u-min-width-0 {
-  min-width: 0;
+.bs-u-min-width-1em {
+  min-width: 1em;
 }
 .bsu-object-cover {
   display: block;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -3260,6 +3260,9 @@ table {
   min-height: -moz-available;
   min-height: stretch;
 }
+.u-min-width-0 {
+  min-width: 0;
+}
 .u-object-cover {
   display: block;
   height: 100%;

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -194,6 +194,9 @@ $bitstyles-margin-breakpoints: ('xl', 's');
 $bitstyles-min-height-values: (
   '1em': 1em,
 );
+$bitstyles-min-width-values: (
+  '1em': 1em,
+);
 $bitstyles-overflow-values: (
   'overflow': (
     'hidden': hidden,

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -194,6 +194,9 @@ $bitstyles-margin-breakpoints: ('xl', 's');
 $bitstyles-min-height-values: (
   '1em': 1em,
 );
+$bitstyles-min-width-values: (
+  '1em': 1em,
+);
 $bitstyles-overflow-values: (
   'overflow': (
     'hidden': hidden,
@@ -308,6 +311,7 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/utilities/line-height';
 @import '../../scss/bitstyles/utilities/margin';
 @import '../../scss/bitstyles/utilities/min-height';
+@import '../../scss/bitstyles/utilities/min-width';
 @import '../../scss/bitstyles/utilities/object-cover';
 @import '../../scss/bitstyles/utilities/outline';
 @import '../../scss/bitstyles/utilities/overflow';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -139,6 +139,7 @@
   $justify-values: ('start': start),
   $margin-breakpoints: ('xl', 's'),
   $min-height-values: ('1em': 1em),
+  $min-width-values: ('1em': 1em),
   $overflow-values: (
     'overflow': (
       'hidden': hidden,

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -330,6 +330,11 @@
     '1em': 1em,
   )
 );
+@use '../../scss/bitstyles/utilities/min-width' with (
+  $values: (
+    '1em': 1em,
+  )
+);
 @use '../../scss/bitstyles/utilities/object-cover';
 @use '../../scss/bitstyles/utilities/outline';
 @use '../../scss/bitstyles/utilities/overflow' with (


### PR DESCRIPTION
Fixes #634 

## Changes

- Adds a min-width utility class, with just `0` and no breakpoints as the default configuration

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
