### PR TITLE
[#651] Generate line-height utility class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Position classes are now available for `static`, `absolute`, `fixed`, and `sticky`, as well as the existing `relative`. These classes are available at the `m` breakpoint by default, and are customizable using `$bitstyles-position-values`
+- `u-line-height` class can now be configured using `$bitstyles-line-height-values` and `$bitstyles-line-height-breakpoints`
 
 ## [[4.2.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v4.2.0) - 2022-02-09
 

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -96,7 +96,7 @@ These classes are available at the `m` breakpoint.
 
 ## Customization
 
-Customize the available justify-content values by overriding the `$bitstyles-justify-values` Sass map. Provide the name to be used for the class as the key, and the favlue for the `justify-content` property:
+Customize the available justify-content values by overriding the `$bitstyles-justify-values` Sass map. Provide the name to be used for the class as the key, and the value for the `justify-content` property:
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/justify' with (

--- a/scss/bitstyles/utilities/line-height/_index.import.scss
+++ b/scss/bitstyles/utilities/line-height/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-line-height-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/line-height/_index.scss
+++ b/scss/bitstyles/utilities/line-height/_index.scss
@@ -1,6 +1,21 @@
-@use '../../settings/setup';
-@use '../../settings/typography';
+@forward 'settings';
+@use 'settings';
+@use '../../tools/properties';
+@use '../../tools/media-query';
 
-.#{setup.$namespace}u-line-height-min {
-  line-height: typography.$line-height-min;
+@include properties.output(
+  $property-name: 'line-height',
+  $classname-root: 'line-height',
+  $values: settings.$values
+);
+
+@each $breakpoint-alias in settings.$breakpoints {
+  @include media-query.get($breakpoint-alias) {
+    @include properties.output(
+      $property-name: 'line-height',
+      $classname-root: 'line-height',
+      $values: settings.$values,
+      $breakpoint-suffix: '\\\@#{$breakpoint-alias}'
+    );
+  }
 }

--- a/scss/bitstyles/utilities/line-height/_settings.scss
+++ b/scss/bitstyles/utilities/line-height/_settings.scss
@@ -1,0 +1,6 @@
+@use '../../settings/typography';
+
+$values: (
+  'min': typography.$line-height-min,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/line-height/line-height.stories.mdx
+++ b/scss/bitstyles/utilities/line-height/line-height.stories.mdx
@@ -4,13 +4,41 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Line-height
 
+Specify `line-height` property on an element. With the default configuration `min` is available, setting the line-height to the minimum safe value that doesn’t truncate diacritics from above letters. This is not available at any breakpoints, but see [customization](#customization) below for details on how change the configuration.
+
 <Canvas>
   <Story name="u-line-height-min">
     {`
       <div class="u-flex">
-        <h1 class="u-bg-gray-10">Default line-height</h1>
-        <h1 class="u-bg-gray-20 u-line-height-min">u-line-height-min</h1>
+        <p class="u-padding-m u-bg-gray-10">
+          <span class="u-bg-white">Default line-height</span>
+        </p>
+        <p class="u-padding-m u-bg-gray-20 u-line-height-min">
+          <span class="u-bg-white">u-line-height-min</span>
+        </p>
       </div>
     `}
   </Story>
 </Canvas>
+
+## Customization
+
+Customize the available line-height values by overriding the `$bitstyles-line-height-values` Sass map. Provide the name to be used for the class as the key, and the value for the `line-height` property:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/line-height' with (
+  $values: (
+    'large': 2.5,
+  )
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-line-height-breakpoints` variable:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/line-height' with (
+  $breakpoints: (
+    'm',
+  )
+);
+```

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1899,8 +1899,8 @@ table {
     justify-content: start;
   }
 }
-.bsu-line-height-min {
-  line-height: 1.25;
+.bs-u-line-height-10 {
+  line-height: 10;
 }
 .bs-u-margin-0 {
   margin: 0;

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -191,6 +191,9 @@ $bitstyles-items-values: (
 $bitstyles-justify-values: (
   'start': start,
 );
+$bitstyles-line-height-values: (
+  '10': 10,
+);
 $bitstyles-margin-breakpoints: ('xl', 's');
 $bitstyles-min-height-values: (
   '1em': 1em,

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -191,6 +191,9 @@ $bitstyles-items-values: (
 $bitstyles-justify-values: (
   'start': start,
 );
+$bitstyles-line-height-values: (
+  '10': 10,
+);
 $bitstyles-margin-breakpoints: ('xl', 's');
 $bitstyles-min-height-values: (
   '1em': 1em,

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -138,9 +138,7 @@
   $height-values: ('1em': 1em),
   $items-values: ('start': start),
   $justify-values: ('start': start),
-  $line-height-values: (
-    '10': 10,
-  ),
+  $line-height-values: ('10': 10),
   $margin-breakpoints: ('xl', 's'),
   $min-height-values: ('1em': 1em),
   $min-width-values: ('1em': 1em),

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -138,6 +138,9 @@
   $height-values: ('1em': 1em),
   $items-values: ('start': start),
   $justify-values: ('start': start),
+  $line-height-values: (
+    '10': 10,
+  ),
   $margin-breakpoints: ('xl', 's'),
   $min-height-values: ('1em': 1em),
   $min-width-values: ('1em': 1em),

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -322,7 +322,7 @@
 @use '../../scss/bitstyles/utilities/line-height' with (
   $values: (
     '10': 10,
-  ),
+  )
 );
 @use '../../scss/bitstyles/utilities/margin' with (
   $breakpoints: (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -319,7 +319,11 @@
     'start': start,
   )
 );
-@use '../../scss/bitstyles/utilities/line-height';
+@use '../../scss/bitstyles/utilities/line-height' with (
+  $values: (
+    '10': 10,
+  ),
+);
 @use '../../scss/bitstyles/utilities/margin' with (
   $breakpoints: (
     'xl',


### PR DESCRIPTION
Fixes #651

## Changes

- line-height utility class is now generated in the standard way

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
