### PR TITLE
[#688] Fix text utility overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Fixed
 
 - All classnames of atoms and organisms now correctly insert a minus character between the global namespace and the rest of the classname. If you were using `setup.$namespace`, you’ll need to update those classnames to include a minus e.g. `.namespacea-button` becomes `.namespace-a-button`
+- `utilities/text` now correctly forwards its configuration, so it can be overridden when imported or used
 
 ## [[4.3.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v4.3.0) - 2022-05-25
 

--- a/scss/bitstyles/utilities/text/_index.import.scss
+++ b/scss/bitstyles/utilities/text/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-text-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/text/_index.scss
+++ b/scss/bitstyles/utilities/text/_index.scss
@@ -1,3 +1,4 @@
+@forward './settings';
 @use './settings';
 @use '../../tools/properties';
 @use '../../tools/media-query';

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -3549,17 +3549,8 @@ table {
     width: 1px;
   }
 }
-.bs-text-left {
-  text-align: left;
-}
-.bs-text-right {
-  text-align: right;
-}
-.bs-text-center {
-  text-align: center;
-}
-.bs-text-justify {
-  text-align: justify;
+.bs-text-top {
+  text-align: top;
 }
 .bs-truncate {
   max-width: 100%;

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -242,6 +242,9 @@ $bitstyles-self-values: (
   'start': start,
 );
 $bitstyles-sr-only-breakpoints: ('xl');
+$bitstyles-text-values: (
+  'top': top,
+);
 $bitstyles-typography-responsive-utilities-values: (
   'm': (
     'h1': (

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -242,6 +242,9 @@ $bitstyles-self-values: (
   'start': start,
 );
 $bitstyles-sr-only-breakpoints: ('xl');
+$bitstyles-text-values: (
+  'top': top,
+);
 $bitstyles-typography-responsive-utilities-values: (
   'm': (
     'h1': (

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -172,6 +172,7 @@
   $row-start-values: ('100': 100, '200': 200),
   $self-values: ('start': start),
   $sr-only-breakpoints: ('xl'),
+  $text-values: ('top': top),
   $typography-responsive-utilities-values: (
     'm': (
       'h1': (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -413,7 +413,11 @@
     'xl',
   )
 );
-@use '../../scss/bitstyles/utilities/text';
+@use '../../scss/bitstyles/utilities/text' with (
+  $values: (
+    'top': top,
+  )
+);
 @use '../../scss/bitstyles/utilities/truncate';
 @use '../../scss/bitstyles/utilities/typography-responsive' as
   typography-responsive-utilities with (


### PR DESCRIPTION
Fixes #688 

## Changes

- settings for utilities/text are now correctly forwarded for each of the possible import methods

## Checks

Delete if not applicable:

- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
