### PR TITLE
[#691] Rename u-gap-m to u-gap-l

### DIFF
--- a/scss/bitstyles/atoms/card/card.stories.mdx
+++ b/scss/bitstyles/atoms/card/card.stories.mdx
@@ -9,7 +9,7 @@ A content wrapper that sections and subtly highlights a chunk of content. For la
 <Canvas>
   <Story name="Card">
     {`
-    <div class="u-grid u-grid-cols-3@m u-gap-m">
+    <div class="u-grid u-grid-cols-3@m u-gap-l">
       <article class="a-card">
         <h3 class="u-h4">Standard card</h3>
         <ul class="a-list-reset">
@@ -33,7 +33,7 @@ A content wrapper that sections and subtly highlights a chunk of content. For la
   </Story>
   <Story name="Card-L">
     {`
-    <div class="u-grid u-grid-cols-2@m u-gap-m">
+    <div class="u-grid u-grid-cols-2@m u-gap-l">
       <article class="a-card-l">
         <h3>Large card</h3>
         <ul class="a-list-reset">
@@ -58,7 +58,7 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
 <Canvas isColumn>
   <Story name="Card header">
     {`
-    <div class="u-grid u-grid-cols-2@m u-gap-m">
+    <div class="u-grid u-grid-cols-2@m u-gap-l">
       <article class="a-card">
         <div class="a-card__header a-flash a-flash--danger">
           Something happened

--- a/scss/bitstyles/atoms/dl/dl.stories.mdx
+++ b/scss/bitstyles/atoms/dl/dl.stories.mdx
@@ -10,15 +10,15 @@ A list of term/description pairs, used to display any set of key-value pairs. It
   <Story name="dl">
     {`
       <dl class="a-dl">
-        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
+        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-l u-padding-m-y u-padding-m@m u-items-baseline">
           <dt class="u-font-medium u-h6 u-fg-text u-margin-xs-bottom@s">Full name</dt>
           <dd class="u-col-span-2">Muffin Gummies</dd>
         </div>
-        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
+        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-l u-padding-m-y u-padding-m@m u-items-baseline">
           <dt class="u-font-medium u-h6 u-fg-text u-margin-xs-bottom@s">Email</dt>
           <dd class="u-col-span-2">cupcake@tiramisu.com</dd>
         </div>
-        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
+        <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-l u-padding-m-y u-padding-m@m u-items-baseline">
           <dt class="u-font-medium u-h6 u-fg-text u-margin-xs-bottom@s">Description</dt>
           <dd class="u-col-span-2">Muffin gummies tart fruitcake gummi bears chocolate bar. Jujubes candy macaroon topping dessert biscuit topping sugar plum sesame snaps. Chocolate donut cake tootsie roll donut biscuit caramels sugar plum jelly beans. Dessert dragée jelly-o gummi bears sweet halvah soufflé.</dd>
         </div>

--- a/scss/bitstyles/organisms/modal/modal.stories.mdx
+++ b/scss/bitstyles/organisms/modal/modal.stories.mdx
@@ -78,7 +78,7 @@ If you have multiple options for the user, present them with any information the
         <div class="u-flex-grow-1 u-overflow-y-auto u-fg-text u-text-center">
           <p>The previous email we sent to email@example.com will no longer be valid.</p>
         </div>
-        <ul class="a-list-reset u-grid u-grid-cols-2@m u-gap-m u-items-center u-margin-l-top">
+        <ul class="a-list-reset u-grid u-grid-cols-2@m u-gap-l u-items-center u-margin-l-top">
           <li class="u-flex u-flex-col">
             <button class="a-button a-button--ui" type="button" data-a11y-dialog-hide>Cancel</button>
           </li>

--- a/scss/bitstyles/settings/breakpoints.stories.mdx
+++ b/scss/bitstyles/settings/breakpoints.stories.mdx
@@ -35,7 +35,7 @@ Most of the utility classes and many of the components are available at various 
 Breakpoint-limited classnames are suffixed with an `@` symbol and the name of the breakpoint e.g. `.u-classname@xl`, `u-classname@motion-ok`. As we’re using the mobile-first approach, apply your base styles suitable for smaller viewport sizes then provide overrides for larger viewports using classes with breakpoint suffixes.
 
 ```html
-<div class="u-grid u-gap-m u-grid-cols-6@m">
+<div class="u-grid u-gap-l u-grid-cols-6@m">
   <!--
     Insert content blocks here, they’ll display in a single column on smaller viewports,
     and six columns in viewports larger than the `m` breakpoint

--- a/scss/bitstyles/ui/dl.stories.mdx
+++ b/scss/bitstyles/ui/dl.stories.mdx
@@ -25,7 +25,7 @@ A list of term/description pairs, used to display any set of key-value pairs. It
       <a href="/docs/utilities-font--font-medium">u-font</a>
     </li>
     <li>
-      <a href="/docs/utilities-gap--u-gap-m">u-gap</a>
+      <a href="/docs/utilities-gap--u-gap-l">u-gap</a>
     </li>
     <li>
       <a href="/docs/utilities-grid--u-grid">u-grid</a>
@@ -48,15 +48,15 @@ A list of term/description pairs, used to display any set of key-value pairs. It
           <p class="u-fg-text u-h6">Cookie croissant jujubes tart. Jelly beans marshmallow cake apple pie. Sweet carrot cake marshmallow bonbon gummies lollipop bear claw.</p>
         </div>
         <dl class="a-dl">
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-l u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font-medium u-h6 u-fg-text u-margin-xs-bottom@s">Full name</dt>
             <dd class="u-col-span-2">Muffin Gummies</dd>
           </div>
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-l u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font-medium u-h6 u-fg-text u-margin-xs-bottom@s">Email</dt>
             <dd class="u-col-span-2">cupcake@tiramisu.com</dd>
           </div>
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-l u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font-medium u-h6 u-fg-text u-margin-xs-bottom@s">Description</dt>
             <dd class="u-col-span-2">Muffin gummies tart fruitcake gummi bears chocolate bar. Jujubes candy macaroon topping dessert biscuit topping sugar plum sesame snaps. Chocolate donut cake tootsie roll donut biscuit caramels sugar plum jelly beans. Dessert dragée jelly-o gummi bears sweet halvah soufflé.</dd>
           </div>

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -193,8 +193,8 @@ For a more complex form, `.u-grid-cols-6@m` allows for fields of different sizes
           <div class="a-bordered-header u-margin-xl-bottom">
             <legend class="u-h3 u-font-bold">Account details</legend>
           </div>
-          <div class="u-grid u-gap-m u-grid-cols-6@l u-gap-m">
-            <ul class="a-list-reset u-col-start-3@l u-grid u-gap-m u-grid-cols-6@m u-col-span-4@l">
+          <div class="u-grid u-gap-l u-grid-cols-6@l u-gap-l">
+            <ul class="a-list-reset u-col-start-3@l u-grid u-gap-l u-grid-cols-6@m u-col-span-4@l">
               <li class="u-col-span-4@m u-col-start-1@m u-col-span-3@l">
                 <label for="name">Name</label>
                 <input id="name" type="text" autocomplete="name" value="Jon Doe" />
@@ -217,11 +217,11 @@ For a more complex form, `.u-grid-cols-6@m` allows for fields of different sizes
           <div class="a-bordered-header u-margin-xl-bottom">
             <legend class="u-h3 u-font-bold a-bordered-header">Address</legend>
           </div>
-          <div class="u-grid u-gap-m u-grid-cols-6@l">
+          <div class="u-grid u-gap-l u-grid-cols-6@l">
             <div class="u-col-span-2@l">
               <p class="u-h6 u-fg-text-light u-padding-l-y@l u-padding-xl-right@m">Some intro text can go here, to describe this section</p>
             </div>
-            <ul class="a-list-reset u-col-start-3@l u-col-span-4@l u-grid u-gap-m u-grid-cols-6@m u-gap-m">
+            <ul class="a-list-reset u-col-start-3@l u-col-span-4@l u-grid u-gap-l u-grid-cols-6@m u-gap-l">
               <li class="u-col-span-4@m u-col-span-3@l">
                 <label for="street">Street</label>
                 <input id="street" type="text" autocomplete="address-line1" />
@@ -245,7 +245,7 @@ For a more complex form, `.u-grid-cols-6@m` allows for fields of different sizes
             </ul>
           <div>
         </fieldset>
-        <div class="u-grid u-gap-m u-grid-cols-6@l u-gap-m u-margin-xl-bottom">
+        <div class="u-grid u-gap-l u-grid-cols-6@l u-gap-l u-margin-xl-bottom">
           <ul class="a-list-reset u-flex u-items-center u-col-start-3@l u-col-span-4@l">
             <li class="u-margin-l-right">
               <button type="submit" class="a-button">Save changes</button>
@@ -270,8 +270,8 @@ Some forms are always going to be small and simple, with just a few text inputs 
       <form action="" method="POST" class="a-content">
         <fieldset>
           <legend class="u-sr-only">User LKJHAS786SGLKJHAFGO7YEGKJBF</legend>
-          <div class="u-grid u-gap-m u-grid-cols-6@l u-margin-xl-bottom">
-            <ul class="a-list-reset u-grid u-gap-m u-grid-cols-6@m u-col-span-4@l">
+          <div class="u-grid u-gap-l u-grid-cols-6@l u-margin-xl-bottom">
+            <ul class="a-list-reset u-grid u-gap-l u-grid-cols-6@m u-col-span-4@l">
               <li class="u-col-span-4@m u-col-start-1@m">
                 <label for="name">Name</label>
                 <input id="name" type="text" autocomplete="name" value="Jon Doe" />

--- a/scss/bitstyles/ui/stats.stories.mdx
+++ b/scss/bitstyles/ui/stats.stories.mdx
@@ -25,7 +25,7 @@ Highlighting a few statistics presents us the opportunity to give context and in
       <a href="/docs/utilities-font--font-medium">u-font</a>
     </li>
     <li>
-      <a href="/docs/utilities-gap--u-gap-m">u-gap</a>
+      <a href="/docs/utilities-gap--u-gap-l">u-gap</a>
     </li>
     <li>
       <a href="/docs/utilities-grid--u-grid">u-grid</a>
@@ -58,7 +58,7 @@ Highlighting a few statistics presents us the opportunity to give context and in
   <Story name="Stats (with change indicators)">
     {`
       <div class="a-content">
-        <dl class="u-grid u-grid-cols-3@m u-gap-m">
+        <dl class="u-grid u-grid-cols-3@m u-gap-l">
           <div class="a-card u-flex u-items-center">
             <div class="u-flex--shrink-0 u-margin-s-right">
               <div class="a-badge a-badge--danger u-padding-l">
@@ -113,7 +113,7 @@ As in this next example, the change indicators could be replaced by static icono
   <Story name="Stats (with iconography)">
     {`
       <div class="a-content">
-        <dl class="u-grid u-grid-cols-3@m u-gap-m">
+        <dl class="u-grid u-grid-cols-3@m u-gap-l">
           <div class="a-card u-flex u-items-center">
             <div class="u-flex--shrink-0 u-margin-s-right">
               <div class="a-badge a-badge--danger u-padding-m">
@@ -166,7 +166,7 @@ The simplest form (but least easily-digestible for the user) shows some text-onl
   <Story name="Stats (simple)">
     {`
       <div class="a-content">
-        <dl class="u-grid u-grid-cols-3@m u-gap-m">
+        <dl class="u-grid u-grid-cols-3@m u-gap-l">
           <div class="a-card">
             <dt class="u-font-medium u-h6 u-fg-text-light">In storage</dt>
             <dd class="u-h2 u-font-bold u-line-height-min">104</dd>

--- a/scss/bitstyles/ui/ui-components.mdx
+++ b/scss/bitstyles/ui/ui-components.mdx
@@ -64,7 +64,7 @@ import iconThumb from '../../../test/assets/images/icon-thumb.svg';
 
 Large chunks of navigation at various levels.
 
-<ul class="a-list-reset u-grid@m u-gap-m u-grid-cols-2@m u-grid-cols-3@l u-margin-xl-top">
+<ul class="a-list-reset u-grid@m u-gap-l u-grid-cols-2@m u-grid-cols-3@l u-margin-xl-top">
   <li>
     <a class="u-block" href="/docs/ui-navigation-navbar--navbar">
       <div class="a-card u-padding-0 u-margin-m-bottom">
@@ -119,7 +119,7 @@ Large chunks of navigation at various levels.
 
 Some larger chunks of the content for each page.
 
-<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-m u-margin-xl-top">
+<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
   <li>
     <a class="u-block" href="/docs/ui-content-page-header--page-header">
       <div class="a-card u-padding-0 u-margin-m-bottom">
@@ -144,7 +144,7 @@ Some larger chunks of the content for each page.
 
 Various buttons, and some methods to arrange them together.
 
-<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-m u-margin-xl-top">
+<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
   <li>
     <a class="u-block" href="/docs/ui-buttons-buttons--page">
       <div class="a-card u-padding-0 u-margin-m-bottom">
@@ -211,7 +211,7 @@ Various buttons, and some methods to arrange them together.
 
 Organize and highlight the information the user is here to see.
 
-<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-m u-margin-xl-top">
+<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
   <li>
     <a class="u-block" href="/docs/ui-data-description-list--description-list">
       <div class="a-card u-padding-0 u-margin-m-bottom">

--- a/scss/bitstyles/utilities/col-span/col-span.stories.mdx
+++ b/scss/bitstyles/utilities/col-span/col-span.stories.mdx
@@ -9,7 +9,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
 <Canvas isColumn>
   <Story name="u-col-span-1">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-1">Grid child 1, span 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -21,7 +21,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-2">Grid child 1, span 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -33,7 +33,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-3">Grid child 1, span 3</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -45,7 +45,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-4">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-4">Grid child 1, span 4</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -57,7 +57,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-5">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-5">Grid child 1, span 5</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -69,7 +69,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-6">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6">Grid child 1, span 6</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -88,7 +88,7 @@ The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See
 <Canvas isColumn>
   <Story name="u-col-span-6@s">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@s">Grid child 1, span 6 @s</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -100,7 +100,7 @@ The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See
   </Story>
   <Story name="u-col-span-6@m">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@m">Grid child 1, span 6 @m</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -112,7 +112,7 @@ The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See
   </Story>
   <Story name="u-col-span-6@l">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@l">Grid child 1, span 6 @l</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -124,7 +124,7 @@ The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See
   </Story>
   <Story name="u-col-span-6@xl">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@xl">Grid child 1, span 6 @xl</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>

--- a/scss/bitstyles/utilities/col-start/col-start.stories.mdx
+++ b/scss/bitstyles/utilities/col-start/col-start.stories.mdx
@@ -13,7 +13,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
 <Canvas isColumn>
   <Story name="u-col-start-1">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1">6-column grid, child 3, col-start-1</li>
@@ -25,7 +25,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-2">6-column grid, child 3, col-start-2</li>
@@ -37,7 +37,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
@@ -49,7 +49,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-4">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-4">6-column grid, child 3, col-start-4</li>
@@ -61,7 +61,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-5">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-5">6-column grid, child 3, col-start-5</li>
@@ -73,7 +73,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-6">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-6">6-column grid, child 3, col-start-6</li>
@@ -92,7 +92,7 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 <Canvas isColumn>
   <Story name="u-col-start-1@s">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@s">6-column grid, child 3, col-start-1@s</li>
@@ -104,7 +104,7 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
   </Story>
   <Story name="u-col-start-1@m">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@m">6-column grid, child 3, col-start-1@m</li>
@@ -116,7 +116,7 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
   </Story>
   <Story name="u-col-start-1@xl">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@xl">6-column grid, child 3, col-start-1@xl</li>

--- a/scss/bitstyles/utilities/display/display.stories.mdx
+++ b/scss/bitstyles/utilities/display/display.stories.mdx
@@ -113,7 +113,7 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 <Canvas isColumn>
   <Story name="u-grid">
     {`
-      <div class="u-grid u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-grid u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
@@ -128,7 +128,7 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 <Canvas isColumn>
   <Story name="u-grid@s">
     {`
-      <div class="u-grid@s u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-grid@s u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
@@ -140,7 +140,7 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
   </Story>
   <Story name="u-grid@m">
     {`
-      <div class="u-grid@m u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-grid@m u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
@@ -152,7 +152,7 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
   </Story>
   <Story name="u-grid@l">
     {`
-      <div class="u-grid@l u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-grid@l u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 3</div>
@@ -169,7 +169,7 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 <Canvas isColumn>
   <Story name="u-hidden">
     {`
-      <div class="u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Element 1 content</div>
         <div class="u-hidden u-bg-background u-padding-m a-card">Element 2 content, always hidden</div>
         <div class="u-bg-background u-padding-m a-card">Element 3 content</div>
@@ -181,7 +181,7 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
 <Canvas isColumn>
   <Story name="u-hidden@s">
     {`
-      <div class="u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Element 1 content</div>
         <div class="u-hidden@s u-bg-background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
         <div class="u-bg-background u-padding-m a-card">Element 3 content</div>
@@ -190,7 +190,7 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
   </Story>
   <Story name="u-hidden@m">
     {`
-      <div class="u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Element 1 content</div>
         <div class="u-hidden@m u-bg-background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
         <div class="u-bg-background u-padding-m a-card">Element 3 content</div>
@@ -199,7 +199,7 @@ See the documentation for [grid](/docs/utilities-grid--u-grid) classes for more 
   </Story>
   <Story name="u-hidden@l">
     {`
-      <div class="u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Element 1 content</div>
         <div class="u-hidden@l u-bg-background u-padding-m a-card">Element 2 content, hidden on small viewports</div>
         <div class="u-bg-background u-padding-m a-card">Element 3 content</div>

--- a/scss/bitstyles/utilities/gap/gap.stories.mdx
+++ b/scss/bitstyles/utilities/gap/gap.stories.mdx
@@ -21,9 +21,9 @@ By default, available sizes are `xs`, `s`, `m`, and `l`, and the classes are ava
       </div>
     `}
   </Story>
-  <Story name="u-gap-m">
+  <Story name="u-gap-l">
     {`
-      <div class="u-grid u-padding-m u-gap-m u-bg-gray-light">
+      <div class="u-grid u-padding-m u-gap-l u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">Grid child 1</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 2</div>
         <div class="u-bg-background u-padding-m a-card">Grid child 3</div>

--- a/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
+++ b/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
@@ -10,12 +10,12 @@ By default grids of `2`, `3`, `4`, and `6` columns are provided, and they are av
 
 Giving an element the base class `.u-grid` alone will not create the columns you probably want — see the example below. The grid children have some space between them, but otherwise they behave like block elements.
 
-The grid classes are only rarely used without the [gap](/docs/utilities-gap--u-gap-m) utilities, as you normally want some space between items.
+The grid classes are only rarely used without the [gap](/docs/utilities-gap--u-gap-l) utilities, as you normally want some space between items.
 
 <Canvas>
   <Story name="u-grid">
     {`
-      <div class="u-grid u-gap-m u-padding-m u-bg-gray-light">
+      <div class="u-grid u-gap-l u-padding-m u-bg-gray-light">
         <div class="u-bg-background u-padding-m a-card">1-column grid, child 1</div>
         <div class="u-bg-background u-padding-m a-card">1-column grid, child 2</div>
         <div class="u-bg-background u-padding-m a-card">1-column grid, child 3</div>
@@ -32,7 +32,7 @@ If you’re rendering a list of related items, use a list element (could be a `<
 <Canvas>
   <Story name="u-grid (list)">
     {`
-      <ul class="u-grid u-gap-m a-list-reset u-padding-m u-bg-gray-light">
+      <ul class="u-grid u-gap-l a-list-reset u-padding-m u-bg-gray-light">
         <li class="u-bg-background u-padding-m a-card">1-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">1-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">1-column grid, child 3</li>
@@ -51,7 +51,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
 <Canvas isColumn>
   <Story name="u-grid-cols-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-2 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-2 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">2-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">2-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">2-column grid, child 3</li>
@@ -63,7 +63,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
   </Story>
   <Story name="u-grid-cols-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-3 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">3-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">3-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">3-column grid, child 3</li>
@@ -75,7 +75,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
   </Story>
   <Story name="u-grid-cols-4">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-4 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-4 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">4-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">4-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">4-column grid, child 3</li>
@@ -87,7 +87,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
   </Story>
   <Story name="u-grid-cols-6">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
@@ -106,7 +106,7 @@ Column classes are available at `s`, `m`, and `xl` breakpoints using the suffix 
 <Canvas isColumn>
   <Story name="u-grid-cols-3@s">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3@s u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-3@s u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -118,7 +118,7 @@ Column classes are available at `s`, `m`, and `xl` breakpoints using the suffix 
   </Story>
   <Story name="u-grid-cols-3@m">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3@m u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-3@m u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -130,7 +130,7 @@ Column classes are available at `s`, `m`, and `xl` breakpoints using the suffix 
   </Story>
   <Story name="u-grid-cols-3@xl">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-3@m u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-3@m u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>

--- a/scss/bitstyles/utilities/row-start/row-start.stories.mdx
+++ b/scss/bitstyles/utilities/row-start/row-start.stories.mdx
@@ -13,7 +13,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
 <Canvas isColumn>
   <Story name="u-row-start-1">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-1">6-column grid, child 3, row-start-1</li>
@@ -25,7 +25,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-2">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2">6-column grid, child 3, row-start-2</li>
@@ -37,7 +37,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-3">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
@@ -49,7 +49,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-4">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-4">6-column grid, child 3, row-start-4</li>
@@ -61,7 +61,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-5">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-5">6-column grid, child 3, row-start-5</li>
@@ -73,7 +73,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-6">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-6">6-column grid, child 3, row-start-6</li>
@@ -92,7 +92,7 @@ The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 <Canvas isColumn>
   <Story name="u-row-start-2@s">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@s">6-column grid, child 3, row-start-1@s</li>
@@ -104,7 +104,7 @@ The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
   </Story>
   <Story name="u-row-start-2@m">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@m">6-column grid, child 3, row-start-1@m</li>
@@ -116,7 +116,7 @@ The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
   </Story>
   <Story name="u-row-start-2@xl">
     {`
-      <ul class="u-grid u-gap-m u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@xl">6-column grid, child 3, row-start-1@xl</li>


### PR DESCRIPTION
Fixes #691

## Changes

Cleanup after #674 — renames all the uses of `u-gap-m` in our documentation to `u-gap-l`, to match the renamed classname

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
