### PR TITLE
[#646] Add utility: max-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `a-link` and `<a>` elements now have variables to specify the active state
 - Position classes are now available for `static`, `absolute`, `fixed`, and `sticky`, as well as the existing `relative`. These classes are available at the `m` breakpoint by default, and are customizable using `$bitstyles-position-values`
 - `u-line-height` class can now be configured using `$bitstyles-line-height-values` and `$bitstyles-line-height-breakpoints`
+- New `u-max-width` utility class
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 - Adds utility class to specify max-height property, with `100vh` and `stretch` as default values. Customizable using `$bitstyles-max-height-values` and `$bitstyles-max-height-breakpoints`
 - `a-link` and `<a>` elements now have variables to specify the active state
 - Position classes are now available for `static`, `absolute`, `fixed`, and `sticky`, as well as the existing `relative`. These classes are available at the `m` breakpoint by default, and are customizable using `$bitstyles-position-values`
-- `u-line-height` class can now be configured using `$bitstyles-line-height-values` and `$bitstyles-line-height-breakpoints`
-- New `u-max-width` utility class
+- New `u-max-width` utility class, with `0` and `100vw` as default values. Customizable using `$bitstyles-max-width-values` and `$bitstyles-max-width-breakpoints`
 
 ### Breaking
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -98,6 +98,7 @@
 @forward 'bitstyles/utilities/line-height' as line-height-*;
 @forward 'bitstyles/utilities/margin' as margin-*;
 @forward 'bitstyles/utilities/max-height' as max-height-*;
+@forward 'bitstyles/utilities/max-width' as max-width-*;
 @forward 'bitstyles/utilities/min-height' as min-height-*;
 @forward 'bitstyles/utilities/min-width' as min-width-*;
 @forward 'bitstyles/utilities/object-cover' as object-cover-*;

--- a/scss/bitstyles/utilities/max-width/_index.import.scss
+++ b/scss/bitstyles/utilities/max-width/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-max-width-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/max-width/_index.scss
+++ b/scss/bitstyles/utilities/max-width/_index.scss
@@ -1,0 +1,21 @@
+@forward './settings';
+@use './settings';
+@use '../../tools/properties';
+@use '../../tools/media-query';
+
+@include properties.output(
+  $property-name: 'max-width',
+  $classname-root: 'max-width',
+  $values: settings.$values
+);
+
+@each $breakpoint-alias in settings.$breakpoints {
+  @include media-query.get($breakpoint-alias) {
+    @include properties.output(
+      $property-name: 'max-width',
+      $classname-root: 'max-width',
+      $values: settings.$values,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+  }
+}

--- a/scss/bitstyles/utilities/max-width/_settings.scss
+++ b/scss/bitstyles/utilities/max-width/_settings.scss
@@ -1,4 +1,5 @@
 $values: (
-  '100': 100vw,
+  '0': 0,
+  '100vw': 100vw,
 ) !default;
 $breakpoints: () !default;

--- a/scss/bitstyles/utilities/max-width/_settings.scss
+++ b/scss/bitstyles/utilities/max-width/_settings.scss
@@ -1,0 +1,4 @@
+$values: (
+  '100': 100vw,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/max-width/max-width.stories.mdx
+++ b/scss/bitstyles/utilities/max-width/max-width.stories.mdx
@@ -1,0 +1,39 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/max-width" />
+
+# max-width
+
+Specify the `max-width` property of an element. Default configuration provides `max-width: 0` with no breakpoint variations. See [customization](#customization) for details on how to change that.
+
+<Canvas>
+  <Story name="u-max-width-100" inline={false} height="13rem" width="100%">
+    {`
+      <div class="u-bg-brand-2 u-padding-m" style="height:12rem">
+        <div class="u-max-width-100 u-bg-gray-5" style="width:9999rem">u-max-width-100</div>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+Customize the available max-width by overriding the `$bitstyles-max-width-values` Sass map, providing the name to be used for the class, and the value to use.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/max-width' with (
+  $values: (
+    '10rem': 10rem,
+  )
+);
+```
+
+Available breakpoint variables can be specified by overriding the `$bitstyles-max-width-breakpoints` Sass list, providing a list of names of breakpoints taken from the global breakpoint list:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/max-width' with (
+  $breakpoints: (
+    'm',
+  )
+);
+```

--- a/scss/bitstyles/utilities/max-width/max-width.stories.mdx
+++ b/scss/bitstyles/utilities/max-width/max-width.stories.mdx
@@ -4,13 +4,20 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # max-width
 
-Specify the `max-width` property of an element. Default configuration provides `max-width: 0` with no breakpoint variations. See [customization](#customization) for details on how to change that.
+Specify the `max-width` property of an element. Default configuration provides `max-width: 0` and `100vw` with no breakpoint variations. See [customization](#customization) for details on how to change that.
 
 <Canvas>
-  <Story name="u-max-width-100" inline={false} height="13rem" width="100%">
+  <Story name="u-max-width-0" inline={false} height="13rem" width="100%">
     {`
       <div class="u-bg-brand-2 u-padding-m" style="height:12rem">
-        <div class="u-max-width-100 u-bg-gray-5" style="width:9999rem">u-max-width-100</div>
+        <div class="u-max-width-0 u-bg-gray-5" style="width:9999rem">u-max-width-0</div>
+      </div>
+    `}
+  </Story>
+  <Story name="u-max-width-100vw" inline={false} height="13rem" width="100%">
+    {`
+      <div class="u-bg-brand-2 u-padding-m" style="height:12rem">
+        <div class="u-max-width-100vw u-bg-gray-5" style="width:9999rem">u-max-width-100vw</div>
       </div>
     `}
   </Story>

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -2899,6 +2899,9 @@ table {
 .bs-u-max-height-1em {
   max-height: 1em;
 }
+.bs-u-max-width-1em {
+  max-width: 1em;
+}
 .bs-u-min-height-1em {
   min-height: 1em;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -3304,7 +3304,10 @@ table {
   max-height: -moz-available;
   max-height: stretch;
 }
-.u-max-width-100 {
+.u-max-width-0 {
+  max-width: 0;
+}
+.u-max-width-100vw {
   max-width: 100vw;
 }
 .u-min-height-0 {

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -3304,6 +3304,9 @@ table {
   max-height: -moz-available;
   max-height: stretch;
 }
+.u-max-width-100 {
+  max-width: 100vw;
+}
 .u-min-height-0 {
   min-height: 0;
 }

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -204,6 +204,9 @@ $bitstyles-margin-breakpoints: ('xl', 's');
 $bitstyles-max-height-values: (
   '1em': 1em,
 );
+$bitstyles-max-width-values: (
+  '1em': 1em,
+);
 $bitstyles-min-height-values: (
   '1em': 1em,
 );

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -204,6 +204,9 @@ $bitstyles-margin-breakpoints: ('xl', 's');
 $bitstyles-max-height-values: (
   '1em': 1em,
 );
+$bitstyles-max-width-values: (
+  '1em': 1em,
+);
 $bitstyles-min-height-values: (
   '1em': 1em,
 );
@@ -327,6 +330,7 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/utilities/line-height';
 @import '../../scss/bitstyles/utilities/margin';
 @import '../../scss/bitstyles/utilities/max-height';
+@import '../../scss/bitstyles/utilities/max-width';
 @import '../../scss/bitstyles/utilities/min-height';
 @import '../../scss/bitstyles/utilities/min-width';
 @import '../../scss/bitstyles/utilities/object-cover';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -145,6 +145,9 @@
   $line-height-values: ('10': 10),
   $margin-breakpoints: ('xl', 's'),
   $max-height-values: ('1em': 1em),
+  $max-width-values: (
+    '1em': 1em,
+  ),
   $min-height-values: ('1em': 1em),
   $min-width-values: ('1em': 1em),
   $overflow-values: (

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -145,9 +145,7 @@
   $line-height-values: ('10': 10),
   $margin-breakpoints: ('xl', 's'),
   $max-height-values: ('1em': 1em),
-  $max-width-values: (
-    '1em': 1em,
-  ),
+  $max-width-values: ('1em': 1em),
   $min-height-values: ('1em': 1em),
   $min-width-values: ('1em': 1em),
   $overflow-values: (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -343,6 +343,11 @@
     '1em': 1em,
   )
 );
+@use '../../scss/bitstyles/utilities/max-width' with (
+  $values: (
+    '1em': 1em,
+  )
+);
 @use '../../scss/bitstyles/utilities/min-height' with (
   $values: (
     '1em': 1em,


### PR DESCRIPTION
Fixes #646 

## Changes

- Adds max-width utility class with `100vw` in the default configuration, at no breakpoints

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
