### PR TITLE
[#663] Use join-with-dashes to generate component-level classnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - `media-query.get()` will now output the content block you pass it without a media-query wrapping them, if the media-query name matches `settings.no-media-query`. This is useful for outputing base CSS with media-query wrapped CSS in one loop
 - The `overflow` utility classes can now be output at breakpoints, configurable with the `$bitstyles-overflow-breakpoints` variable
 
+### Fixed
+
+- All classnames of atoms and organisms now correctly insert a minus character between the global namespace and the rest of the classname. If you were using `setup.$namespace`, you’ll need to update those classnames to include a minus e.g. `.namespacea-button` becomes `.namespace-a-button`
+
 ## [[4.3.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v4.3.0) - 2022-05-25
 
 ### Added

--- a/scss/bitstyles/atoms/avatar/_index.scss
+++ b/scss/bitstyles/atoms/avatar/_index.scss
@@ -2,8 +2,9 @@
 @use './settings';
 @use '../../settings/layout';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-avatar {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'avatar'))} {
   width: 2em;
   height: 2em;
   overflow: hidden;
@@ -19,7 +20,7 @@
 }
 
 @each $size-alias, $size in settings.$sizes {
-  .#{setup.$namespace}a-avatar--#{$size-alias} {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'avatar--#{$size-alias}'))} {
     width: $size;
     height: $size;
   }

--- a/scss/bitstyles/atoms/badge/_index.scss
+++ b/scss/bitstyles/atoms/badge/_index.scss
@@ -3,23 +3,24 @@
 @use '../../settings/layout';
 @use '../../settings/setup';
 @use '../../tools/palette';
+@use '../../tools/properties';
 @use '../../tools/size';
 
-.#{setup.$namespace}a-badge {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'badge'))} {
   display: inline-flex;
   align-items: center;
   padding: settings.$padding-vertical settings.$padding-horizontal;
   border-radius: layout.$border-radius-round;
   white-space: nowrap;
 
-  .#{setup.$namespace}a-badge__button {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'badge__button'))} {
     margin-right: -#{size.get('s')};
     margin-left: size.get('xs');
   }
 }
 
 @each $variant in (settings.$variants) {
-  .#{setup.$namespace}a-badge--#{$variant} {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'badge--#{$variant}'))} {
     --button-fg: #{palette.get($variant, settings.$color)};
     --button-bg: #{palette.get($variant, settings.$background-color)};
     --button-fg-hover: #{palette.get($variant, settings.$background-color)};

--- a/scss/bitstyles/atoms/bordered-header/_index.scss
+++ b/scss/bitstyles/atoms/bordered-header/_index.scss
@@ -1,8 +1,9 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-bordered-header {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'bordered-header'))} {
   display: grid;
   grid-gap: settings.$gutter;
   grid-template-columns: auto minmax(1px, 1fr);

--- a/scss/bitstyles/atoms/button--danger/_index.scss
+++ b/scss/bitstyles/atoms/button--danger/_index.scss
@@ -1,8 +1,9 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-button--danger {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--danger'))} {
   &:hover,
   &:focus {
     border-color: settings.$border-color-hover;

--- a/scss/bitstyles/atoms/button--icon-reversed/_index.scss
+++ b/scss/bitstyles/atoms/button--icon-reversed/_index.scss
@@ -1,8 +1,9 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-button--icon-reversed {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--icon-reversed'))} {
   &,
   &:visited {
     border-color: settings.$border-color;

--- a/scss/bitstyles/atoms/button--icon/_index.scss
+++ b/scss/bitstyles/atoms/button--icon/_index.scss
@@ -1,8 +1,9 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-button--icon {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--icon'))} {
   justify-content: flex-start;
   padding: settings.$padding-vertical settings.$padding-horizontal;
   border-radius: settings.$border-radius;
@@ -38,7 +39,7 @@
     color: settings.$color-disabled;
   }
 
-  .#{setup.$namespace}a-button__icon {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'button__icon'))} {
     margin: 0;
   }
 }

--- a/scss/bitstyles/atoms/button--menu/_index.scss
+++ b/scss/bitstyles/atoms/button--menu/_index.scss
@@ -1,8 +1,9 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-button--menu {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--menu'))} {
   display: flex;
   justify-content: flex-start;
   min-height: 0;

--- a/scss/bitstyles/atoms/button--mode/_index.scss
+++ b/scss/bitstyles/atoms/button--mode/_index.scss
@@ -1,13 +1,14 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 @use '../../tools/size';
 
-.#{setup.$namespace}a-button--mode-container {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--mode-container'))} {
   border-radius: size.get('s');
 }
 
-.#{setup.$namespace}a-button--mode {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--mode'))} {
   padding-top: 0;
   padding-bottom: 0;
 

--- a/scss/bitstyles/atoms/button--nav-large/_index.scss
+++ b/scss/bitstyles/atoms/button--nav-large/_index.scss
@@ -2,7 +2,9 @@
 @use './settings';
 @use '../../settings/setup';
 
-.#{setup.$namespace}a-button--nav-large {
+@use '../../tools/properties';
+
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--nav-large'))} {
   display: flex;
   justify-content: flex-start;
   width: 100%;

--- a/scss/bitstyles/atoms/button--nav/_index.scss
+++ b/scss/bitstyles/atoms/button--nav/_index.scss
@@ -2,8 +2,9 @@
 @use 'sass:math';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-button--nav {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--nav'))} {
   justify-content: flex-start;
   padding: settings.$padding-vertical settings.$padding-horizontal;
   border-radius: settings.$border-radius;
@@ -48,7 +49,7 @@
   }
 }
 
-.#{setup.$namespace}a-button-nav__icon {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button-nav__icon'))} {
   margin-right: settings.$padding-horizontal;
   margin-left: -#{math.div(settings.$padding-horizontal, 4)};
 }

--- a/scss/bitstyles/atoms/button--small/_index.scss
+++ b/scss/bitstyles/atoms/button--small/_index.scss
@@ -2,13 +2,14 @@
 @use 'sass:math';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 @use '../../tools/size';
 
-.#{setup.$namespace}a-button--small {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--small'))} {
   min-height: size.get('xl');
   padding: settings.$padding-vertical settings.$padding-horizontal;
 
-  &.#{setup.$namespace}a-button--icon {
+  &.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--icon'))} {
     padding: math.div(settings.$padding-horizontal, 2);
     border-radius: settings.$border-radius;
   }

