### PR TITLE
[#699] Add utility: white-space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - New helper function `custom-property.get()` for generating names of CSS custom properties that respect the namespace and layer-prefix configuration.
 - Most design tokens are now output as CSS Custom Properties in a `:root` block. All are prefixed with `bs` in the default configuration (customize that using `setup.$custom-property-namespace`), with names matching their Sass variable e.g. `--bs-color-brand-1-base`, `--bs-color-brand-1-light`, `--bs-size-xs`, `--bs-size-s`.
 - Use `setup.$viewport-elements` to define which elements should be considered equal to the viewport in size. These elements’ heights will match the viewport (including any variable sizing on mobile browsers). Make sure to add a selector for any wrapper elements your framework may be wrapping around your app/content.
-- Adds a utility class for the `width` property. Defaults to providing `width: 100%` under the name `u-width-full`. This can be customized using `$bitstyles-width-values` and `$bitstyles-width-breakpoints`
+- Adds a utility class for the `width` property. Defaults to providing `width: 100%` under the name `u-width-full`. This can be customized using `$bitstyles-width-values` and `$bitstyles-width-breakpoints`.
+- Adds utility classes to specify white-space property. Defaults to just `nowrap`, and is configurable with `$bitstyles-white-space-values`, and `$bitstyles-white-space-breakpoints`.
 
 ### Changed
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -130,5 +130,6 @@
 @forward 'bitstyles/utilities/typography-responsive' as
   typography-responsive-utilities-*;
 @forward 'bitstyles/utilities/typography' as typography-utilities-*;
+@forward 'bitstyles/utilities/white-space' as white-space-*;
 @forward 'bitstyles/utilities/width' as width-*;
 @forward 'bitstyles/utilities/z-index' as z-index-*;

--- a/scss/bitstyles/utilities/white-space/_index.import.scss
+++ b/scss/bitstyles/utilities/white-space/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-white-space-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/white-space/_index.scss
+++ b/scss/bitstyles/utilities/white-space/_index.scss
@@ -1,0 +1,10 @@
+@forward 'settings';
+@use './settings';
+@use '../../tools/properties';
+
+@include properties.output(
+  $property-name: 'white-space',
+  $classname-root: 'white-space',
+  $values: settings.$values,
+  $breakpoints: settings.$breakpoints
+);

--- a/scss/bitstyles/utilities/white-space/_settings.scss
+++ b/scss/bitstyles/utilities/white-space/_settings.scss
@@ -1,0 +1,4 @@
+$values: (
+  'nowrap': nowrap,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/white-space/white-space.stories.mdx
+++ b/scss/bitstyles/utilities/white-space/white-space.stories.mdx
@@ -1,0 +1,44 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/White-space" />
+
+# White-space
+
+Utility classes to specify `white-space`.
+
+Default configuration gives you `nowrap`, which prevents text from wrapping when its containing element is too narrow, not available with any breakpoint suffixes. See [Customization](#customization) for details on how to change that.
+
+<Canvas>
+  <Story name="nowrap">
+    {`
+      <div style="width: 15rem" class="u-bg-gray-light u-padding-m">
+        <div class="u-white-space-nowrap">.u-white-space-nowrap Lorem ipsum dolor sit amet</div>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+The available classes can be customized by overriding the `$bitstyles-white-space-values` map. Provide the name to be used for the class as the key, and the value:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/white-space' with (
+  $values: (
+    'nowrap': nowrap,
+    'normal': normal,
+  )
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-white-space-breakpoints` list, providing the names of breakpoints from the global list of breakpoints:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/white-space' with (
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
+);
+```

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -3708,6 +3708,9 @@ table {
     font-size: 100rem;
   }
 }
+.bs-white-space-normal {
+  white-space: normal;
+}
 .bs-width-0 {
   width: 0;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -4373,6 +4373,9 @@ table {
     font-size: 4.8rem;
   }
 }
+.u-white-space-nowrap {
+  white-space: nowrap;
+}
 .u-width-full {
   width: 100%;
 }

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -263,6 +263,9 @@ $bitstyles-typography-responsive-utilities-values: (
 $bitstyles-typography-utilities-values: (
   '100': 100rem,
 );
+$bitstyles-white-space-values: (
+  'normal': normal,
+);
 $bitstyles-width-values: (
   '0': 0,
 );

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -263,6 +263,9 @@ $bitstyles-typography-responsive-utilities-values: (
 $bitstyles-typography-utilities-values: (
   '100': 100rem,
 );
+$bitstyles-white-space-values: (
+  'normal': normal,
+);
 $bitstyles-width-values: (
   '0': 0,
 );
@@ -396,5 +399,6 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/utilities/truncate';
 @import '../../scss/bitstyles/utilities/typography-responsive';
 @import '../../scss/bitstyles/utilities/typography';
+@import '../../scss/bitstyles/utilities/white-space';
 @import '../../scss/bitstyles/utilities/width';
 @import '../../scss/bitstyles/utilities/z-index';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -189,9 +189,7 @@
     )
   ),
   $typography-utilities-values: ('100': 100rem),
-  $white-space-values: (
-    'normal': normal,
-  ),
+  $white-space-values: ('normal': normal),
   $width-values: ('0': 0),
   $z-index-values: ('100': 100)
 );

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -189,6 +189,9 @@
     )
   ),
   $typography-utilities-values: ('100': 100rem),
+  $white-space-values: (
+    'normal': normal,
+  ),
   $width-values: ('0': 0),
   $z-index-values: ('100': 100)
 );

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -460,7 +460,7 @@
 @use '../../scss/bitstyles/utilities/white-space' with (
   $values: (
     'normal': normal,
-  ),
+  )
 );
 @use '../../scss/bitstyles/utilities/width' with (
   $values: (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -457,6 +457,11 @@
     '100': 100rem,
   )
 );
+@use '../../scss/bitstyles/utilities/white-space' with (
+  $values: (
+    'normal': normal,
+  ),
+);
 @use '../../scss/bitstyles/utilities/width' with (
   $values: (
     '0': 0,


### PR DESCRIPTION
Fixes #699 

## Changes

- Adds a white-space utility class with minimal defaults

## 📸

<img width="1105" alt="Screenshot 2022-10-13 at 16 06 39" src="https://user-images.githubusercontent.com/2479422/195620041-b613389b-3fd8-4eed-9136-a583eca12b45.png">


## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
