### PR TITLE
[#641] Add utility: inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Adds utility classes for specifying inset — top/right/bottom/left CSS properties. Defaults to just classes specifying `0` for each, customizable using `$bitstyles-inset-values`, `$bitstyles-inset-directions`, and `$bitstyles-inset-breakpoints`
+
+### Breaking
+
+- `properties.get-classname()` has been renamed to `properties.join-with-dashes()` to reflect its more generic usage. The list of strings passed as a parameter is renamed from `$classname-items` to `$string-items`. If you were using this function, rename the function call and the parameter (if using named parameters in your call)
+
 ## [[4.2.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v4.2.0) - 2022-02-09
 
 ### Added

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -92,6 +92,7 @@
 @forward 'bitstyles/utilities/gap' as gap-*;
 @forward 'bitstyles/utilities/grid-cols' as grid-cols-*;
 @forward 'bitstyles/utilities/height' as height-*;
+@forward 'bitstyles/utilities/inset' as inset-*;
 @forward 'bitstyles/utilities/items' as items-*;
 @forward 'bitstyles/utilities/justify' as justify-*;
 @forward 'bitstyles/utilities/line-height' as line-height-*;

--- a/scss/bitstyles/tools/_properties.scss
+++ b/scss/bitstyles/tools/_properties.scss
@@ -25,14 +25,14 @@
  *
  * @param $classname-items An ordered list of strings to be joined with dashes to form the classname
  */
-@function get-classname($classname-items) {
+@function join-with-dashes($classname-items) {
   $classname: null;
-  $classname-items: remove($classname-items, null);
+  $classname-items: remove(remove($classname-items, null), '');
 
   @for $i from 1 through list.length($classname-items) {
     $classname-item: list.nth($classname-items, $i);
 
-    @if $classname-item != '' and $classname-item {
+    @if $classname-item {
       $classname: if(
         $i == 1,
         $classname-item,
@@ -53,9 +53,7 @@
  */
 @mixin output-property-directions($direction-values, $name, $value) {
   @each $direction in $direction-values {
-    $property: if($direction, '#{$name}-#{$direction}', $name);
-
-    #{$property}: $value;
+    #{join-with-dashes(($name, $direction))}: $value;
   }
 }
 
@@ -74,7 +72,7 @@
   $breakpoint-suffix: ''
 ) {
   @each $alias, $value in $values {
-    $classname: get-classname((setup.$namespace, 'u', $classname-root, $alias));
+    $classname: join-with-dashes((setup.$namespace, 'u', $classname-root, $alias));
 
     .#{$classname}#{$breakpoint-suffix} {
       #{$property-name}: $value;
@@ -100,7 +98,7 @@
 ) {
   @each $alias, $value in $values {
     @each $direction-name, $direction-values in $directions {
-      $classname: get-classname(
+      $classname: join-with-dashes(
         (setup.$namespace, 'u', $classname-root, $alias, $direction-name)
       );
 
@@ -127,7 +125,7 @@
   $classname-root,
   $breakpoint-suffix: ''
 ) {
-  $classname: get-classname(
+  $classname: join-with-dashes(
     (setup.$namespace, $classname-prefix, $classname-root)
   );
 

--- a/scss/bitstyles/tools/_properties.scss
+++ b/scss/bitstyles/tools/_properties.scss
@@ -21,27 +21,27 @@
 }
 
 /*
- * Returns a classname suitable for a utility class, by joining strings with dash characters
+ * Returns a string suitable for a utility class or CSS property name, by joining strings with dash characters
  *
- * @param $classname-items An ordered list of strings to be joined with dashes to form the classname
+ * @param $string-items An ordered list of strings to be joined with dashes to form the string
  */
-@function join-with-dashes($classname-items) {
-  $classname: null;
-  $classname-items: remove(remove($classname-items, null), '');
+@function join-with-dashes($string-items) {
+  $string: null;
+  $string-items: remove(remove($string-items, null), '');
 
-  @for $i from 1 through list.length($classname-items) {
-    $classname-item: list.nth($classname-items, $i);
+  @for $i from 1 through list.length($string-items) {
+    $string-item: list.nth($string-items, $i);
 
-    @if $classname-item {
-      $classname: if(
+    @if $string-item {
+      $string: if(
         $i == 1,
-        $classname-item,
-        '#{$classname}#{string.unquote('-')}#{$classname-item}'
+        $string-item,
+        '#{$string}#{string.unquote('-')}#{$string-item}'
       );
     }
   }
 
-  @return $classname;
+  @return $string;
 }
 
 /*
@@ -72,7 +72,9 @@
   $breakpoint-suffix: ''
 ) {
   @each $alias, $value in $values {
-    $classname: join-with-dashes((setup.$namespace, 'u', $classname-root, $alias));
+    $classname: join-with-dashes(
+      (setup.$namespace, 'u', $classname-root, $alias)
+    );
 
     .#{$classname}#{$breakpoint-suffix} {
       #{$property-name}: $value;

--- a/scss/bitstyles/utilities/inset/_index.import.scss
+++ b/scss/bitstyles/utilities/inset/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-inset-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/inset/_index.scss
+++ b/scss/bitstyles/utilities/inset/_index.scss
@@ -1,0 +1,23 @@
+@forward 'settings';
+@use './settings';
+@use '../../tools/properties';
+@use '../../tools/media-query';
+
+@include properties.output-directional(
+  $property-name: '',
+  $classname-root: '',
+  $values: settings.$values,
+  $directions: settings.$directions
+);
+
+@each $breakpoint-alias in settings.$breakpoints {
+  @include media-query.get($breakpoint-alias) {
+    @include properties.output-directional(
+      $property-name: '',
+      $classname-root: '',
+      $values: settings.$values,
+      $directions: settings.$directions,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+  }
+}

--- a/scss/bitstyles/utilities/inset/_settings.scss
+++ b/scss/bitstyles/utilities/inset/_settings.scss
@@ -1,5 +1,5 @@
 $values: (
-  '0': 0
+  '0': 0,
 ) !default;
 $breakpoints: () !default;
 $directions: (
@@ -14,5 +14,5 @@ $directions: (
   ),
   'left': (
     'left',
-  )
+  ),
 ) !default;

--- a/scss/bitstyles/utilities/inset/_settings.scss
+++ b/scss/bitstyles/utilities/inset/_settings.scss
@@ -1,0 +1,18 @@
+$values: (
+  '0': 0
+) !default;
+$breakpoints: () !default;
+$directions: (
+  'top': (
+    'top',
+  ),
+  'right': (
+    'right',
+  ),
+  'bottom': (
+    'bottom',
+  ),
+  'left': (
+    'left',
+  )
+) !default;

--- a/scss/bitstyles/utilities/inset/inset.stories.mdx
+++ b/scss/bitstyles/utilities/inset/inset.stories.mdx
@@ -3,3 +3,82 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 <Meta title="Utilities/inset" />
 
 # Inset
+
+Specify the various directional inset properties (top/right/bottom/left) on an element. These are only useful on an element that has something other than `static` positioning — that means elements with position `relative`, `absolute`, `fixed`, and `sticky`. For elements with relative-, absolute-, or sticky-positioning, the inset will be relative to their nearest non-statically positioned parent elements. For those with position `fixed`, the inset will be relative to the viewport.
+
+Default configuration provides a value of `0` for each of the properties at the four cardinal directions, and is not available at other breakpoints. See [customization](#customization) below for details on how to change that.
+
+<Canvas>
+  <Story name="u-0-top" inline={false} height="12rem">
+    {`
+      <div class="u-bg-brand-2 u-padding-m" style="width: 20rem">
+        <div class="u-bg-background u-padding-m" style="height:10rem;">
+          <div style="position:absolute;" class="u-0-top u-padding-m u-bg-white u-drop-shadow-default">u-0-top</div>
+        </div>
+      </div>
+    `}
+  </Story>
+  <Story name="u-0-right" inline={false} height="12rem">
+    {`
+      <div class="u-bg-brand-2 u-padding-m" style="width: 20rem">
+        <div class="u-bg-background u-padding-m" style="height:10rem;">
+          <div style="position:absolute;" class="u-0-right u-padding-m u-bg-white u-drop-shadow-default">u-0-right</div>
+        </div>
+      </div>
+    `}
+  </Story>
+  <Story name="u-0-bottom" inline={false} height="12rem">
+    {`
+      <div class="u-bg-brand-2 u-padding-m" style="width: 20rem">
+        <div class="u-bg-background u-padding-m" style="height:10rem;">
+          <div style="position:absolute;" class="u-0-bottom u-padding-m u-bg-white u-drop-shadow-default">u-0-bottom</div>
+        </div>
+      </div>
+    `}
+  </Story>
+  <Story name="u-0-left" inline={false} height="12rem">
+    {`
+      <div class="u-bg-brand-2 u-padding-m" style="width: 20rem">
+        <div class="u-bg-background u-padding-m" style="height:10rem;">
+          <div style="position:absolute;" class="u-0-left u-padding-m u-bg-white u-drop-shadow-default">u-0-left</div>
+        </div>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+Available positioning types can be configured by overriding the `$bitstyles-inset-values` Sass map. Provide the name to be used for the class as the key, and the value for the property as the value. If you want to keep the existing values, you’ll need to copy the default configuration as you cannot merge or update the existing map.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/inset' with (
+  $values: (
+    '0': 0,
+    'm': size.get('m'),
+  )
+);
+```
+
+To make these classes available at breakpoints, override `$bitstyles-inset-breakpoints`, providing the name(s) of breakpoints defined in your global breakpoint settings:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/inset' with (
+  $breakpoints: (
+    'm',
+  )
+);
+```
+
+Available directions can be customised by overriding the `$bitstyles-inset-directions` Sass map. Provide the name for the direction as the key, and the list of directions. Note that if you want to keep the existing directions, you’ll need to copy the existing configurations — the map cannot be updated, only overwritten.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/inset' with (
+  $directions: (
+    'top-and-right': (
+      'top',
+      'right',
+    ),
+  )
+);
+```

--- a/scss/bitstyles/utilities/inset/inset.stories.mdx
+++ b/scss/bitstyles/utilities/inset/inset.stories.mdx
@@ -1,0 +1,5 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/inset" />
+
+# Inset

--- a/scss/bitstyles/utilities/margin/margin.stories.mdx
+++ b/scss/bitstyles/utilities/margin/margin.stories.mdx
@@ -191,13 +191,13 @@ All the margins are also available at the `@s` and `@m` breakpoint suffixes.
 
 ## Customization
 
-Available margin-sizes can be configured by overriding the `$bitstyles-margin-sizes` Sass map. Provide the name to be used for the class as the key, and the value for the property as the value. If you want to keey the existing values, you’ll need to copy the default configuration as you cannot merge or update the existing map.
+Available margin-sizes can be configured by overriding the `$bitstyles-margin-sizes` Sass map. Provide the name to be used for the class as the key, and the value for the property as the value. If you want to keep the existing values, you’ll need to copy the default configuration as you cannot merge or update the existing map.
 
 The `positive` and `negative` keys are required for each group you want to define (e.g. if you have no negative margins, that key is not required).
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/margin' with (
-  $bitstyles-margin-sizes: (
+  $sizes: (
     'positive': (
       '0': 0,
       'xxs': size.get('xxs'),

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1883,6 +1883,18 @@ table {
 .bs-u-height-1em {
   height: 1em;
 }
+.bs-u-100-top {
+  top: 100rem;
+}
+.bs-u-100-right {
+  right: 100rem;
+}
+.bs-u-100-bottom {
+  bottom: 100rem;
+}
+.bs-u-100-left {
+  left: 100rem;
+}
 .bs-u-items-start {
   align-items: start;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2247,6 +2247,18 @@ table {
   height: -moz-available;
   height: stretch;
 }
+.u-0-top {
+  top: 0;
+}
+.u-0-right {
+  right: 0;
+}
+.u-0-bottom {
+  bottom: 0;
+}
+.u-0-left {
+  left: 0;
+}
 .u-items-center {
   align-items: center;
 }

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -185,6 +185,9 @@ $bitstyles-grid-cols-values: (
 $bitstyles-height-values: (
   '1em': 1em,
 );
+$bitstyles-inset-values: (
+  '100': 100rem,
+);
 $bitstyles-items-values: (
   'start': start,
 );

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -185,6 +185,9 @@ $bitstyles-grid-cols-values: (
 $bitstyles-height-values: (
   '1em': 1em,
 );
+$bitstyles-inset-values: (
+  '100': 100rem,
+);
 $bitstyles-items-values: (
   'start': start,
 );
@@ -308,6 +311,7 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/utilities/gap';
 @import '../../scss/bitstyles/utilities/grid-cols';
 @import '../../scss/bitstyles/utilities/height';
+@import '../../scss/bitstyles/utilities/inset';
 @import '../../scss/bitstyles/utilities/items';
 @import '../../scss/bitstyles/utilities/justify';
 @import '../../scss/bitstyles/utilities/line-height';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -136,9 +136,7 @@
   $gap-sizes: ('100': 100rem),
   $grid-cols-values: ('100': repeat(100, minmax(0, 1fr))),
   $height-values: ('1em': 1em),
-  $inset-values: (
-    '100': 100rem,
-  ),
+  $inset-values: ('100': 100rem),
   $items-values: ('start': start),
   $justify-values: ('start': start),
   $margin-breakpoints: ('xl', 's'),

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -136,6 +136,9 @@
   $gap-sizes: ('100': 100rem),
   $grid-cols-values: ('100': repeat(100, minmax(0, 1fr))),
   $height-values: ('1em': 1em),
+  $inset-values: (
+    '100': 100rem,
+  ),
   $items-values: ('start': start),
   $justify-values: ('start': start),
   $margin-breakpoints: ('xl', 's'),

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -309,6 +309,11 @@
     '1em': 1em,
   )
 );
+@use '../../scss/bitstyles/utilities/inset' with (
+  $values: (
+    '100': 100rem,
+  ),
+);
 @use '../../scss/bitstyles/utilities/items' with (
   $values: (
     'start': start,

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -312,7 +312,7 @@
 @use '../../scss/bitstyles/utilities/inset' with (
   $values: (
     '100': 100rem,
-  ),
+  )
 );
 @use '../../scss/bitstyles/utilities/items' with (
   $values: (


### PR DESCRIPTION
Fixes #641 

## Changes

- Adds an `inset` utility class that outputs top/right/bottom/left
- Updates the `get-classname` helper function to output property names too, and uses that instead of the inline interpolation in `properties.output-directional()`
- 🚓DRIVE-BY: fixes a couple of typos in the margin docs

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