--- a/scss/bitstyles/atoms/button--tab/_index.scss
+++ b/scss/bitstyles/atoms/button--tab/_index.scss
@@ -3,15 +3,16 @@
 @use '../../settings/animation';
 @use '../../settings/layout';
 @use '../../settings/setup';
+@use '../../tools/properties';
 @use '../button/settings' as button-settings;
 
-.#{setup.$namespace}a-button--tab-container {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--tab-container'))} {
   & > *:first-child {
     margin-left: -(button-settings.$padding-horizontal);
   }
 }
 
-.#{setup.$namespace}a-button--tab {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--tab'))} {
   position: relative;
   border: 0;
   border-radius: settings.$border-radius;

--- a/scss/bitstyles/atoms/button--ui/_index.scss
+++ b/scss/bitstyles/atoms/button--ui/_index.scss
@@ -1,8 +1,9 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-button--ui {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button--ui'))} {
   &,
   &:visited {
     border-color: settings.$border-color;

--- a/scss/bitstyles/atoms/button/_index.scss
+++ b/scss/bitstyles/atoms/button/_index.scss
@@ -68,7 +68,8 @@
   margin-left: math.div(-(settings.$icon-spacing), 4);
 }
 
-.#{properties.join-with-dashes((setup.$namespace, 'a', 'button__label'))} + .#{properties.join-with-dashes((setup.$namespace, 'a', 'button__icon'))} {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button__label'))}
+  + .#{properties.join-with-dashes((setup.$namespace, 'a', 'button__icon'))} {
   margin-right: math.div(-(settings.$icon-spacing), 4);
   margin-left: settings.$icon-spacing;
 }

--- a/scss/bitstyles/atoms/button/_index.scss
+++ b/scss/bitstyles/atoms/button/_index.scss
@@ -2,8 +2,9 @@
 @use 'sass:math';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-button {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button'))} {
   display: inline-flex;
   position: relative;
   flex-shrink: 0;
@@ -61,13 +62,13 @@
   }
 }
 
-.#{setup.$namespace}a-button__avatar,
-.#{setup.$namespace}a-button__icon {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button__avatar'))},
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button__icon'))} {
   margin-right: settings.$icon-spacing;
   margin-left: math.div(-(settings.$icon-spacing), 4);
 }
 
-.#{setup.$namespace}a-button__label + .#{setup.$namespace}a-button__icon {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'button__label'))} + .#{properties.join-with-dashes((setup.$namespace, 'a', 'button__icon'))} {
   margin-right: math.div(-(settings.$icon-spacing), 4);
   margin-left: settings.$icon-spacing;
 }

--- a/scss/bitstyles/atoms/content/_index.scss
+++ b/scss/bitstyles/atoms/content/_index.scss
@@ -4,13 +4,14 @@
 @use '../../settings/animation';
 @use '../../settings/setup';
 @use '../../tools/media-query';
+@use '../../tools/properties';
 
 @mixin content-padding($padding-value) {
   padding-right: $padding-value;
   padding-left: $padding-value;
 }
 
-.#{setup.$namespace}a-content {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'content'))} {
   width: 100%;
   max-width: map.get(settings.$max-width, settings.$max-width-base);
   margin-right: auto;
@@ -32,7 +33,7 @@
 }
 
 @each $max-width-alias, $max-width-value in settings.$max-width {
-  .#{setup.$namespace}a-content--#{$max-width-alias} {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'content--#{$max-width-alias}'))} {
     max-width: $max-width-value;
   }
 }

--- a/scss/bitstyles/atoms/dl/_index.scss
+++ b/scss/bitstyles/atoms/dl/_index.scss
@@ -2,12 +2,14 @@
 @use '../../tools/palette';
 @use '../../tools/media-query';
 
-.#{setup.$namespace}a-dl {
+@use '../../tools/properties';
+
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'dl'))} {
   border-top: 1px solid palette.get('gray', '5');
 }
 
 @include media-query.get('m') {
-  .#{setup.$namespace}a-dl__item {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'dl__item'))} {
     border-bottom: 1px solid palette.get('gray', '5');
   }
 }

--- a/scss/bitstyles/atoms/dropdown/_index.scss
+++ b/scss/bitstyles/atoms/dropdown/_index.scss
@@ -2,8 +2,9 @@
 @use './settings';
 @use '../../settings/setup';
 @use '../../tools/media-query';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-dropdown {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'dropdown'))} {
   position: absolute;
   z-index: 1;
   top: 100%;
@@ -42,16 +43,16 @@
   }
 }
 
-.#{setup.$namespace}a-dropdown--right {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'dropdown--right'))} {
   right: 0;
 }
 
-.#{setup.$namespace}a-dropdown--top {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'dropdown--top'))} {
   top: auto;
   bottom: 100%;
 }
 
