### PR TITLE
[#697] Add utility: width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [[5.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0) - 2022-09-12
+## Unreleased
+
+### Added
+
+- Adds a utility class for the `width` property. Defaults to providing `width: 100%` under the name `u-width-full`. This can be customized using `$bitstyles-width-values` and `$bitstyles-width-breakpoints`
+
+## [[5.0.0-alpha]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0) - 2022-09-12
 
 ### Added
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -117,4 +117,5 @@
 @forward 'bitstyles/utilities/typography-responsive' as
   typography-responsive-utilities-*;
 @forward 'bitstyles/utilities/typography' as typography-utilities-*;
+@forward 'bitstyles/utilities/width' as width-*;
 @forward 'bitstyles/utilities/z-index' as z-index-*;

--- a/scss/bitstyles/utilities/width/_index.import.scss
+++ b/scss/bitstyles/utilities/width/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-width-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/width/_index.scss
+++ b/scss/bitstyles/utilities/width/_index.scss
@@ -1,0 +1,10 @@
+@forward './settings';
+@use './settings';
+@use '../../tools/properties';
+
+@include properties.output(
+  $property-name: 'width',
+  $classname-root: 'width',
+  $values: settings.$values,
+  $breakpoints: settings.$breakpoints
+);

--- a/scss/bitstyles/utilities/width/_settings.scss
+++ b/scss/bitstyles/utilities/width/_settings.scss
@@ -1,0 +1,4 @@
+$values: (
+  'full': 100%,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/width/width.stories.mdx
+++ b/scss/bitstyles/utilities/width/width.stories.mdx
@@ -1,0 +1,39 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/width" />
+
+# width
+
+Specify the `width` property of an element. Default configuration provides `100%` with no breakpoint variations. See [customization](#customization) for details on how to change that.
+
+<Canvas>
+  <Story name="u-width-full" inline={false} height="13rem" width="100%">
+    {`
+      <div class="u-bg-brand-2 u-padding-m" style="height:12rem">
+        <span class="u-width-full u-bg-gray-lighter">u-width-100%</span>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+Customize the available widths by overriding the `$bitstyles-width-values` Sass map, providing the name to be used for the class, and the value to use.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/width' with (
+  $values: (
+    '10rem': 10rem,
+  )
+);
+```
+
+Available breakpoint variables can be specified by overriding the `$bitstyles-width-breakpoints` Sass list, providing a list of names of breakpoints taken from the global breakpoint list:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/width' with (
+  $breakpoints: (
+    'm',
+  )
+);
+```

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -3578,6 +3578,9 @@ table {
     font-size: 100rem;
   }
 }
+.bs-width-0 {
+  width: 0;
+}
 .bs-z-100 {
   z-index: 100;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -4246,6 +4246,9 @@ table {
     font-size: 4.8rem;
   }
 }
+.u-width-full {
+  width: 100%;
+}
 .u-z-1 {
   z-index: 1;
 }

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -262,6 +262,9 @@ $bitstyles-typography-responsive-utilities-values: (
 $bitstyles-typography-utilities-values: (
   '100': 100rem,
 );
+$bitstyles-width-values: (
+  '0': 0,
+);
 $bitstyles-z-index-values: (
   '100': 100,
 );

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -262,6 +262,9 @@ $bitstyles-typography-responsive-utilities-values: (
 $bitstyles-typography-utilities-values: (
   '100': 100rem,
 );
+$bitstyles-width-values: (
+  '0': 0,
+);
 $bitstyles-z-index-values: (
   '100': 100,
 );
@@ -382,4 +385,5 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/utilities/truncate';
 @import '../../scss/bitstyles/utilities/typography-responsive';
 @import '../../scss/bitstyles/utilities/typography';
+@import '../../scss/bitstyles/utilities/width';
 @import '../../scss/bitstyles/utilities/z-index';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -188,8 +188,6 @@
     )
   ),
   $typography-utilities-values: ('100': 100rem),
-  $width-values: (
-    '0': 0,
-  ),
+  $width-values: ('0': 0),
   $z-index-values: ('100': 100)
 );

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -188,5 +188,8 @@
     )
   ),
   $typography-utilities-values: ('100': 100rem),
+  $width-values: (
+    '0': 0,
+  ),
   $z-index-values: ('100': 100)
 );

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -441,6 +441,11 @@
     '100': 100rem,
   )
 );
+@use '../../scss/bitstyles/utilities/width' with (
+  $values: (
+    '0': 0,
+  )
+);
 @use '../../scss/bitstyles/utilities/z-index' with (
   $values: (
     '100': 100,


### PR DESCRIPTION
Fixes #697 

## Changes

Adds a width utility class, with basic defaults and stories

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