-.a-dropdown--full-width {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'dropdown--full-width'))} {
   right: 0;
   left: 0;
   width: 100%;
@@ -59,7 +60,7 @@
 }
 
 @include media-query.get('s') {
-  .#{setup.$namespace}a-dropdown {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'dropdown'))} {
     right: 0;
     left: 0;
     width: 100%;

--- a/scss/bitstyles/atoms/flash/_index.scss
+++ b/scss/bitstyles/atoms/flash/_index.scss
@@ -2,9 +2,10 @@
 @use './settings';
 @use '../../settings/setup';
 @use '../../tools/palette';
+@use '../../tools/properties';
 
 @each $variant in (settings.$variants) {
-  .#{setup.$namespace}a-flash--#{$variant} {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'flash--#{$variant}'))} {
     background-color: palette.get($variant, settings.$background-color);
     color: palette.get($variant, settings.$color);
   }

--- a/scss/bitstyles/atoms/icon/_index.scss
+++ b/scss/bitstyles/atoms/icon/_index.scss
@@ -2,13 +2,14 @@
 @use './settings';
 @use '../../settings/setup';
 @use '../../tools/icon';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-icon {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'icon'))} {
   @include icon.icon;
 }
 
 @each $size-alias, $size-size in settings.$sizes {
-  .#{setup.$namespace}a-icon--#{$size-alias} {
+  .#{properties.join-with-dashes((setup.$namespace, 'a', 'icon--#{$size-alias}'))} {
     font-size: $size-size;
   }
 }

--- a/scss/bitstyles/atoms/link/_index.scss
+++ b/scss/bitstyles/atoms/link/_index.scss
@@ -1,7 +1,8 @@
 @use '../../settings/link' as link2;
 @use '../../settings/setup';
 @use '../../tools/link';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-link {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'link'))} {
   @include link.link;
 }

--- a/scss/bitstyles/atoms/list-reset/_index.scss
+++ b/scss/bitstyles/atoms/list-reset/_index.scss
@@ -1,6 +1,7 @@
 @use '../../settings/setup';
 @use '../../tools/list-reset';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-list-reset {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'list-reset'))} {
   @include list-reset.list-reset;
 }

--- a/scss/bitstyles/atoms/skip-link/_index.scss
+++ b/scss/bitstyles/atoms/skip-link/_index.scss
@@ -1,7 +1,9 @@
 @forward './settings';
 @use './settings';
+@use '../../settings/setup';
+@use '../../tools/properties';
 
-.a-skip-link {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'skip-link'))} {
   position: absolute;
   z-index: 1;
   top: -100%;

--- a/scss/bitstyles/atoms/topbar/_index.scss
+++ b/scss/bitstyles/atoms/topbar/_index.scss
@@ -1,8 +1,9 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}a-topbar {
+.#{properties.join-with-dashes((setup.$namespace, 'a', 'topbar'))} {
   position: settings.$position;
   z-index: settings.$z-index;
   top: 0;

--- a/scss/bitstyles/organisms/modal/_index.scss
+++ b/scss/bitstyles/organisms/modal/_index.scss
@@ -2,13 +2,14 @@
 @use './settings';
 @use '../../settings/setup';
 @use '../../tools/media-query';
+@use '../../tools/properties';
 
 @mixin modal-is-hidden {
   visibility: hidden;
   opacity: 0;
 }
 
-.#{setup.$namespace}o-modal__overlay {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'modal__overlay'))} {
   position: fixed;
   z-index: 10;
   top: 0;
@@ -30,7 +31,7 @@
   }
 }
 
-.#{setup.$namespace}o-modal__content {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'modal__content'))} {
   position: fixed;
   z-index: 20;
   top: 50%;
@@ -60,7 +61,7 @@
 }
 
 @include media-query.get(settings.$breakpoint) {
-  .#{setup.$namespace}o-modal__content {
+  .#{properties.join-with-dashes((setup.$namespace, 'o', 'modal__content'))} {
     transition: all settings.$transition-duration settings.$transition-easing,
       visibility 0 settings.$transition-easing;
 
@@ -73,9 +74,9 @@
 }
 
 @mixin modal-variation($state) {
-  .#{setup.$namespace}o-modal--animation-#{$state} {
+  .#{properties.join-with-dashes((setup.$namespace, 'o', 'modal--animation', $state))} {
     &[aria-hidden='true'] {
-      .#{setup.$namespace}o-modal__content {
+      .#{properties.join-with-dashes((setup.$namespace, 'o', 'modal__content'))} {
         @content;
       }
     }

--- a/scss/bitstyles/organisms/navbar/_index.scss
+++ b/scss/bitstyles/organisms/navbar/_index.scss
@@ -2,8 +2,9 @@
 @use './settings';
 @use '../../settings/setup';
 @use '../../tools/media-query';
+@use '../../tools/properties';
 
-.#{setup.$namespace}o-navbar {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'navbar'))} {
   position: absolute;
   top: 100%;
   right: 0;

--- a/scss/bitstyles/organisms/notification-center/_index.scss
+++ b/scss/bitstyles/organisms/notification-center/_index.scss
@@ -1,6 +1,7 @@
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}o-notification-center {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'notification-center'))} {
   position: fixed;
   top: 0;
   right: 0;

--- a/scss/bitstyles/organisms/sidebar/_index.scss
+++ b/scss/bitstyles/organisms/sidebar/_index.scss
@@ -2,12 +2,13 @@
 @use './settings';
 @use '../../settings/setup';
 @use '../../tools/media-query';
+@use '../../tools/properties';
 
-.#{setup.$namespace}o-sidebar--large {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'sidebar--large'))} {
   width: settings.$large-width;
 }
 
-.#{setup.$namespace}o-sidebar--small {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'sidebar--small'))} {
   position: fixed;
   z-index: 1;
   top: 0;

--- a/scss/bitstyles/organisms/table/_index.scss
+++ b/scss/bitstyles/organisms/table/_index.scss
@@ -1,8 +1,9 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}o-table {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'table'))} {
   width: 100%;
 
   /* stylelint-disable selector-max-type */
@@ -26,8 +27,8 @@
     }
   }
   /* stylelint-enable selector-max-type */
+}
 
-  .#{setup.$namespace}o-table__actions {
-    padding-right: settings.$padding-vertical-td;
-  }
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'table__actions'))} {
+  padding-right: settings.$padding-vertical-td;
 }

--- a/scss/bitstyles/organisms/ui-group/_index.scss
+++ b/scss/bitstyles/organisms/ui-group/_index.scss
@@ -1,20 +1,21 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/setup';
+@use '../../tools/properties';
 
-.#{setup.$namespace}o-ui-group {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'ui-group'))} {
   border-radius: settings.$border-radius;
   box-shadow: settings.$box-shadow;
 }
 
-.#{setup.$namespace}o-ui-group__item {
+.#{properties.join-with-dashes((setup.$namespace, 'o', 'ui-group__item'))} {
   box-shadow: none;
 
   &,
   &:hover,
   &:active,
   &:focus {
-    &:not(.#{setup.$namespace}o-ui-group__last) {
+    &:not(.#{properties.join-with-dashes((setup.$namespace, 'o', 'ui-group__last'))}) {
       border-right: 0;
     }
   }

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1478,7 +1478,7 @@ table {
   top: 0;
   z-index: 1;
 }
-.bso-modal__overlay {
+.bs-o-modal__overlay {
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   background: rgba(0, 0, 0, 0.95);
@@ -1492,12 +1492,12 @@ table {
   will-change: opacity, transform, visibility;
   z-index: 10;
 }
-[aria-hidden='true'] .bso-modal__overlay {
+[aria-hidden='true'] .bs-o-modal__overlay {
   opacity: 0;
   transition: all 0.2s ease-in-out, visibility 0 ease-in-out 0.2s;
   visibility: hidden;
 }
-.bso-modal__content {
+.bs-o-modal__content {
   -webkit-overflow-scrolling: touch;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
@@ -1515,52 +1515,52 @@ table {
   will-change: opacity, transform, visibility;
   z-index: 20;
 }
-[aria-hidden='true'] .bso-modal__content {
+[aria-hidden='true'] .bs-o-modal__content {
   opacity: 0;
   transform: translate(-50%, 50%);
   transition: all 0.25s ease-in-out, visibility 0 ease-in-out 0.2s;
   visibility: hidden;
 }
 @media screen and (min-width: 30em) {
-  .bso-modal__content {
+  .bs-o-modal__content {
     transition: all 0.2s ease-in-out, visibility 0 ease-in-out;
   }
-  [aria-hidden='true'] .bso-modal__content {
+  [aria-hidden='true'] .bs-o-modal__content {
     transform: translate(-50%, -50%) scale(0.875);
     transition: all 0.2s ease-in-out, visibility 0 ease-in-out 0.2s;
   }
 }
-.bso-modal--animation-cancel[aria-hidden='true'] .bso-modal__content {
+.bs-o-modal--animation-cancel[aria-hidden='true'] .bs-o-modal__content {
   transform: translate(-50%, 50%);
 }
-.bso-modal--animation-ok[aria-hidden='true'] .bso-modal__content {
+.bs-o-modal--animation-ok[aria-hidden='true'] .bs-o-modal__content {
   opacity: 1;
   transform: translate(-50%, -200%);
 }
-.bso-navbar {
+.bs-o-navbar {
   left: 0;
   position: absolute;
   right: 0;
   top: 100%;
 }
 @media screen and (prefers-reduced-motion: no-preference) {
-  .bso-navbar.is-transitioning {
+  .bs-o-navbar.is-transitioning {
     transition: opacity 0.2s ease-in, transform 0.12s ease-in;
     will-change: opacity;
   }
 }
-.bso-navbar.is-off-screen {
+.bs-o-navbar.is-off-screen {
   opacity: 0;
   transform: translateY(-7%);
 }
-.bso-navbar.is-on-screen {
+.bs-o-navbar.is-on-screen {
   opacity: 1;
   transform: none;
 }
-.bso-sidebar--large {
+.bs-o-sidebar--large {
   width: 1rem;
 }
-.bso-sidebar--small {
+.bs-o-sidebar--small {
   bottom: 0;
   box-shadow: 10rem 0 12.5rem rgba(0, 0, 0, 0.1),
     12.5rem 0 10rem rgba(0, 0, 0, 0.07), 0 0 20rem rgba(0, 0, 0, 0.1);
@@ -1571,60 +1571,60 @@ table {
   z-index: 1;
 }
 @media screen and (prefers-reduced-motion: no-preference) {
-  .bso-sidebar--small.is-transitioning {
+  .bs-o-sidebar--small.is-transitioning {
     transition: transform 0.12s ease-in;
     will-change: transform;
   }
 }
-.bso-sidebar--small.is-off-screen {
+.bs-o-sidebar--small.is-off-screen {
   transform: translateX(-100%);
 }
-.bso-sidebar--small.is-on-screen {
+.bs-o-sidebar--small.is-on-screen {
   transform: none;
 }
-.bso-notification-center {
+.bs-o-notification-center {
   pointer-events: none;
   position: fixed;
   right: 0;
   top: 0;
 }
-.bso-notification-center > * {
+.bs-o-notification-center > * {
   pointer-events: auto;
 }
-.bso-table {
+.bs-o-table {
   width: 100%;
 }
-.bso-table th {
+.bs-o-table th {
   background: #000;
   border-bottom: 1px solid #000;
   color: red;
   padding: 2.5rem 10rem;
   white-space: nowrap;
 }
-.bso-table td {
+.bs-o-table td {
   background: #000;
   border-bottom: 1px solid #000;
   padding: 7.5rem 10rem;
 }
-.bso-table tr:last-child td {
+.bs-o-table tr:last-child td {
   border: 0;
 }
-.bso-table .bso-table__actions {
+.bs-o-table__actions {
   padding-right: 7.5rem;
 }
-.bso-ui-group {
+.bs-o-ui-group {
   border-radius: 10rem;
   box-shadow: 0 0 1.25rem rgba(0, 0, 0, 0.025),
     0 0 1.6666666667rem rgba(0, 0, 0, 0.025), 0 0 2.5rem rgba(0, 0, 0, 0.025),
     0 0 5rem rgba(0, 0, 0, 0.025);
 }
-.bso-ui-group__item {
+.bs-o-ui-group__item {
   box-shadow: none;
 }
-.bso-ui-group__item:active:not(.bso-ui-group__last),
-.bso-ui-group__item:focus:not(.bso-ui-group__last),
-.bso-ui-group__item:hover:not(.bso-ui-group__last),
-.bso-ui-group__item:not(.bso-ui-group__last) {
+.bs-o-ui-group__item:active:not(.bs-o-ui-group__last),
+.bs-o-ui-group__item:focus:not(.bs-o-ui-group__last),
+.bs-o-ui-group__item:hover:not(.bs-o-ui-group__last),
+.bs-o-ui-group__item:not(.bs-o-ui-group__last) {
   border-right: 0;
 }
 .bs-u-absolute-center {

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -670,34 +670,34 @@ table {
   max-width: 100%;
   text-align: left;
 }
-.bsa-avatar {
+.bs-a-avatar {
   border-radius: 9999rem;
   height: 2em;
   overflow: hidden;
   width: 2em;
 }
-.bsa-avatar img {
+.bs-a-avatar img {
   height: 100%;
   -o-object-fit: cover;
   object-fit: cover;
   width: 100%;
 }
-.bsa-avatar--xl {
+.bs-a-avatar--xl {
   height: 10rem;
   width: 10rem;
 }
-.bsa-badge {
+.bs-a-badge {
   align-items: center;
   border-radius: 9999rem;
   display: inline-flex;
   padding: 2.5rem 10rem;
   white-space: nowrap;
 }
-.bsa-badge .bsa-badge__button {
+.bs-a-badge .bs-a-badge__button {
   margin-left: 5rem;
   margin-right: -7.5rem;
 }
-.bsa-badge--gray {
+.bs-a-badge--gray {
   --button-fg: #000;
   --button-bg: #000;
   --button-fg-hover: #000;
@@ -705,7 +705,7 @@ table {
   background-color: #000;
   color: #000;
 }
-.bsa-badge--danger {
+.bs-a-badge--danger {
   --button-fg: #000;
   --button-bg: #000;
   --button-fg-hover: #000;
@@ -713,7 +713,7 @@ table {
   background-color: #000;
   color: #000;
 }
-.bsa-badge--brand-1 {
+.bs-a-badge--brand-1 {
   --button-fg: #000;
   --button-bg: #000;
   --button-fg-hover: #000;
@@ -721,7 +721,7 @@ table {
   background-color: #000;
   color: #000;
 }
-.bsa-badge--brand-2 {
+.bs-a-badge--brand-2 {
   --button-fg: #000;
   --button-bg: #000;
   --button-fg-hover: #000;
@@ -729,7 +729,7 @@ table {
   background-color: #000;
   color: #000;
 }
-.bsa-badge--positive {
+.bs-a-badge--positive {
   --button-fg: #000;
   --button-bg: #000;
   --button-fg-hover: #000;
@@ -737,18 +737,18 @@ table {
   background-color: #000;
   color: #000;
 }
-.bsa-bordered-header {
+.bs-a-bordered-header {
   grid-gap: 10rem;
   align-items: center;
   display: grid;
   grid-template-columns: auto minmax(1px, 1fr);
   width: 100%;
 }
-.bsa-bordered-header:after {
+.bs-a-bordered-header:after {
   border-top: 1.25rem solid #000;
   content: '';
 }
-.bsa-button {
+.bs-a-button {
   align-items: center;
   -webkit-appearance: none;
   border-radius: 5rem;
@@ -775,8 +775,8 @@ table {
   user-select: none;
   white-space: nowrap;
 }
-.bsa-button,
-.bsa-button:visited {
+.bs-a-button,
+.bs-a-button:visited {
   background: #000;
   border: 1.25rem solid #000;
   box-shadow: 0 0 1.25rem rgba(0, 0, 0, 0.2),
@@ -784,8 +784,8 @@ table {
     0 0 5rem rgba(0, 0, 0, 0.2);
   color: #000;
 }
-.bsa-button:focus,
-.bsa-button:hover {
+.bs-a-button:focus,
+.bs-a-button:hover {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 1.875rem rgba(0, 0, 0, 0.2), 0 0 2.5rem rgba(0, 0, 0, 0.2),
@@ -794,7 +794,7 @@ table {
   outline: none;
   text-decoration: none;
 }
-.bsa-button:active {
+.bs-a-button:active {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 1.25rem rgba(0, 0, 0, 0.3),
@@ -802,32 +802,32 @@ table {
     0 0 5rem rgba(0, 0, 0, 0.3);
   color: #000;
 }
-.bsa-button:disabled,
-.bsa-button[aria-disabled='true'] {
+.bs-a-button:disabled,
+.bs-a-button[aria-disabled='true'] {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
   cursor: not-allowed;
 }
-.bsa-button__avatar,
-.bsa-button__icon {
+.bs-a-button__avatar,
+.bs-a-button__icon {
   margin-left: -1.875rem;
   margin-right: 7.5rem;
 }
-.bsa-button__label + .bsa-button__icon {
+.bs-a-button__label + .bs-a-button__icon {
   margin-left: 7.5rem;
   margin-right: -1.875rem;
 }
-.bsa-button--danger:focus,
-.bsa-button--danger:hover {
+.bs-a-button--danger:focus,
+.bs-a-button--danger:hover {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 1.875rem rgba(0, 0, 0, 0.3), 0 0 2.5rem rgba(0, 0, 0, 0.3),
     0 0 3.75rem rgba(0, 0, 0, 0.3), 0 0 7.5rem rgba(0, 0, 0, 0.3);
   color: #000;
 }
-.bsa-button--danger:active {
+.bs-a-button--danger:active {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 1.25rem rgba(0, 0, 0, 0.3),
@@ -835,125 +835,125 @@ table {
     0 0 5rem rgba(0, 0, 0, 0.3);
   color: #000;
 }
-.bsa-button--danger:disabled,
-.bsa-button--danger[aria-disabled='true'] {
+.bs-a-button--danger:disabled,
+.bs-a-button--danger[aria-disabled='true'] {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--icon {
+.bs-a-button--icon {
   border-radius: 7.5rem;
   justify-content: flex-start;
   padding: 10rem;
 }
-.bsa-button--icon,
-.bsa-button--icon:visited {
+.bs-a-button--icon,
+.bs-a-button--icon:visited {
   background-color: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--icon:focus,
-.bsa-button--icon:hover {
+.bs-a-button--icon:focus,
+.bs-a-button--icon:hover {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--icon:active {
+.bs-a-button--icon:active {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--icon:disabled,
-.bsa-button--icon[aria-disabled='true'] {
+.bs-a-button--icon:disabled,
+.bs-a-button--icon[aria-disabled='true'] {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--icon .bsa-button__icon {
+.bs-a-button--icon .bs-a-button__icon {
   margin: 0;
 }
-.bsa-button--icon-reversed,
-.bsa-button--icon-reversed:visited {
+.bs-a-button--icon-reversed,
+.bs-a-button--icon-reversed:visited {
   background: var(--button-bg, transparent);
   border-color: transparent;
   box-shadow: none;
   color: var(--button-fg, #000);
 }
-.bsa-button--icon-reversed:focus,
-.bsa-button--icon-reversed:hover {
+.bs-a-button--icon-reversed:focus,
+.bs-a-button--icon-reversed:hover {
   background: var(--button-bg-hover, #000);
   border-color: #000;
   box-shadow: none;
   color: var(--button-fg-hover, #000);
 }
-.bsa-button--icon-reversed:active {
+.bs-a-button--icon-reversed:active {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--icon-reversed:disabled,
-.bsa-button--icon-reversed[aria-disabled='true'] {
+.bs-a-button--icon-reversed:disabled,
+.bs-a-button--icon-reversed[aria-disabled='true'] {
   background: transparent;
   border-color: transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--menu {
+.bs-a-button--menu {
   border-radius: 0;
   display: flex;
   justify-content: flex-start;
   min-height: 0;
   padding: 7.5rem 10rem;
 }
-.bsa-button--menu,
-.bsa-button--menu:visited {
+.bs-a-button--menu,
+.bs-a-button--menu:visited {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--menu:focus,
-.bsa-button--menu:hover {
+.bs-a-button--menu:focus,
+.bs-a-button--menu:hover {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--menu:active {
+.bs-a-button--menu:active {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--menu:disabled,
-.bsa-button--menu[aria-disabled='true'] {
+.bs-a-button--menu:disabled,
+.bs-a-button--menu[aria-disabled='true'] {
   background: transparent;
   border-color: transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--mode-container {
+.bs-a-button--mode-container {
   border-radius: 7.5rem;
 }
-.bsa-button--mode {
+.bs-a-button--mode {
   padding-bottom: 0;
   padding-top: 0;
 }
-.bsa-button--mode,
-.bsa-button--mode:visited {
+.bs-a-button--mode,
+.bs-a-button--mode:visited {
   background: transparent;
   border-color: transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--mode:focus,
-.bsa-button--mode:hover {
+.bs-a-button--mode:focus,
+.bs-a-button--mode:hover {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 2.5rem rgba(0, 0, 0, 0.05),
@@ -961,7 +961,7 @@ table {
     0 0 10rem rgba(0, 0, 0, 0.05);
   color: #000;
 }
-.bsa-button--mode:active {
+.bs-a-button--mode:active {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 1.25rem rgba(0, 0, 0, 0.05),
@@ -969,34 +969,34 @@ table {
     0 0 5rem rgba(0, 0, 0, 0.05);
   color: #000;
 }
-.bsa-button--mode[aria-pressed='true'] {
+.bs-a-button--mode[aria-pressed='true'] {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 1.875rem rgba(0, 0, 0, 0.05), 0 0 2.5rem rgba(0, 0, 0, 0.05),
     0 0 3.75rem rgba(0, 0, 0, 0.05), 0 0 7.5rem rgba(0, 0, 0, 0.05);
   color: #000;
 }
-.bsa-button--mode:disabled,
-.bsa-button--mode[aria-disabled='true'] {
+.bs-a-button--mode:disabled,
+.bs-a-button--mode[aria-disabled='true'] {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--nav {
+.bs-a-button--nav {
   border-radius: 5rem;
   justify-content: flex-start;
   padding: 5rem 10rem;
 }
-.bsa-button--nav,
-.bsa-button--nav:visited {
+.bs-a-button--nav,
+.bs-a-button--nav:visited {
   background: transparent;
   border-color: transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--nav:focus,
-.bsa-button--nav:hover {
+.bs-a-button--nav:focus,
+.bs-a-button--nav:hover {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 3.125rem rgba(0, 0, 0, 0.15),
@@ -1004,7 +1004,7 @@ table {
     0 0 12.5rem rgba(0, 0, 0, 0.15);
   color: #000;
 }
-.bsa-button--nav:active {
+.bs-a-button--nav:active {
   background: #000;
   border-color: #000;
   box-shadow: 0 0 1.25rem rgba(0, 0, 0, 0.15),
@@ -1012,90 +1012,90 @@ table {
     0 0 5rem rgba(0, 0, 0, 0.15);
   color: #000;
 }
-.bsa-button--nav[aria-current],
-.bsa-button--nav[aria-expanded='true'] {
+.bs-a-button--nav[aria-current],
+.bs-a-button--nav[aria-expanded='true'] {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--nav:disabled,
-.bsa-button--nav[aria-disabled='true'] {
+.bs-a-button--nav:disabled,
+.bs-a-button--nav[aria-disabled='true'] {
   background: transparent;
   border-color: transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button-nav__icon {
+.bs-a-button-nav__icon {
   margin-left: -2.5rem;
   margin-right: 10rem;
 }
-.bsa-button--nav-large {
+.bs-a-button--nav-large {
   border-radius: 7.5rem;
   display: flex;
   justify-content: flex-start;
   padding: 12.5rem;
   width: 100%;
 }
-.bsa-button--nav-large,
-.bsa-button--nav-large:visited {
+.bs-a-button--nav-large,
+.bs-a-button--nav-large:visited {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--nav-large:focus,
-.bsa-button--nav-large:hover {
+.bs-a-button--nav-large:focus,
+.bs-a-button--nav-large:hover {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--nav-large:active {
+.bs-a-button--nav-large:active {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--nav-large[aria-current],
-.bsa-button--nav-large[aria-expanded='true'] {
+.bs-a-button--nav-large[aria-current],
+.bs-a-button--nav-large[aria-expanded='true'] {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--nav-large:disabled,
-.bsa-button--nav-large[aria-disabled='true'] {
+.bs-a-button--nav-large:disabled,
+.bs-a-button--nav-large[aria-disabled='true'] {
   background: #000;
   border: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--small {
+.bs-a-button--small {
   min-height: 20rem;
   padding: 10rem;
 }
-.bsa-button--small.bsa-button--icon {
+.bs-a-button--small.bs-a-button--icon {
   border-radius: 9999rem;
   padding: 5rem;
 }
-.bsa-button--tab-container > :first-child {
+.bs-a-button--tab-container > :first-child {
   margin-left: -10rem;
 }
-.bsa-button--tab {
+.bs-a-button--tab {
   border: 0;
   border-radius: 0;
   position: relative;
 }
-.bsa-button--tab,
-.bsa-button--tab:visited {
+.bs-a-button--tab,
+.bs-a-button--tab:visited {
   background: transparent;
   border: 2px solid transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--tab:after,
-.bsa-button--tab:visited:after {
+.bs-a-button--tab:after,
+.bs-a-button--tab:visited:after {
   background-color: transparent;
   border-radius: 9999rem;
   bottom: 0;
@@ -1106,77 +1106,77 @@ table {
   right: 10rem;
   transition: background-color 75ms ease-out;
 }
-.bsa-button--tab:focus,
-.bsa-button--tab:hover {
+.bs-a-button--tab:focus,
+.bs-a-button--tab:hover {
   background: transparent;
   border: 2px solid transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--tab:focus:after,
-.bsa-button--tab:hover:after {
+.bs-a-button--tab:focus:after,
+.bs-a-button--tab:hover:after {
   background-color: #000;
 }
-.bsa-button--tab:active {
+.bs-a-button--tab:active {
   background: transparent;
   border: 2px solid transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--tab:active:after {
+.bs-a-button--tab:active:after {
   background-color: #000;
 }
-.bsa-button--tab[aria-current],
-.bsa-button--tab[aria-selected='true'] {
+.bs-a-button--tab[aria-current],
+.bs-a-button--tab[aria-selected='true'] {
   background: transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--tab[aria-current]:after,
-.bsa-button--tab[aria-selected='true']:after {
+.bs-a-button--tab[aria-current]:after,
+.bs-a-button--tab[aria-selected='true']:after {
   background-color: #000;
 }
-.bsa-button--tab:disabled,
-.bsa-button--tab[aria-disabled='true'] {
+.bs-a-button--tab:disabled,
+.bs-a-button--tab[aria-disabled='true'] {
   background: transparent;
   border: 2px solid transparent;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--tab:disabled:after,
-.bsa-button--tab[aria-disabled='true']:after {
+.bs-a-button--tab:disabled:after,
+.bs-a-button--tab[aria-disabled='true']:after {
   background-color: transparent;
 }
-.bsa-button--ui,
-.bsa-button--ui:visited {
+.bs-a-button--ui,
+.bs-a-button--ui:visited {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--ui:focus,
-.bsa-button--ui:hover {
+.bs-a-button--ui:focus,
+.bs-a-button--ui:hover {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--ui:active {
+.bs-a-button--ui:active {
   background: #000;
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--ui:disabled,
-.bsa-button--ui[aria-disabled='true'] {
+.bs-a-button--ui:disabled,
+.bs-a-button--ui[aria-disabled='true'] {
   background: rgba(0, 0, 0, 0.5);
   border-color: #000;
   box-shadow: none;
   color: #000;
 }
-.bsa-button--ui[aria-current],
-.bsa-button--ui[aria-expanded='true'],
-.bsa-button--ui[aria-pressed='true'] {
+.bs-a-button--ui[aria-current],
+.bs-a-button--ui[aria-expanded='true'],
+.bs-a-button--ui[aria-pressed='true'] {
   background: #000;
   border-color: #000;
   color: #000;
@@ -1281,7 +1281,7 @@ table {
     padding: 10rem 20rem;
   }
 }
-.bsa-content {
+.bs-a-content {
   margin-left: auto;
   margin-right: auto;
   max-width: 100%;
@@ -1291,41 +1291,41 @@ table {
   width: 100%;
 }
 @media screen and (min-width: 55em) {
-  .bsa-content {
+  .bs-a-content {
     padding-left: 12.5rem;
     padding-right: 12.5rem;
   }
 }
 @media screen and (min-width: 95em) {
-  .bsa-content {
+  .bs-a-content {
     padding-left: 20rem;
     padding-right: 20rem;
   }
 }
-.bsa-content--xs {
+.bs-a-content--xs {
   max-width: 25rem;
 }
-.bsa-content--s {
+.bs-a-content--s {
   max-width: 35rem;
 }
-.bsa-content--m {
+.bs-a-content--m {
   max-width: 65rem;
 }
-.bsa-content--l {
+.bs-a-content--l {
   max-width: 85rem;
 }
-.bsa-content--full {
+.bs-a-content--full {
   max-width: 100%;
 }
-.bsa-dl {
+.bs-a-dl {
   border-top: 1px solid #000;
 }
 @media screen and (min-width: 30em) {
-  .bsa-dl__item {
+  .bs-a-dl__item {
     border-bottom: 1px solid #000;
   }
 }
-.bsa-dropdown {
+.bs-a-dropdown {
   background-color: #000;
   border: 2px solid #000;
   border-radius: 5rem;
@@ -1345,59 +1345,59 @@ table {
   width: min-content;
   z-index: 1;
 }
-.bsa-dropdown [role='separator'] {
+.bs-a-dropdown [role='separator'] {
   border-top: 1px solid #000;
   margin: 2.5rem 0;
 }
 @media screen and (prefers-reduced-motion: no-preference) {
-  .bsa-dropdown.is-transitioning {
+  .bs-a-dropdown.is-transitioning {
     transition: opacity 0.12s ease-in;
     will-change: opacity;
   }
 }
-.bsa-dropdown.is-off-screen {
+.bs-a-dropdown.is-off-screen {
   opacity: 0;
 }
-.bsa-dropdown.is-on-screen {
+.bs-a-dropdown.is-on-screen {
   opacity: 1;
 }
-.bsa-dropdown--right {
+.bs-a-dropdown--right {
   right: 0;
 }
-.bsa-dropdown--top {
+.bs-a-dropdown--top {
   bottom: 100%;
   top: auto;
 }
-.a-dropdown--full-width {
+.bs-a-dropdown--full-width {
   left: 0;
   max-width: none;
   right: 0;
   width: 100%;
 }
 @media screen and (max-width: 20em) {
-  .bsa-dropdown {
+  .bs-a-dropdown {
     left: 0;
     right: 0;
     width: 100%;
   }
 }
-.bsa-flash--brand-1 {
+.bs-a-flash--brand-1 {
   background-color: #000;
   color: #000;
 }
-.bsa-flash--positive {
+.bs-a-flash--positive {
   background-color: #000;
   color: #000;
 }
-.bsa-flash--danger {
+.bs-a-flash--danger {
   background-color: #000;
   color: #000;
 }
-.bsa-flash--warning {
+.bs-a-flash--warning {
   background-color: #000;
   color: #000;
 }
-.bsa-icon {
+.bs-a-icon {
   fill: currentColor;
   display: inline-block;
   flex-shrink: 0;
@@ -1409,10 +1409,10 @@ table {
   vertical-align: middle;
   width: 1em;
 }
-.bsa-icon--s {
+.bs-a-icon--s {
   font-size: 10rem;
 }
-.bsa-link {
+.bs-a-link {
   -webkit-text-decoration-skip: ink;
   -webkit-appearance: none;
   background-color: none;
@@ -1426,31 +1426,31 @@ table {
   text-decoration-skip-ink: auto;
   transition: color 75ms ease-out;
 }
-.bsa-link:visited {
+.bs-a-link:visited {
   background-color: none;
   box-shadow: none;
   color: #000;
   text-decoration: none;
 }
-.bsa-link:focus,
-.bsa-link:hover {
+.bs-a-link:focus,
+.bs-a-link:hover {
   background-color: none;
   box-shadow: none;
   color: #000;
   text-decoration: underline;
 }
-.bsa-link:active {
+.bs-a-link:active {
   background-color: none;
   box-shadow: none;
   color: #000;
   text-decoration: underline;
 }
-.bsa-list-reset {
+.bs-a-list-reset {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
-.a-skip-link {
+.bs-a-skip-link {
   font-weight: 600;
   left: 50%;
   padding: 10rem;
@@ -1459,18 +1459,18 @@ table {
   transform: translateX(-50%);
   z-index: 1;
 }
-.a-skip-link,
-.a-skip-link:focus,
-.a-skip-link:hover,
-.a-skip-link:visited {
+.bs-a-skip-link,
+.bs-a-skip-link:focus,
+.bs-a-skip-link:hover,
+.bs-a-skip-link:visited {
   background: #000;
   border: 2.5rem solid #000;
   color: red;
 }
-.a-skip-link:focus {
+.bs-a-skip-link:focus {
   top: 0;
 }
-.bsa-topbar {
+.bs-a-topbar {
   left: 0;
   padding: 10rem;
   position: relative;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -1629,7 +1629,7 @@ table {
 .o-table tr:last-child td {
   border: 0;
 }
-.o-table .o-table__actions {
+.o-table__actions {
   padding-right: 0.6rem;
 }
 .o-ui-group {


### PR DESCRIPTION
Fixes #663 

## Changes

- All atoms and organisms now use the helper function to create correct classnames (see fixtures for results)

No visual changes.

## Checks

Delete if not applicable:

- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
