### PR TITLE
[#702] Add utility: list-style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - Adds a utility class for the `width` property. Defaults to providing `width: 100%` under the name `u-width-full`. This can be customized using `$bitstyles-width-values` and `$bitstyles-width-breakpoints`.
 - Adds utility classes to specify white-space property. Defaults to just `nowrap`, and is configurable with `$bitstyles-white-space-values`, and `$bitstyles-white-space-breakpoints`.
 - Adds a new set of utility classes for specifying the `text-decoration-line` property. Default configuration gives `underline` and `line-through` as values, and is not available at any breakpoints. This can be configured using `$values` and `$breakpoints`.
-- Adds utility classes for specifying `justify-self` and `justify-items`
+- Adds utility classes for specifying `justify-self` and `justify-items`.
+- A new utility class `u-list` to specify the `list-style-type` property. Default values available are `none`, `decimal`, `disc`. Configuration is possible using `$bitstyles-list-values` and `$bitstyles-list-breakpoints`.
 
 ### Changed
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -110,6 +110,7 @@
 @forward 'bitstyles/utilities/items' as items-*;
 @forward 'bitstyles/utilities/justify' as justify-*;
 @forward 'bitstyles/utilities/line-height' as line-height-*;
+@forward 'bitstyles/utilities/list' as list-*;
 @forward 'bitstyles/utilities/margin' as margin-*;
 @forward 'bitstyles/utilities/max-height' as max-height-*;
 @forward 'bitstyles/utilities/max-width' as max-width-*;

--- a/scss/bitstyles/atoms/badge/badge.stories.mdx
+++ b/scss/bitstyles/atoms/badge/badge.stories.mdx
@@ -21,7 +21,7 @@ By default `gray`, `brand-1`, `brand-2`, and `danger` colors are available (see 
 <Canvas>
   <Story name="Badge — color variants">
     {`
-      <ul class="a-list-reset u-flex">
+      <ul class="u-list-none u-flex">
         <li class="u-margin-s-right">
           <span class="a-badge a-badge--text u-h6 u-font-medium">gray</span>
         </li>
@@ -44,7 +44,7 @@ You may want the badges to be removable, for example when used as part of a filt
 <Canvas>
   <Story name="Badge — with buttons">
     {`
-      <ul class="a-list-reset u-flex">
+      <ul class="u-list-none u-flex">
         <li class="u-margin-s-right">
           <span class="a-badge a-badge--text u-h6 u-font-medium">
             badge 1

--- a/scss/bitstyles/atoms/button--danger/button--danger.stories.mdx
+++ b/scss/bitstyles/atoms/button--danger/button--danger.stories.mdx
@@ -59,7 +59,7 @@ These buttons are often placed in a list of possible actions:
 <Canvas>
   <Story name="Danger list">
     {`
-      <ul class="a-list-reset u-flex">
+      <ul class="u-list-none u-flex">
         <li class="u-margin-s-right">
           <a href="/" class="a-button a-button--ui">
             Show

--- a/scss/bitstyles/atoms/button--nav-large/button--nav-large.stories.mdx
+++ b/scss/bitstyles/atoms/button--nav-large/button--nav-large.stories.mdx
@@ -61,7 +61,7 @@ It’s rare to have only one link, so here’s how it looks with multiple:
 <Canvas isColumn>
   <Story name="Nav-large list">
     {`
-      <ul class="a-list-reset u-flex u-flex-col">
+      <ul class="u-list-none u-flex u-flex-col">
         <li class="u-margin-s-bottom">
           <a href="/" class="a-button a-button--nav-large">
             Dashboard
@@ -82,7 +82,7 @@ It’s rare to have only one link, so here’s how it looks with multiple:
   </Story>
   <Story name="Nav-large list current page">
     {`
-      <ul class="a-list-reset u-flex u-flex-col">
+      <ul class="u-list-none u-flex u-flex-col">
         <li class="u-margin-s-bottom">
           <a href="/" class="a-button a-button--nav-large" aria-current="page">
             Dashboard

--- a/scss/bitstyles/atoms/button--nav/button--nav.stories.mdx
+++ b/scss/bitstyles/atoms/button--nav/button--nav.stories.mdx
@@ -76,7 +76,7 @@ It’s rare to have only one link, so here’s how it looks with multiple:
   <Story name="Nav list">
     {`
       <div class="u-bg-gray-darker u-padding-m">
-        <ul class="a-list-reset u-flex">
+        <ul class="u-list-none u-flex">
           <li class="u-margin-s-right">
             <a href="/" class="a-button a-button--nav">
               Dashboard
@@ -99,7 +99,7 @@ It’s rare to have only one link, so here’s how it looks with multiple:
   <Story name="Nav list current page">
     {`
       <div class="u-bg-gray-darker u-padding-m">
-        <ul class="a-list-reset u-flex">
+        <ul class="u-list-none u-flex">
           <li class="u-margin-s-right">
             <a href="/" class="a-button a-button--nav" aria-current="page">
               Dashboard

--- a/scss/bitstyles/atoms/card/card.stories.mdx
+++ b/scss/bitstyles/atoms/card/card.stories.mdx
@@ -12,19 +12,19 @@ A content wrapper that sections and subtly highlights a chunk of content. For la
     <div class="u-grid u-grid-cols-3@m u-gap-l">
       <article class="a-card">
         <h3 class="u-h4">Standard card</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
       <article class="a-card">
         <h3 class="u-h4">Standard card</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
       <article class="a-card">
         <h3 class="u-h4">Standard card</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
@@ -36,13 +36,13 @@ A content wrapper that sections and subtly highlights a chunk of content. For la
     <div class="u-grid u-grid-cols-2@m u-gap-l">
       <article class="a-card-l">
         <h3>Large card</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
       <article class="a-card-l">
         <h3>Large card</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
@@ -64,7 +64,7 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
           Something happened
         </div>
         <h3 class="u-h4">Card with header</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
@@ -78,7 +78,7 @@ It is common to present important content edge-to-edge, using `.a-card__header`:
         Something happened
       </div>
       <h3 class="u-h4">Large card with header</h3>
-      <ul class="a-list-reset">
+      <ul class="u-list-none">
         <li>User one changed date to 01.01.2021 [5 mins ago]</li>
       </ul>
     </article>
@@ -95,7 +95,7 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default, inclu
     {`
       <article class="a-card@m">
         <h3 class="u-h4">Recent activity (a-card@m)</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
@@ -105,7 +105,7 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default, inclu
     {`
       <article class="a-card@l">
         <h3 class="u-h4">Recent activity (a-card@l)</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
@@ -115,7 +115,7 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default, inclu
     {`
       <article class="a-card-l@m">
         <h3 class="u-h4">Recent activity (a-card@m)</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>
@@ -125,7 +125,7 @@ The `.a-card` classes are available at `m` and `l` breakpoints by default, inclu
     {`
       <article class="a-card-l@l">
         <h3 class="u-h4">Recent activity (a-card@l)</h3>
-        <ul class="a-list-reset">
+        <ul class="u-list-none">
           <li>User one changed date to 01.01.2021 [5 mins ago]</li>
         </ul>
       </article>

--- a/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
+++ b/scss/bitstyles/atoms/dropdown/dropdown.stories.mdx
@@ -12,7 +12,7 @@ A floating container shown on clicking a button (use JS for this), to show some 
   <Story name="Dropdown" inline={false} height="20rem">
     {`
       <div class="u-relative" style="height: 10rem; width: 30rem">
-        <ul class="a-dropdown u-overflow-y-auto a-list-reset">
+        <ul class="a-dropdown u-overflow-y-auto u-list-none">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -40,7 +40,7 @@ The dropdown defaults to left-top-aligned, but can be aligned to any edges using
   <Story name="a-dropdown--right" inline={false} height="20rem">
     {`
       <div class="u-relative" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset">
+        <ul class="a-dropdown a-dropdown--right u-overflow-y-auto u-list-none">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -61,7 +61,7 @@ The dropdown defaults to left-top-aligned, but can be aligned to any edges using
   <Story name="a-dropdown--top" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--top u-overflow-y-auto a-list-reset">
+        <ul class="a-dropdown a-dropdown--top u-overflow-y-auto u-list-none">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -82,7 +82,7 @@ The dropdown defaults to left-top-aligned, but can be aligned to any edges using
   <Story name="a-dropdown--top a-dropdown--right" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--top a-dropdown--right u-overflow-y-auto a-list-reset">
+        <ul class="a-dropdown a-dropdown--top a-dropdown--right u-overflow-y-auto u-list-none">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -103,7 +103,7 @@ The dropdown defaults to left-top-aligned, but can be aligned to any edges using
   <Story name="a-dropdown--bottom dropdown--full" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--full-width u-overflow-y-auto a-list-reset">
+        <ul class="a-dropdown a-dropdown--full-width u-overflow-y-auto u-list-none">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>
@@ -124,7 +124,7 @@ The dropdown defaults to left-top-aligned, but can be aligned to any edges using
   <Story name="a-dropdown--top dropdown--full" inline={false} height="20rem">
     {`
       <div class="u-relative u-flex" style="height: 10rem; width: 100%">
-        <ul class="a-dropdown a-dropdown--top a-dropdown--full-width u-overflow-y-auto a-list-reset">
+        <ul class="a-dropdown a-dropdown--top a-dropdown--full-width u-overflow-y-auto u-list-none">
           <li>
             <a href="/" class="a-button a-button--menu u-h6">Settings</a>
           </li>

--- a/scss/bitstyles/base/typography/_index.scss
+++ b/scss/bitstyles/base/typography/_index.scss
@@ -24,12 +24,6 @@ p {
   margin: 0 0 settings.$margin-paragraph;
 }
 
-ol,
-ul {
-  margin: 0;
-  padding: 0;
-}
-
 address {
   font-style: normal;
 }

--- a/scss/bitstyles/base/typography/_index.scss
+++ b/scss/bitstyles/base/typography/_index.scss
@@ -24,6 +24,12 @@ p {
   margin: 0 0 settings.$margin-paragraph;
 }
 
+ol,
+ul {
+  margin: 0;
+  padding: 0;
+}
+
 address {
   font-style: normal;
 }

--- a/scss/bitstyles/organisms/modal/modal.stories.mdx
+++ b/scss/bitstyles/organisms/modal/modal.stories.mdx
@@ -78,7 +78,7 @@ If you have multiple options for the user, present them with any information the
         <div class="u-flex-grow-1 u-overflow-y-auto u-fg-text u-text-center">
           <p>The previous email we sent to email@example.com will no longer be valid.</p>
         </div>
-        <ul class="a-list-reset u-grid u-grid-cols-2@m u-gap-l u-items-center u-margin-l-top">
+        <ul class="u-list-none u-grid u-grid-cols-2@m u-gap-l u-items-center u-margin-l-top">
           <li class="u-flex u-flex-col">
             <button class="a-button a-button--ui" type="button" data-a11y-dialog-hide>Cancel</button>
           </li>

--- a/scss/bitstyles/organisms/navbar/navbar.stories.mdx
+++ b/scss/bitstyles/organisms/navbar/navbar.stories.mdx
@@ -14,7 +14,7 @@ A top-level navigation container, this organism is only responsible for the layo
     {`
       <div style="min-height:25rem;">
         <div class="u-relative">
-          <ul class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg-gray-darker" id="navbar-1">
+          <ul class="u-flex u-flex-col u-list-none o-navbar u-padding-s u-bg-gray-darker" id="navbar-1">
             <li class="u-margin-s-bottom">
               <a href="/" class="a-button a-button--nav-large" aria-current="page">Team</a>
             </li>

--- a/scss/bitstyles/organisms/table/table.stories.mdx
+++ b/scss/bitstyles/organisms/table/table.stories.mdx
@@ -25,7 +25,7 @@ A basic table layout. It will need a wrapper to deal with overflow.
             <td>sesame.snaps@gmail.com</td>
             <td><span class="a-badge a-badge--danger">Banned</span></td>
             <td class="o-table__actions u-text-right">
-              <ul class="a-list-reset u-inline-flex">
+              <ul class="u-list-none u-inline-flex">
                 <li class="u-margin-xs-right">
                   <a href="/" class="a-button a-button--small">Edit</a>
                 </li>
@@ -40,7 +40,7 @@ A basic table layout. It will need a wrapper to deal with overflow.
             <td>croissant.gummies@gmx.de</td>
             <td><span class="a-badge a-badge--positive">Confirmed</span></td>
             <td class="o-table__actions u-text-right">
-              <ul class="a-list-reset u-inline-flex">
+              <ul class="u-list-none u-inline-flex">
                 <li class="u-margin-xs-right">
                   <a href="/" class="a-button a-button--small">Edit</a>
                 </li>
@@ -55,7 +55,7 @@ A basic table layout. It will need a wrapper to deal with overflow.
             <td>liquorice.fruitcake@mailbox.org</td>
             <td><span class="a-badge a-badge--positive">Confirmed</span></td>
             <td class="o-table__actions u-text-right">
-              <ul class="a-list-reset u-inline-flex">
+              <ul class="u-list-none u-inline-flex">
                 <li class="u-margin-xs-right">
                   <a href="/" class="a-button a-button--small">Edit</a>
                 </li>

--- a/scss/bitstyles/organisms/ui-group/ui-group.stories.mdx
+++ b/scss/bitstyles/organisms/ui-group/ui-group.stories.mdx
@@ -11,7 +11,7 @@ Commonly, this layout is used for buttons.
 <Canvas>
   <Story name="UI group - buttons">
     {`
-      <ul class="o-ui-group u-flex a-list-reset">
+      <ul class="o-ui-group u-flex u-list-none">
         <li>
           <button type="button" class="a-button a-button--ui o-ui-group__item u-border-radius-0-tr u-border-radius-0-br">First</button>
         </li>
@@ -31,7 +31,7 @@ The `ui-group` is also used for grouping inputs & buttons:
 <Canvas>
   <Story name="UI group - input & button">
     {`
-      <ul class="o-ui-group u-flex a-list-reset">
+      <ul class="o-ui-group u-flex u-list-none">
         <li class="u-flex">
           <label for="search_users" class="u-sr-only">Search users</label>
           <input type="search" id="search_users" class="o-ui-group__item u-border-radius-0-tr u-border-radius-0-br" />

--- a/scss/bitstyles/ui/Colors.stories.js
+++ b/scss/bitstyles/ui/Colors.stories.js
@@ -69,11 +69,10 @@ const RenderColors = ({ colors, layout }) => {
   let classname;
   switch (layout) {
     case 'dense':
-      classname = 'u-flex-grow-1 u-grid u-grid-cols-auto a-list-reset';
+      classname = 'u-flex-grow-1 u-grid u-grid-cols-auto u-list-none';
       break;
     default:
-      classname =
-        'u-flex-grow-1 u-grid u-grid-cols-auto a-list-reset u-gap-xxs';
+      classname = 'u-flex-grow-1 u-grid u-grid-cols-auto u-list-none u-gap-xxs';
   }
 
   return `
@@ -114,14 +113,14 @@ const RenderColorPaletteList = ({
   switch (layout) {
     case 'dense':
       classname =
-        'a-list-reset u-grid u-gap-l u-grid-cols-2@m u-grid-cols-3@l u-margin-xl-bottom u-items-start';
+        'u-list-none u-grid u-gap-l u-grid-cols-2@m u-grid-cols-3@l u-margin-xl-bottom u-items-start';
       break;
     case 'row':
-      classname = 'a-list-reset u-flex';
+      classname = 'u-list-none u-flex';
       break;
     default:
       classname =
-        'a-list-reset u-grid u-gap-l u-grid-cols-2@l u-margin-xl-bottom u-items-start';
+        'u-list-none u-grid u-gap-l u-grid-cols-2@l u-margin-xl-bottom u-items-start';
   }
 
   return `

--- a/scss/bitstyles/ui/app-layouts.stories.mdx
+++ b/scss/bitstyles/ui/app-layouts.stories.mdx
@@ -16,7 +16,7 @@ Sidebar, header, and content that uses all available space.
         <nav class="u-flex">
           <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg-gray-darker u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto u-list-none u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-2xs--left" aria-hidden="true" focusable="false">
@@ -90,7 +90,7 @@ Sidebar, header, and content that uses all available space.
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto u-list-none u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-2xs--left" aria-hidden="true" focusable="false">
@@ -162,7 +162,7 @@ Sidebar, header, and content that uses all available space.
           <header class="u-bg-gray-light u-padding-l-top u-flex-shrink-0">
             <div class="a-content a-content--full">
               <div class="u-padding-xl-bottom">
-                <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
+                <ol class="u-h6 u-list-none u-flex u-flex-wrap u-items-center">
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Main section</a>
                     <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -189,7 +189,7 @@ Sidebar, header, and content that uses all available space.
                       <span class="a-badge a-badge--text u-font-medium">Published</span>
                     </div>
                   </div>
-                  <ul class="a-list-reset u-flex u-flex-wrap">
+                  <ul class="u-list-none u-flex u-flex-wrap">
                     <li class="u-margin-s-right u-margin-m-bottom u-relative@m">
                       <button type="button" class="a-button a-button--ui" aria-controls="dropdown-1" aria-expanded="false">
                         <span class="a-button__label">Move</span>
@@ -204,7 +204,7 @@ Sidebar, header, and content that uses all available space.
                   </ul>
                 </div>
               </div>
-              <ul class="a-list-reset u-flex u-overflow-x-auto l-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
+              <ul class="u-list-none u-flex u-overflow-x-auto l-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
                 <li class="u-margin-s-right">
                   <button class="a-button a-button--tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">
                     Personal details
@@ -227,7 +227,7 @@ Sidebar, header, and content that uses all available space.
             <h2 class="u-sr-only">Users</h2>
             <form action="" method="POST" role="search" class="u-margin-m-bottom u-flex">
               <h3 class="u-sr-only">Filter results</h3>
-              <ul class="o-ui-group u-flex a-list-reset">
+              <ul class="o-ui-group u-flex u-list-none">
                 <li class="u-flex">
                   <label for="search_users" class="u-sr-only">Filter users by email</label>
                   <input type="search" id="search_users" class="o-ui-group__item u-border-radius-0-tr u-border-radius-0-br" placeholder="Filter by email…" />
@@ -244,7 +244,7 @@ Sidebar, header, and content that uses all available space.
               <div class="u-absolute-center">List or table with long rows of information that need full width of available display</div>
             </div>
             <h2>Further content</h2>
-            <ul class="a-list-reset u-grid u-grid-cols-2@l u-grid-cols-3@xl u-gap-l u-margin-xl-bottom">
+            <ul class="u-list-none u-grid u-grid-cols-2@l u-grid-cols-3@xl u-gap-l u-margin-xl-bottom">
               <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                 <div class="u-absolute-center">Content block</div>
               </li>
@@ -269,7 +269,7 @@ Sidebar, header, and content that uses all available space.
         <nav class="u-flex">
           <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg-gray-darker u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto u-list-none u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-2xs--left" aria-hidden="true" focusable="false">
@@ -343,7 +343,7 @@ Sidebar, header, and content that uses all available space.
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto u-list-none u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-2xs--left" aria-hidden="true" focusable="false">
@@ -415,7 +415,7 @@ Sidebar, header, and content that uses all available space.
           <header class="u-bg-gray-light u-padding-l-top u-flex-shrink-0">
             <div class="a-content a-content--full">
               <div class="u-padding-xl-bottom">
-                <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
+                <ol class="u-h6 u-list-none u-flex u-flex-wrap u-items-center">
                   <li class="u-margin-xs-right u-flex u-items-center">
                     <a href="/">Main section</a>
                     <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -442,7 +442,7 @@ Sidebar, header, and content that uses all available space.
                       <span class="a-badge a-badge--text u-font-medium">Published</span>
                     </div>
                   </div>
-                  <ul class="a-list-reset u-flex u-flex-wrap">
+                  <ul class="u-list-none u-flex u-flex-wrap">
                     <li class="u-margin-s-right u-margin-m-bottom u-relative@m">
                       <button type="button" class="a-button a-button--ui" aria-controls="dropdown-1" aria-expanded="false">
                         <span class="a-button__label">Move</span>
@@ -457,7 +457,7 @@ Sidebar, header, and content that uses all available space.
                   </ul>
                 </div>
               </div>
-              <ul class="a-list-reset u-flex u-overflow-x-auto l-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
+              <ul class="u-list-none u-flex u-overflow-x-auto l-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
                 <li class="u-margin-s-right">
                   <button class="a-button a-button--tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">
                     Personal details
@@ -480,7 +480,7 @@ Sidebar, header, and content that uses all available space.
             <div class="u-padding-l-y">
               <form action="" method="POST" role="search" class="u-margin-m-bottom u-flex">
                 <h3 class="u-sr-only">Filter results</h3>
-                <ul class="o-ui-group u-flex a-list-reset">
+                <ul class="o-ui-group u-flex u-list-none">
                   <li class="u-flex">
                     <label for="search_users" class="u-sr-only">Filter users by email</label>
                     <input type="search" id="search_users" class="o-ui-group__item u-border-radius-0-tr u-border-radius-0-br" placeholder="Filter by email…" />
@@ -501,7 +501,7 @@ Sidebar, header, and content that uses all available space.
             </div>
             <div class="u-padding-l-y">
               <h2>Further content</h2>
-              <ul class="a-list-reset u-grid u-grid-cols-2@l u-grid-cols-3@xl u-gap-l u-margin-xl-bottom">
+              <ul class="u-list-none u-grid u-grid-cols-2@l u-grid-cols-3@xl u-gap-l u-margin-xl-bottom">
                 <li class="a-card u-bg-background u-aspect-ratio u-aspect-ratio-16-9 u-relative">
                   <div class="u-absolute-center">Content block</div>
                 </li>

--- a/scss/bitstyles/ui/breadcrumbs.stories.mdx
+++ b/scss/bitstyles/ui/breadcrumbs.stories.mdx
@@ -14,7 +14,7 @@ A list of links charting the user’s place in the site structure. The title of 
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-typography--typography">u-h6</a>
@@ -43,7 +43,7 @@ A list of links charting the user’s place in the site structure. The title of 
   <Story name="Breadcrumbs">
     {`
       <nav aria-label="breadcrumbs">
-        <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
+        <ol class="u-h6 u-list-none u-flex u-flex-wrap u-items-center">
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/">Main section</a>
             <svg width="14" height="14" class="a-icon a-icon--m u-fg-gray u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -74,7 +74,7 @@ Using the same structure, your root page might be represented with an icon, for 
   <Story name="Breadcrumbs with icon">
     {`
       <nav aria-label="breadcrumbs">
-        <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center u-line-height-min">
+        <ol class="u-h6 u-list-none u-flex u-flex-wrap u-items-center u-line-height-min">
           <li class="u-margin-xs-right u-flex u-items-center">
             <a href="/" class="u-margin-xs-right u-flex u-items-center">
               <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" class="a-icon a-icon--l" viewBox="0 0 100 100">

--- a/scss/bitstyles/ui/button-groups.stories.mdx
+++ b/scss/bitstyles/ui/button-groups.stories.mdx
@@ -17,7 +17,7 @@ A group of buttons aligned horizontally, collapsing onto a new row when there’
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-typography--typography">u-h6</a>
@@ -37,7 +37,7 @@ A group of buttons aligned horizontally, collapsing onto a new row when there’
 <Canvas>
   <Story name="Button group">
     {`
-      <ul class="a-list-reset u-flex u-flex-wrap u-items-center">
+      <ul class="u-list-none u-flex u-flex-wrap u-items-center">
         <li class="u-margin-xs-right">
           <button class="a-button" type="button">Show</button>
         </li>
@@ -55,7 +55,7 @@ A group of buttons aligned horizontally, collapsing onto a new row when there’
 <Canvas>
   <Story name="Button group with icons">
     {`
-      <ul class="a-list-reset u-flex u-flex-wrap u-items-center">
+      <ul class="u-list-none u-flex u-flex-wrap u-items-center">
         <li class="u-flex u-margin-xs-right">
           <button class="a-button" type="button">
             <svg width="14" height="14" class="a-button__icon a-icon a-icon-m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">

--- a/scss/bitstyles/ui/dropdown-menu.stories.mdx
+++ b/scss/bitstyles/ui/dropdown-menu.stories.mdx
@@ -42,7 +42,7 @@ The component requires JS to show and hide the `ul`, and update the aria attribu
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-typography--typography">u-h6</a>
@@ -98,7 +98,7 @@ These examples show various contents for the dropdown menus — what you put in 
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown u-overflow-y-auto a-list-reset u-margin-s-top"
+            class="a-dropdown u-overflow-y-auto u-list-none u-margin-s-top"
             id="dropdown-1"
           >
             <li>
@@ -164,7 +164,7 @@ These examples show various contents for the dropdown menus — what you put in 
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown u-overflow-y-auto a-list-reset u-margin-s-top"
+            class="a-dropdown u-overflow-y-auto u-list-none u-margin-s-top"
             id="dropdown-2"
           >
             <li>
@@ -230,7 +230,7 @@ These examples show various contents for the dropdown menus — what you put in 
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown u-overflow-y-auto a-list-reset u-margin-s-top"
+            class="a-dropdown u-overflow-y-auto u-list-none u-margin-s-top"
             id="dropdown-3"
           >
             <li>
@@ -308,7 +308,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
             id="dropdown-3"
-            class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset u-margin-s-top"
+            class="a-dropdown a-dropdown--right u-overflow-y-auto u-list-none u-margin-s-top"
           >
             <li>
               <div class="u-padding-xs-top u-padding-xs-bottom u-padding-s-left u-padding-s-right u-flex u-items-center u-h6 u-line-height-min">
@@ -374,7 +374,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown a-dropdown--top u-overflow-y-auto a-list-reset u-margin-s-bottom"
+            class="a-dropdown a-dropdown--top u-overflow-y-auto u-list-none u-margin-s-bottom"
             id="dropdown-3"
           >
             <li>
@@ -440,7 +440,7 @@ The default dropdowns are aligned to the left edge of their relative parent, und
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown a-dropdown--full-width u-overflow-y-auto a-list-reset u-margin-s-top"
+            class="a-dropdown a-dropdown--full-width u-overflow-y-auto u-list-none u-margin-s-top"
             id="dropdown-3"
           >
             <li>
@@ -512,7 +512,7 @@ The directions can be combined.
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown a-dropdown--top a-dropdown--right u-overflow-y-auto a-list-reset u-margin-s-bottom"
+            class="a-dropdown a-dropdown--top a-dropdown--right u-overflow-y-auto u-list-none u-margin-s-bottom"
             id="dropdown-3"
           >
             <li>
@@ -579,7 +579,7 @@ The directions can be combined.
             x-transition:leave-start="is-on-screen"
             x-transition:leave-end="is-off-screen"
             @click.away="dropdownOpen = false"
-            class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y-auto a-list-reset u-margin-s-bottom"
+            class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y-auto u-list-none u-margin-s-bottom"
             id="dropdown-3"
           >
             <li>

--- a/scss/bitstyles/ui/filter.stories.mdx
+++ b/scss/bitstyles/ui/filter.stories.mdx
@@ -44,7 +44,7 @@ When a user wants to filter a list of objects by fields which have a limited num
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-typography--typography">u-h6</a>
@@ -70,7 +70,7 @@ When a user wants to filter a list of objects by fields which have a limited num
       <div style="min-height: 15rem;">
         <form action="" method="POST" class="u-flex u-items-center" role="search">
           <h3 class="u-sr-only">Filter results</h3>
-          <ul class="a-list-reset u-flex" x-data="{ dropdownOpen: false }">
+          <ul class="u-list-none u-flex" x-data="{ dropdownOpen: false }">
             <li class="u-relative u-margin-xs-right">
               <button
                 type="button"
@@ -95,7 +95,7 @@ When a user wants to filter a list of objects by fields which have a limited num
                 x-transition:leave-start="is-on-screen"
                 x-transition:leave-end="is-off-screen"
                 @click.away="dropdownOpen = false"
-                class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset u-margin-s-top"
+                class="a-dropdown a-dropdown--right u-overflow-y-auto u-list-none u-margin-s-top"
                 id="dropdown-1"
               >
                 <li>
@@ -148,7 +148,7 @@ When a user wants to filter a list of objects by fields which have a limited num
                 x-transition:leave-start="is-on-screen"
                 x-transition:leave-end="is-off-screen"
                 @click.away="dropdownOpen = false"
-                class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset u-margin-s-top"
+                class="a-dropdown a-dropdown--right u-overflow-y-auto u-list-none u-margin-s-top"
                 id="dropdown-2"
               >
                 <li>
@@ -196,7 +196,7 @@ Some fields such as names and emails will need to be filtered by user-entered fr
       <div style="min-height: 10rem;">
         <form action="" method="POST" role="search">
           <h3 class="u-sr-only">Filter results</h3>
-          <ul class="o-ui-group u-flex a-list-reset">
+          <ul class="o-ui-group u-flex u-list-none">
             <li class="u-flex">
               <label for="search_users" class="u-sr-only">Search users</label>
               <input type="search" id="search_users" class="o-ui-group__item u-border-radius-0-tr u-border-radius-0-br" placeholder="Search users…" />
@@ -223,7 +223,7 @@ Some fields such as names and emails will need to be filtered by user-entered fr
                 x-transition:leave-start="is-on-screen"
                 x-transition:leave-end="is-off-screen"
                 @click.away="dropdownOpen = false"
-                class="a-dropdown a-dropdown--right u-margin-s-top u-overflow-y-auto a-list-reset u-margin-s-bottom"
+                class="a-dropdown a-dropdown--right u-margin-s-top u-overflow-y-auto u-list-none u-margin-s-bottom"
                 id="dropdown-1"
               >
                 <li>
@@ -264,9 +264,9 @@ When giving the user filters by category and free text, place the free text sear
       <div style="min-height: 10rem;">
         <form action="" method="POST" role="search">
           <h3 class="u-sr-only">Filter results</h3>
-          <ul class="a-list-reset u-flex u-items-center">
+          <ul class="u-list-none u-flex u-items-center">
             <li class="u-margin-xs-right">
-              <ul class="o-ui-group u-flex a-list-reset">
+              <ul class="o-ui-group u-flex u-list-none">
                 <li class="u-flex">
                   <label for="search_users" class="u-sr-only">Search users</label>
                   <input type="search" id="search_users" class="o-ui-group__item u-border-radius-0-tr u-border-radius-0-br" placeholder="Search users…" />
@@ -294,7 +294,7 @@ When giving the user filters by category and free text, place the free text sear
                     x-transition:leave-start="is-on-screen"
                     x-transition:leave-end="is-off-screen"
                     @click.away="dropdownOpen = false"
-                    class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset u-margin-s-top"
+                    class="a-dropdown a-dropdown--right u-overflow-y-auto u-list-none u-margin-s-top"
                     id="dropdown-1"
                   >
                     <li>
@@ -337,7 +337,7 @@ When giving the user filters by category and free text, place the free text sear
                 x-transition:leave-start="is-on-screen"
                 x-transition:leave-end="is-off-screen"
                 @click.away="dropdownOpen = false"
-                class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset u-margin-s-top"
+                class="a-dropdown a-dropdown--right u-overflow-y-auto u-list-none u-margin-s-top"
                 id="dropdown-1"
               >
                 <li>

--- a/scss/bitstyles/ui/flashes.stories.mdx
+++ b/scss/bitstyles/ui/flashes.stories.mdx
@@ -20,7 +20,7 @@ Inform the user of a global or important event, such as may happen after a page 
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-flex--flex">u-flex</a>

--- a/scss/bitstyles/ui/forms.stories.mdx
+++ b/scss/bitstyles/ui/forms.stories.mdx
@@ -29,7 +29,7 @@ Here are some examples using the grid utility classes to create common form layo
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-color--brand-1">u-fg</a>
@@ -63,7 +63,7 @@ Here are some examples using the grid utility classes to create common form layo
       <div class="a-content a-content--s">
         <form class="a-card-l@m u-bg-white" method="POST" action="">
           <h2>Login</h2>
-          <ul class="a-list-reset u-margin-xl-bottom">
+          <ul class="u-list-none u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
               <label for="email">Email</label>
               <input id="email" type="email" autocomplete="email" />
@@ -76,7 +76,7 @@ Here are some examples using the grid utility classes to create common form layo
               </div>
             </li>
           </ul>
-          <ul class="a-list-reset u-flex u-items-center">
+          <ul class="u-list-none u-flex u-items-center">
             <li class="u-margin-xl-right">
               <button type="submit" class="a-button">Login</button>
             </li>
@@ -114,7 +114,7 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
             </div>
           </div>
           <h2>Login</h2>
-          <ul class="a-list-reset u-margin-xl-bottom">
+          <ul class="u-list-none u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
               <label for="email">Email</label>
               <input id="email" type="email" autocomplete="email" aria-invalid="true" aria-describedby="email-help-text" />
@@ -128,7 +128,7 @@ The `aria-describedby` attribute accepts a space-separated list of IDs, so if an
               </div>
             </li>
           </ul>
-          <ul class="a-list-reset u-flex u-items-center">
+          <ul class="u-list-none u-flex u-items-center">
             <li class="u-margin-xl-right">
               <button type="submit" class="a-button">Login</button>
             </li>
@@ -152,7 +152,7 @@ This form has the commonly-required fields for creating an account. Note the wor
       <div class="a-content a-content--s">
         <form class="a-card-l@m u-bg-white" method="POST" action="">
           <h2>Create an account</h2>
-          <ul class="a-list-reset u-margin-xl-bottom">
+          <ul class="u-list-none u-margin-xl-bottom">
             <li class="u-margin-m-bottom">
               <label for="email">Email</label>
               <input id="email" type="email" autocomplete="email" />
@@ -166,7 +166,7 @@ This form has the commonly-required fields for creating an account. Note the wor
               <input id="confirm_password" type="password" autocomplete="new-password" />
             </li>
           </ul>
-          <ul class="a-list-reset u-flex u-items-center">
+          <ul class="u-list-none u-flex u-items-center">
             <li class="u-margin-xl-right">
               <button type="submit" class="a-button">Create account</button>
             </li>
@@ -193,8 +193,8 @@ For a more complex form, `.u-grid-cols-6@m` allows for fields of different sizes
           <div class="a-bordered-header u-margin-xl-bottom">
             <legend class="u-h3 u-font-bold">Account details</legend>
           </div>
-          <div class="u-grid u-gap-l u-grid-cols-6@l u-gap-l">
-            <ul class="a-list-reset u-col-start-3@l u-grid u-gap-l u-grid-cols-6@m u-col-span-4@l">
+          <div class="u-grid u-gap-l u-grid-cols-6@l">
+            <ul class="u-list-none u-col-start-3@l u-grid u-gap-l u-grid-cols-6@m u-col-span-4@l">
               <li class="u-col-span-4@m u-col-start-1@m u-col-span-3@l">
                 <label for="name">Name</label>
                 <input id="name" type="text" autocomplete="name" value="Jon Doe" />
@@ -221,7 +221,7 @@ For a more complex form, `.u-grid-cols-6@m` allows for fields of different sizes
             <div class="u-col-span-2@l">
               <p class="u-h6 u-fg-text-light u-padding-l-y@l u-padding-xl-right@m">Some intro text can go here, to describe this section</p>
             </div>
-            <ul class="a-list-reset u-col-start-3@l u-col-span-4@l u-grid u-gap-l u-grid-cols-6@m u-gap-l">
+            <ul class="u-list-none u-col-start-3@l u-col-span-4@l u-grid u-gap-l u-grid-cols-6@m">
               <li class="u-col-span-4@m u-col-span-3@l">
                 <label for="street">Street</label>
                 <input id="street" type="text" autocomplete="address-line1" />
@@ -245,8 +245,8 @@ For a more complex form, `.u-grid-cols-6@m` allows for fields of different sizes
             </ul>
           <div>
         </fieldset>
-        <div class="u-grid u-gap-l u-grid-cols-6@l u-gap-l u-margin-xl-bottom">
-          <ul class="a-list-reset u-flex u-items-center u-col-start-3@l u-col-span-4@l">
+        <div class="u-grid u-gap-l u-grid-cols-6@l u-margin-xl-bottom">
+          <ul class="u-list-none u-flex u-items-center u-col-start-3@l u-col-span-4@l">
             <li class="u-margin-l-right">
               <button type="submit" class="a-button">Save changes</button>
             </li>
@@ -271,7 +271,7 @@ Some forms are always going to be small and simple, with just a few text inputs 
         <fieldset>
           <legend class="u-sr-only">User LKJHAS786SGLKJHAFGO7YEGKJBF</legend>
           <div class="u-grid u-gap-l u-grid-cols-6@l u-margin-xl-bottom">
-            <ul class="a-list-reset u-grid u-gap-l u-grid-cols-6@m u-col-span-4@l">
+            <ul class="u-list-none u-grid u-gap-l u-grid-cols-6@m u-col-span-4@l">
               <li class="u-col-span-4@m u-col-start-1@m">
                 <label for="name">Name</label>
                 <input id="name" type="text" autocomplete="name" value="Jon Doe" />
@@ -283,7 +283,7 @@ Some forms are always going to be small and simple, with just a few text inputs 
             </ul>
           </div>
         </fieldset>
-        <ul class="a-list-reset u-flex u-items-center u-margin-xl-bottom">
+        <ul class="u-list-none u-flex u-items-center u-margin-xl-bottom">
           <li class="u-margin-l-right">
             <button type="submit" class="a-button">Save changes</button>
           </li>
@@ -337,7 +337,7 @@ The heights of selects, inputs, and buttons should all match, allowing them to b
   <Story name="Select input and button">
     {`
     <form role="search" action="" method="POST" class="u-flex">
-      <ul class="a-list-reset u-flex u-items-end">
+      <ul class="u-list-none u-flex u-items-end">
         <li class="u-margin-xs-right">
           <label for="filter">Search users</label>
           <input type="search" id="filter" placeholder="Username or email…" />

--- a/scss/bitstyles/ui/joined-buttons.stories.mdx
+++ b/scss/bitstyles/ui/joined-buttons.stories.mdx
@@ -27,7 +27,7 @@ For a series of buttons that are very directly related e.g.
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/organisms-ui-group--ui-group-buttons">o-ui-group</a>
@@ -60,7 +60,7 @@ When you have multiple actions that are applied to a single entity, group those 
 <Canvas>
   <Story name="Joined buttons - icons">
     {`
-      <ul class="a-list-reset u-inline-flex u-items-stretch o-ui-group">
+      <ul class="u-list-none u-inline-flex u-items-stretch o-ui-group">
         <li class="u-flex">
           <button class="a-button a-button--icon a-button--ui u-border-radius-0-tr u-border-radius-0-br o-ui-group__item" type="button">
             <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -85,7 +85,7 @@ When you have multiple actions that are applied to a single entity, group those 
 <Canvas>
   <Story name="Joined buttons - icons 2">
     {`
-      <ul class="a-list-reset u-inline-flex u-items-stretch o-ui-group">
+      <ul class="u-list-none u-inline-flex u-items-stretch o-ui-group">
         <li class="u-flex">
           <button class="a-button a-button--icon a-button--ui u-border-radius-0-tr u-border-radius-0-br o-ui-group__item" type="button">
             <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -115,7 +115,7 @@ Mark the current page in a series of pagination buttons by giving the link the `
   <Story name="Pagination">
     {`
       <nav aria-label="pagination">
-        <ul class="a-list-reset u-inline-flex u-items-stretch o-ui-group">
+        <ul class="u-list-none u-inline-flex u-items-stretch o-ui-group">
           <li class="u-flex">
             <a href="/" class="a-button a-button--icon a-button--ui u-border-radius-0-tr u-border-radius-0-br o-ui-group__item">
               <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -159,7 +159,7 @@ Mark the current page in a series of pagination buttons by giving the link the `
   <Story name="Pagination with disabled buttons">
     {`
       <nav aria-label="pagination">
-        <ul class="a-list-reset u-inline-flex u-items-stretch o-ui-group">
+        <ul class="u-list-none u-inline-flex u-items-stretch o-ui-group">
           <li class="u-flex">
             <a href="/" class="a-button a-button--icon a-button--ui u-border-radius-0-tr u-border-radius-0-br o-ui-group__item" aria-disabled="true">
               <svg width="14" height="14" class="a-button__icon a-icon a-icon--m" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">

--- a/scss/bitstyles/ui/mode-switch-buttons.stories.mdx
+++ b/scss/bitstyles/ui/mode-switch-buttons.stories.mdx
@@ -18,7 +18,7 @@ The currently-selected mode is indicated with the `aria-pressed="true"` attribut
       <a href="/docs/atoms-button-mode-mode">a-button--mode</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-flex--flex">u-flex</a>
@@ -41,7 +41,7 @@ The currently-selected mode is indicated with the `aria-pressed="true"` attribut
 <Canvas>
   <Story name="Mode-switch buttons">
     {`
-      <ul class="a-list-reset u-inline-flex u-items-stretch u-items-center a-button--mode-container u-padding-xs u-bg-gray-light">
+      <ul class="u-list-none u-inline-flex u-items-stretch u-items-center a-button--mode-container u-padding-xs u-bg-gray-light">
         <li class="u-margin-xs-right">
           <button class="a-button a-button--mode" type="button">
             Year

--- a/scss/bitstyles/ui/navbar.stories.mdx
+++ b/scss/bitstyles/ui/navbar.stories.mdx
@@ -49,7 +49,7 @@ Give the active link the `aria-current="page"` attribute.
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-background-color--gray-dark">u-bg</a>
@@ -84,7 +84,7 @@ Give the active link the `aria-current="page"` attribute.
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden u-block@l" />
             <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden@l" />
             <div class="u-hidden u-block@l u-flex-shrink-1 u-overflow-x-auto">
-              <ul class="u-flex a-list-reset">
+              <ul class="u-flex u-list-none">
                 <li class="u-margin-m-right">
                   <a href="/" class="a-button a-button--nav" aria-current="page">Team</a>
                 </li>
@@ -119,7 +119,7 @@ Give the active link the `aria-current="page"` attribute.
               <span class="u-sr-only">Toggle menu</span>
             </button>
             <ul
-              class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg-gray-darker"
+              class="u-flex u-flex-col u-list-none o-navbar u-padding-s u-bg-gray-darker"
               id="navbar-1"
               x-show="navbarOpen"
               @click.away="navbarOpen = false"
@@ -168,7 +168,7 @@ This navbar is only intended to hold a few link to the main sections of your sit
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden u-block@l" />
             <img src="${logoSmall}" width="50" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-l-right u-hidden@l" />
             <div class="u-hidden u-block@l u-flex-shrink-1 u-overflow-x-auto">
-              <ul class="u-flex a-list-reset">
+              <ul class="u-flex u-list-none">
                 <li class="u-margin-m-right">
                   <a href="/" class="a-button a-button--nav" aria-current="page">Team</a>
                 </li>
@@ -215,7 +215,7 @@ This navbar is only intended to hold a few link to the main sections of your sit
               <span class="u-sr-only">Toggle menu</span>
             </button>
             <ul
-              class="u-flex u-flex-col a-list-reset o-navbar u-padding-s u-bg-gray-darker"
+              class="u-flex u-flex-col u-list-none o-navbar u-padding-s u-bg-gray-darker"
               id="navbar-1"
               x-show="navbarOpen"
               @click.away="navbarOpen = false"

--- a/scss/bitstyles/ui/notifications.stories.mdx
+++ b/scss/bitstyles/ui/notifications.stories.mdx
@@ -35,7 +35,7 @@ Some notifications may require or enable further actions by the user — add but
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/organisms-notification-center--notification-center">
@@ -74,7 +74,7 @@ Some notifications may require or enable further actions by the user — add but
             <div>
               <h2 class="u-h5 u-margin-0">Password update request sent</h2>
               <p class="u-h6">We sent you an email. Please click the link inside to confirm your new password</p>
-              <ul class="a-list-reset u-flex">
+              <ul class="u-list-none u-flex">
                 <li class="u-margin-s-right">
                   <button type="button" class="a-button">OK</button>
                 </li>

--- a/scss/bitstyles/ui/page-header.stories.mdx
+++ b/scss/bitstyles/ui/page-header.stories.mdx
@@ -43,7 +43,7 @@ The intro to every page, containing slots for:
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-background-color--gray-dark">u-bg</a>
@@ -89,7 +89,7 @@ This first example shows a header with all these slots filled:
         <header class="u-bg-gray-light u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
-              <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
+              <ol class="u-h6 u-list-none u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
                   <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -116,7 +116,7 @@ This first example shows a header with all these slots filled:
                     <span class="a-badge a-badge--text u-font-medium">Published</span>
                   </div>
                 </div>
-                <ul class="a-list-reset u-flex u-flex-wrap">
+                <ul class="u-list-none u-flex u-flex-wrap">
                   <li class="u-margin-s-right u-margin-m-bottom u-relative@m" x-data="{ dropdownOpen: false }">
                     <button
                       type="button"
@@ -139,7 +139,7 @@ This first example shows a header with all these slots filled:
                       x-transition:leave-start="is-on-screen"
                       x-transition:leave-end="is-off-screen"
                       @click.away="dropdownOpen = false"
-                      class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset u-margin-s-top"
+                      class="a-dropdown a-dropdown--right u-overflow-y-auto u-list-none u-margin-s-top"
                       id="dropdown-1"
                     >
                       <li>
@@ -183,7 +183,7 @@ This first example shows a header with all these slots filled:
                 </ul>
               </div>
             </div>
-            <ul class="a-list-reset u-flex u-overflow-x-auto u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
+            <ul class="u-list-none u-flex u-overflow-x-auto u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
               <li class="u-margin-s-right">
                 <button class="a-button a-button--tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">
                   Personal details
@@ -216,7 +216,7 @@ It’s also common to not need tabs — if the content is not large and varied e
         <header class="u-bg-gray-light u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
-              <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
+              <ol class="u-h6 u-list-none u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
                   <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -243,7 +243,7 @@ It’s also common to not need tabs — if the content is not large and varied e
                     <span class="a-badge a-badge--text u-font-medium">Published</span>
                   </div>
                 </div>
-                <ul class="a-list-reset u-flex u-flex-wrap">
+                <ul class="u-list-none u-flex u-flex-wrap">
                   <li class="u-margin-s-right u-margin-m-bottom u-relative@m" x-data="{ dropdownOpen: false }">
                     <button
                       type="button"
@@ -266,7 +266,7 @@ It’s also common to not need tabs — if the content is not large and varied e
                       x-transition:leave-start="is-on-screen"
                       x-transition:leave-end="is-off-screen"
                       @click.away="dropdownOpen = false"
-                      class="a-dropdown a-dropdown--right u-overflow-y-auto a-list-reset u-margin-s-top"
+                      class="a-dropdown a-dropdown--right u-overflow-y-auto u-list-none u-margin-s-top"
                       id="dropdown-1"
                     >
                       <li>
@@ -326,7 +326,7 @@ This is a minimal example, with only breadcrumbs and a heading.
         <header class="u-bg-gray-light u-padding-l-top">
           <div class="a-content">
             <div class="u-padding-xl-bottom">
-              <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
+              <ol class="u-h6 u-list-none u-flex u-flex-wrap u-items-center">
                 <li class="u-margin-xs-right u-flex u-items-center">
                   <a href="/">Main section</a>
                   <svg width="18" height="18" class="a-icon a-icon--m u-fg-gray u-margin-xs-left" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">

--- a/scss/bitstyles/ui/section-heading.stories.mdx
+++ b/scss/bitstyles/ui/section-heading.stories.mdx
@@ -19,7 +19,7 @@ A heading with optional actions, badges and labels. Be sure to use the correct h
       <a href="/docs/atoms-badge--badge">a-badge</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-border--border-bottom">
@@ -106,7 +106,7 @@ Section headings are a good place for important actions relating to the content 
     {`
       <div class="u-flex u-flex-wrap u-items-center u-justify-between u-padding-m-bottom u-border-gray-light-bottom">
         <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
-        <ul class="a-list-reset u-flex u-flex-wrap u-flex-shrink-0">
+        <ul class="u-list-none u-flex u-flex-wrap u-flex-shrink-0">
           <li class="u-margin-s-right">
             <button type="button" class="a-button a-button--ui">Edit</button>
           </li>
@@ -127,7 +127,7 @@ Section headings are a good place for important actions relating to the content 
           <h3 class="u-margin-0 u-margin-m-right">Recent bookings</h3>
           <span class="a-badge a-badge--brand-1 u-h6">New<span>
         </div>
-        <ul class="a-list-reset u-flex u-flex-wrap u-flex-shrink-0">
+        <ul class="u-list-none u-flex u-flex-wrap u-flex-shrink-0">
           <li class="u-margin-s-right">
             <button type="button" class="a-button a-button--ui">Edit</button>
           </li>

--- a/scss/bitstyles/ui/sidebar.stories.mdx
+++ b/scss/bitstyles/ui/sidebar.stories.mdx
@@ -38,7 +38,7 @@ Uses a fullwidth dropdown to fit with no overlap.
       <a href="/docs/atoms-icon--icon">a-icon</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/organisms-sidebar--sidebar">o-sidebar</a>
@@ -83,7 +83,7 @@ Uses a fullwidth dropdown to fit with no overlap.
         <nav class="u-flex">
           <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-bg-gray-darker u-padding-m-top u-flex@l u-flex-col">
             <img src="${logoLarge}" width="150" height="50" alt="Company logo" class="u-flex-shrink-0 u-margin-m-left u-margin-m-right u-margin-m-bottom" />
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto u-list-none u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-2xs-left" aria-hidden="true" focusable="false">
@@ -158,7 +158,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 <span class="a-button__label">Jane Dobermann</span>
               </button>
               <ul
-                class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y-auto a-list-reset u-margin-s-bottom"
+                class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y-auto u-list-none u-margin-s-bottom"
                 id="dropdown-3"
                 x-show="dropdownOpen"
                 x-transition:enter="is-transitioning"
@@ -216,7 +216,7 @@ Uses a fullwidth dropdown to fit with no overlap.
               </svg>
               <span class="u-sr-only">Close menu</span>
             </button>
-            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+            <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto u-list-none u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
               <li class="u-margin-xs-bottom u-flex">
                 <a href="/" class="a-button a-button--nav u-flex-grow-1">
                   <svg width="16" height="16" class="a-button-nav__icon a-icon a-icon--l u-margin-s-right u-margin-neg-2xs-left" aria-hidden="true" focusable="false">
@@ -294,7 +294,7 @@ Uses a fullwidth dropdown to fit with no overlap.
                 x-show="dropdownOpen"
                 @click.away="dropdownOpen = false"
                 id="dropdown-4"
-                class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y-auto a-list-reset u-margin-s-bottom"
+                class="a-dropdown a-dropdown--full-width a-dropdown--top u-overflow-y-auto u-list-none u-margin-s-bottom"
               >
                 <li>
                   <a href="/" class="a-button a-button--menu u-h6">

--- a/scss/bitstyles/ui/table.stories.mdx
+++ b/scss/bitstyles/ui/table.stories.mdx
@@ -28,7 +28,7 @@ Add base styling to your tables by giving them the `o-table` class. As shown her
       <a href="/docs/atoms-card--card">a-card</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/organisms-table--table">o-table</a>
@@ -77,7 +77,7 @@ Add base styling to your tables by giving them the `o-table` class. As shown her
               <td>sesame.snaps@gmail.com</td>
               <td><span class="a-badge a-badge--danger">Banned</span></td>
               <td class="o-table__actions u-text-right">
-                <ul class="a-list-reset u-inline-flex">
+                <ul class="u-list-none u-inline-flex">
                   <li class="u-margin-xs-right">
                     <a href="/" class="a-button a-button--ui a-button--small">Show</a>
                   </li>
@@ -95,7 +95,7 @@ Add base styling to your tables by giving them the `o-table` class. As shown her
               <td>croissant.gummies@gmx.de</td>
               <td><span class="a-badge a-badge--positive">Confirmed</span></td>
               <td class="o-table__actions u-text-right">
-                <ul class="a-list-reset u-inline-flex">
+                <ul class="u-list-none u-inline-flex">
                   <li class="u-margin-xs-right">
                     <a href="/" class="a-button a-button--ui a-button--small">Show</a>
                   </li>
@@ -113,7 +113,7 @@ Add base styling to your tables by giving them the `o-table` class. As shown her
               <td>liquorice.fruitcake@mailbox.org</td>
               <td><span class="a-badge a-badge--positive">Confirmed</span></td>
               <td class="o-table__actions u-text-right">
-                <ul class="a-list-reset u-inline-flex">
+                <ul class="u-list-none u-inline-flex">
                   <li class="u-margin-xs-right">
                     <a href="/" class="a-button a-button--ui a-button--small">Show</a>
                   </li>

--- a/scss/bitstyles/ui/tabs.stories.mdx
+++ b/scss/bitstyles/ui/tabs.stories.mdx
@@ -23,7 +23,7 @@ Also note the differences in attributes of selected/deselected tabs (`aria-selec
       <a href="/docs/atoms-content--content">a-content</a>
     </li>
     <li>
-      <a href="/docs/atoms-list-reset--list-reset">a-list-reset</a>
+      <a href="/docs/atoms-list-reset--list-reset">u-list-none</a>
     </li>
     <li>
       <a href="/docs/utilities-background-color--gray-lighter">u-bg</a>
@@ -51,7 +51,7 @@ Also note the differences in attributes of selected/deselected tabs (`aria-selec
     {`
       <div class="u-bg-gray-lighter u-padding-xl-top">
         <div class="a-content">
-          <ul class="a-list-reset u-flex u-flex-wrap u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
+          <ul class="u-list-none u-flex u-flex-wrap u-items-end a-button--tab-container u-margin-m-bottom" role="tablist" aria-label="Patient data">
             <li class="u-margin-s-right">
               <button class="a-button a-button--tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">
                 Personal details

--- a/scss/bitstyles/ui/ui-components.mdx
+++ b/scss/bitstyles/ui/ui-components.mdx
@@ -33,7 +33,7 @@ import iconThumb from '../../../test/assets/images/icon-thumb.svg';
       max-width: none;
     }
 
-    .a-list-reset {
+    .u-list-none {
       list-style-type: none;
       margin: 0;
       padding: 0;
@@ -64,7 +64,7 @@ import iconThumb from '../../../test/assets/images/icon-thumb.svg';
 
 Large chunks of navigation at various levels.
 
-<ul class="a-list-reset u-grid@m u-gap-l u-grid-cols-2@m u-grid-cols-3@l u-margin-xl-top">
+<ul class="u-list-none u-grid@m u-gap-l u-grid-cols-2@m u-grid-cols-3@l u-margin-xl-top">
   <li>
     <a class="u-block" href="/docs/ui-navigation-navbar--navbar">
       <div class="a-card u-padding-0 u-margin-m-bottom">
@@ -119,7 +119,7 @@ Large chunks of navigation at various levels.
 
 Some larger chunks of the content for each page.
 
-<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
+<ul class="u-list-none u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
   <li>
     <a class="u-block" href="/docs/ui-content-page-header--page-header">
       <div class="a-card u-padding-0 u-margin-m-bottom">
@@ -144,7 +144,7 @@ Some larger chunks of the content for each page.
 
 Various buttons, and some methods to arrange them together.
 
-<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
+<ul class="u-list-none u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
   <li>
     <a class="u-block" href="/docs/ui-buttons-buttons--page">
       <div class="a-card u-padding-0 u-margin-m-bottom">
@@ -211,7 +211,7 @@ Various buttons, and some methods to arrange them together.
 
 Organize and highlight the information the user is here to see.
 
-<ul class="a-list-reset u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
+<ul class="u-list-none u-grid@m u-grid-cols-2@m u-grid-cols-3@l u-gap-l u-margin-xl-top">
   <li>
     <a class="u-block" href="/docs/ui-data-description-list--description-list">
       <div class="a-card u-padding-0 u-margin-m-bottom">
@@ -243,7 +243,7 @@ Organize and highlight the information the user is here to see.
       </div>
       <span>Badge</span>
     </a>
-    <p>Show state in a subtley attention-catching manner.</p>
+    <p>Show state in a subtly attention-catching manner.</p>
   </li>
   <li>
     <a class="u-block" href="/docs/ui-data-table--table">

--- a/scss/bitstyles/utilities/col-span/col-span.stories.mdx
+++ b/scss/bitstyles/utilities/col-span/col-span.stories.mdx
@@ -9,7 +9,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
 <Canvas isColumn>
   <Story name="u-col-span-1">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-1">Grid child 1, span 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -21,7 +21,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-2">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-2">Grid child 1, span 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -33,7 +33,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-3">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-3">Grid child 1, span 3</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -45,7 +45,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-4">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-4">Grid child 1, span 4</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -57,7 +57,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-5">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-5">Grid child 1, span 5</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -69,7 +69,7 @@ For some layouts, you’ll want to allow some of the grid children a little more
   </Story>
   <Story name="u-col-span-6">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6">Grid child 1, span 6</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -88,7 +88,7 @@ The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See
 <Canvas isColumn>
   <Story name="u-col-span-6@s">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@s">Grid child 1, span 6 @s</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -100,7 +100,7 @@ The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See
   </Story>
   <Story name="u-col-span-6@m">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@m">Grid child 1, span 6 @m</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -112,7 +112,7 @@ The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See
   </Story>
   <Story name="u-col-span-6@l">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@l">Grid child 1, span 6 @l</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -124,7 +124,7 @@ The `col-span` classes are available at `s`, `m`, `l`, and `xl` breakpoints. See
   </Story>
   <Story name="u-col-span-6@xl">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-brand-2 u-padding-m a-card u-col-span-6@xl">Grid child 1, span 6 @xl</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>

--- a/scss/bitstyles/utilities/col-start/col-start.stories.mdx
+++ b/scss/bitstyles/utilities/col-start/col-start.stories.mdx
@@ -13,7 +13,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
 <Canvas isColumn>
   <Story name="u-col-start-1">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1">6-column grid, child 3, col-start-1</li>
@@ -25,7 +25,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-2">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-2">6-column grid, child 3, col-start-2</li>
@@ -37,7 +37,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-3">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
@@ -49,7 +49,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-4">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-4">6-column grid, child 3, col-start-4</li>
@@ -61,7 +61,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-5">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-5">6-column grid, child 3, col-start-5</li>
@@ -73,7 +73,7 @@ It’s common to use `.u-col-start-1` to force an element to start a new row. By
   </Story>
   <Story name="u-col-start-6">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-6">6-column grid, child 3, col-start-6</li>
@@ -92,7 +92,7 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 <Canvas isColumn>
   <Story name="u-col-start-1@s">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@s">6-column grid, child 3, col-start-1@s</li>
@@ -104,7 +104,7 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
   </Story>
   <Story name="u-col-start-1@m">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@m">6-column grid, child 3, col-start-1@m</li>
@@ -116,7 +116,7 @@ The `col-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
   </Story>
   <Story name="u-col-start-1@xl">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-col-start-1@xl">6-column grid, child 3, col-start-1@xl</li>

--- a/scss/bitstyles/utilities/flex/flex.stories.mdx
+++ b/scss/bitstyles/utilities/flex/flex.stories.mdx
@@ -27,7 +27,7 @@ These first examples show the layouts with a small amount of text content.
 <Canvas isColumn>
   <Story name="u-flex-grow-0">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li>List item one</li>
         <li class="u-flex-grow-0 u-bg-brand-2">u-flex-grow-0</li>
         <li>List item three</li>
@@ -37,7 +37,7 @@ These first examples show the layouts with a small amount of text content.
   </Story>
   <Story name="u-flex-grow-1">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li>List item one</li>
         <li class="u-flex-grow-1 u-bg-brand-2">u-flex-grow-1</li>
         <li>List item three</li>
@@ -47,7 +47,7 @@ These first examples show the layouts with a small amount of text content.
   </Story>
   <Story name="u-flex-shrink-0">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li>List item one</li>
         <li class="u-flex-shrink-0 u-bg-brand-2">u-flex-shrink-0</li>
         <li>List item three</li>
@@ -57,7 +57,7 @@ These first examples show the layouts with a small amount of text content.
   </Story>
   <Story name="u-flex-shrink-1">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li>List item one</li>
         <li class="u-flex-shrink-1 u-bg-brand-2">u-flex-shrink-1</li>
         <li>List item three</li>
@@ -72,7 +72,7 @@ These next examples show how the same layouts behave with long text content.
 <Canvas isColumn>
   <Story name="u-flex-grow-0, long content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-flex-grow-0 u-bg-brand-2">u-flex-grow-0. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -82,7 +82,7 @@ These next examples show how the same layouts behave with long text content.
   </Story>
   <Story name="u-flex-grow-1, long content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-flex-grow-1 u-bg-brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -92,7 +92,7 @@ These next examples show how the same layouts behave with long text content.
   </Story>
   <Story name="u-flex-shrink-0, long content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-flex-shrink-0 u-bg-brand-2">u-flex-shrink-0. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -102,7 +102,7 @@ These next examples show how the same layouts behave with long text content.
   </Story>
   <Story name="u-flex-shrink-1, long content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-flex-shrink-1 u-bg-brand-2">u-flex-shrink-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li>Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -119,7 +119,7 @@ And this time the same layouts, with images as content (any element with intrins
 <Canvas isColumn>
   <Story name="u-flex-grow-0, intrinsic-width content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
@@ -138,7 +138,7 @@ And this time the same layouts, with images as content (any element with intrins
   </Story>
   <Story name="u-flex-grow-1, intrinsic-width content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
@@ -157,7 +157,7 @@ And this time the same layouts, with images as content (any element with intrins
   </Story>
   <Story name="u-flex-shrink-0, intrinsic-width content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
@@ -176,7 +176,7 @@ And this time the same layouts, with images as content (any element with intrins
   </Story>
   <Story name="u-flex-shrink-1, intrinsic-width content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
@@ -200,7 +200,7 @@ And this time the same layouts, with images as content (any element with intrins
 <Canvas isColumn>
   <Story name="u-flex-grow-0@m, intrinsic-width content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
@@ -219,7 +219,7 @@ And this time the same layouts, with images as content (any element with intrins
   </Story>
   <Story name="u-flex-grow-1@m, intrinsic-width content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
@@ -238,7 +238,7 @@ And this time the same layouts, with images as content (any element with intrins
   </Story>
   <Story name="u-flex-shrink-0@m, intrinsic-width content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
@@ -257,7 +257,7 @@ And this time the same layouts, with images as content (any element with intrins
   </Story>
   <Story name="u-flex-shrink-1@m, intrinsic-width content">
     {`
-      <ul class="u-flex a-list-reset">
+      <ul class="u-flex u-list-none">
         <li class="u-padding-m">
           <img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" />
         </li>
@@ -285,7 +285,7 @@ Note this layout may not be so useful with elements that take all available spac
 <Canvas isColumn>
   <Story name="u-flex-wrap">
     {`
-      <ul class="u-flex u-flex-wrap a-list-reset">
+      <ul class="u-flex u-flex-wrap u-list-none">
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-padding-m u-flex-grow-1 u-bg-brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -295,7 +295,7 @@ Note this layout may not be so useful with elements that take all available spac
   </Story>
   <Story name="u-flex-wrap@m">
     {`
-      <ul class="u-flex u-flex-wrap@m a-list-reset">
+      <ul class="u-flex u-flex-wrap@m u-list-none">
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-padding-m u-flex-grow-1 u-bg-brand-2">u-flex-grow-1. Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
         <li class="u-padding-m">Gingerbread topping tart. Bear claw cake icing cotton candy cheesecake biscuit pudding. Macaroon gummi bears chocolate bar lollipop. Caramels marzipan halvah fruitcake chocolate cake cake tart pudding. Bonbon sweet roll fruitcake soufflé topping fruitcake sesame snaps muffin. Pudding dragée marzipan ice cream topping chocolate cake fruitcake bear claw muffin.</li>
@@ -305,7 +305,7 @@ Note this layout may not be so useful with elements that take all available spac
   </Story>
   <Story name="u-flex-wrap, intrinsic-width content">
     {`
-      <ul class="u-flex u-flex-wrap a-list-reset">
+      <ul class="u-flex u-flex-wrap u-list-none">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li class="u-flex-grow-1 u-bg-brand-2 u-padding-m">u-flex-grow-1</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
@@ -315,7 +315,7 @@ Note this layout may not be so useful with elements that take all available spac
   </Story>
   <Story name="u-flex-wrap@m, intrinsic-width content">
     {`
-      <ul class="u-flex u-flex-wrap@m a-list-reset">
+      <ul class="u-flex u-flex-wrap@m u-list-none">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li class="u-flex-grow-1 u-bg-brand-2 u-padding-m">u-flex-grow-1</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
@@ -332,7 +332,7 @@ This flex layout is ideal for laying out buttons in a row — perhaps actions at
 <Canvas isColumn>
   <Story name="u-flex-wrap, buttons">
     {`
-      <ul class="u-flex u-flex-wrap a-list-reset">
+      <ul class="u-flex u-flex-wrap u-list-none">
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">An action</button></li>
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">Another action</button></li>
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">A longer-named action</button></li>
@@ -342,7 +342,7 @@ This flex layout is ideal for laying out buttons in a row — perhaps actions at
   </Story>
   <Story name="u-flex-wrap@m, buttons">
     {`
-      <ul class="u-flex u-flex-wrap@m a-list-reset">
+      <ul class="u-flex u-flex-wrap@m u-list-none">
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">An action</button></li>
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">Another action</button></li>
         <li class="u-margin-m-right u-margin-m-bottom"><button type="button">A longer-named action</button></li>
@@ -359,7 +359,7 @@ Flex defaults to laying out children in horizontal rows. To layout items vertica
 <Canvas isColumn>
   <Story name="u-flex-col">
     {`
-      <ul class="u-flex u-flex-col a-list-reset">
+      <ul class="u-flex u-flex-col u-list-none">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li>Text content here</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
@@ -369,7 +369,7 @@ Flex defaults to laying out children in horizontal rows. To layout items vertica
   </Story>
   <Story name="u-flex-col@m">
     {`
-      <ul class="u-flex u-flex-col@m a-list-reset">
+      <ul class="u-flex u-flex-col@m u-list-none">
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>
         <li>Text content here</li>
         <li><img src="https://placekitten.com/300/300" width="300" height="300" class="u-block" /></li>

--- a/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
+++ b/scss/bitstyles/utilities/grid-cols/grid-cols.stories.mdx
@@ -27,12 +27,12 @@ The grid classes are only rarely used without the [gap](/docs/utilities-gap--u-g
   </Story>
 </Canvas>
 
-If you’re rendering a list of related items, use a list element (could be a `<ul>` or `<ol>`) with the class `.a-list-reset`. This describes your content better, and will be announced to screenreader users as something like `List of six items, first item: <first item>`.
+If you’re rendering a list of related items, use a list element (could be a `<ul>` or `<ol>`) with the class `.u-list-none`. This describes your content better, and will be announced to screenreader users as something like `List of six items, first item: <first item>`.
 
 <Canvas>
   <Story name="u-grid (list)">
     {`
-      <ul class="u-grid u-gap-l a-list-reset u-padding-m u-bg-gray-light">
+      <ul class="u-grid u-gap-l u-list-none u-padding-m u-bg-gray-light">
         <li class="u-bg-background u-padding-m a-card">1-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">1-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">1-column grid, child 3</li>
@@ -51,7 +51,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
 <Canvas isColumn>
   <Story name="u-grid-cols-2">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-2 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-2 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">2-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">2-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">2-column grid, child 3</li>
@@ -63,7 +63,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
   </Story>
   <Story name="u-grid-cols-3">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-3 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-3 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">3-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">3-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">3-column grid, child 3</li>
@@ -75,7 +75,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
   </Story>
   <Story name="u-grid-cols-4">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-4 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-4 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">4-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">4-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">4-column grid, child 3</li>
@@ -87,7 +87,7 @@ Most likely you’ll want to also add a grid-column class, to layout the grid ch
   </Story>
   <Story name="u-grid-cols-6">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
@@ -106,7 +106,7 @@ Column classes are available at `s`, `m`, and `xl` breakpoints using the suffix 
 <Canvas isColumn>
   <Story name="u-grid-cols-3@s">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-3@s u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-3@s u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -118,7 +118,7 @@ Column classes are available at `s`, `m`, and `xl` breakpoints using the suffix 
   </Story>
   <Story name="u-grid-cols-3@m">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-3@m u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-3@m u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>
@@ -130,7 +130,7 @@ Column classes are available at `s`, `m`, and `xl` breakpoints using the suffix 
   </Story>
   <Story name="u-grid-cols-3@xl">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-3@m u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-3@m u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">Grid child 1</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 2</li>
         <li class="u-bg-background u-padding-m a-card">Grid child 3</li>

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -174,7 +174,7 @@ These classes are all available at the `m` breakpoint.
 
 ## Customization
 
-Customize the available align-items values by overriding the `$bitstyles-items-values` Sass map. Provide the name to be used for the class as the key, and the favlue for the `align-items` property:
+Customize the available align-items values by overriding the `$bitstyles-items-values` Sass map. Provide the name to be used for the class as the key, and the value for the `align-items` property:
 
 ```scss
 @use '~bitstyles/scss/bitstyles/utilities/items' with (

--- a/scss/bitstyles/utilities/items/items.stories.mdx
+++ b/scss/bitstyles/utilities/items/items.stories.mdx
@@ -15,7 +15,7 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
 <Canvas isColumn>
   <Story name="items-center">
     {`
-      <ul class="a-list-reset u-flex u-items-center u-fg-white">
+      <ul class="u-list-none u-flex u-items-center u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="height: 10rem;">
           u-items-center
         </li>
@@ -30,7 +30,7 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
   </Story>
   <Story name="items-end">
     {`
-      <ul class="a-list-reset u-flex u-items-end u-fg-white">
+      <ul class="u-list-none u-flex u-items-end u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="height: 10rem;">
           u-items-end
         </li>
@@ -45,7 +45,7 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
   </Story>
   <Story name="items-start">
     {`
-      <ul class="a-list-reset u-flex u-items-start u-fg-white">
+      <ul class="u-list-none u-flex u-items-start u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="height: 10rem;">
           u-items-start
         </li>
@@ -60,7 +60,7 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
   </Story>
   <Story name="items-stretch">
     {`
-      <ul class="a-list-reset u-flex u-items-stretch u-fg-white" style="min-height: 10rem;">
+      <ul class="u-list-none u-flex u-items-stretch u-fg-white" style="min-height: 10rem;">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="flex-basis: 33%">
           u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o.
         </li>
@@ -75,7 +75,7 @@ The `u-items-` classes set `align-items` to the respective direction(s) on the m
   </Story>
   <Story name="items-baseline">
     {`
-      <ul class="a-list-reset u-flex u-items-baseline u-fg-white">
+      <ul class="u-list-none u-flex u-items-baseline u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light">
           u-items-baseline. Elements with different padding top & bottom.
         </li>
@@ -97,7 +97,7 @@ These classes are all available at the `m` breakpoint.
 <Canvas isColumn>
   <Story name="items-center@m">
     {`
-      <ul class="a-list-reset u-flex u-items-center@m u-fg-white">
+      <ul class="u-list-none u-flex u-items-center@m u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="height: 10rem;">
           u-items-center
         </li>
@@ -112,7 +112,7 @@ These classes are all available at the `m` breakpoint.
   </Story>
   <Story name="items-end@m">
     {`
-      <ul class="a-list-reset u-flex u-items-end@m u-fg-white">
+      <ul class="u-list-none u-flex u-items-end@m u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="height: 10rem;">
           u-items-end
         </li>
@@ -127,7 +127,7 @@ These classes are all available at the `m` breakpoint.
   </Story>
   <Story name="items-start@m">
     {`
-      <ul class="a-list-reset u-flex u-items-start@m u-fg-white">
+      <ul class="u-list-none u-flex u-items-start@m u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="height: 10rem;">
           u-items-start
         </li>
@@ -142,7 +142,7 @@ These classes are all available at the `m` breakpoint.
   </Story>
   <Story name="items-stretch@m">
     {`
-      <ul class="a-list-reset u-flex u-items-stretch@m u-fg-white" style="min-height: 10rem;">
+      <ul class="u-list-none u-flex u-items-stretch@m u-fg-white" style="min-height: 10rem;">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="flex-basis: 33%">
           u-items-stretch. Elements with different amounts of content. Gummies bonbon oat cake tootsie roll liquorice sugar plum tart pie jelly-o.
         </li>
@@ -157,7 +157,7 @@ These classes are all available at the `m` breakpoint.
   </Story>
   <Story name="items-baseline@m">
     {`
-      <ul class="a-list-reset u-flex u-items-baseline@m u-fg-white">
+      <ul class="u-list-none u-flex u-items-baseline@m u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light">
           u-items-baseline. Elements with different padding top & bottom.
         </li>

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -17,7 +17,7 @@ The `u-justify-` classes set set `justify-content` to align flex children to the
 <Canvas isColumn>
   <Story name="justify-between">
     {`
-      <ul class="a-list-reset u-flex u-justify-between u-fg-white" style="min-height:10rem;">
+      <ul class="u-list-none u-flex u-justify-between u-fg-white" style="min-height:10rem;">
         <li class="a-card u-margin-m u-bg-gray-dark">
           Between
         </li>
@@ -29,7 +29,7 @@ The `u-justify-` classes set set `justify-content` to align flex children to the
   </Story>
   <Story name="justify-start">
     {`
-      <ul class="a-list-reset u-flex u-justify-start u-fg-white" style="min-height:10rem;">
+      <ul class="u-list-none u-flex u-justify-start u-fg-white" style="min-height:10rem;">
         <li class="a-card u-margin-m u-bg-gray-dark">
           Start
         </li>
@@ -41,7 +41,7 @@ The `u-justify-` classes set set `justify-content` to align flex children to the
   </Story>
   <Story name="justify-end">
     {`
-      <ul class="a-list-reset u-flex u-justify-end u-fg-white" style="min-height:10rem;">
+      <ul class="u-list-none u-flex u-justify-end u-fg-white" style="min-height:10rem;">
         <li class="a-card u-margin-m u-bg-gray-dark">
           End
         </li>

--- a/scss/bitstyles/utilities/list/_index.import.scss
+++ b/scss/bitstyles/utilities/list/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-list-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/list/_index.scss
+++ b/scss/bitstyles/utilities/list/_index.scss
@@ -1,0 +1,10 @@
+@forward 'settings';
+@use './settings';
+@use '../../tools/properties';
+
+@include properties.output(
+  $property-name: 'list-style-type',
+  $classname-root: 'list',
+  $values: settings.$values,
+  $breakpoints: settings.$breakpoints
+);

--- a/scss/bitstyles/utilities/list/_settings.scss
+++ b/scss/bitstyles/utilities/list/_settings.scss
@@ -1,0 +1,6 @@
+$values: (
+  'none': none,
+  'disc': disc,
+  'decimal': decimal,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/list/list.stories.mdx
+++ b/scss/bitstyles/utilities/list/list.stories.mdx
@@ -1,0 +1,80 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/list" />
+
+# List
+
+Utility classes to specify the list-style-type property.
+
+Default configuration gives you `none`, `decimal`, and `disc`. To change that, and to make the classes available at specific breakpoints, see [Customization](#customization).
+
+<Canvas isColumn>
+  <Story name="none">
+    {`
+      <ul class="u-list-none">
+        <li>
+          u-list-none
+        </li>
+        <li>
+          u-list-none
+        </li>
+        <li>
+          u-list-none
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="decimal">
+    {`
+      <ul class="u-list-decimal">
+        <li>
+          u-list-decimal
+        </li>
+        <li>
+          u-list-decimal
+        </li>
+        <li>
+          u-list-decimal
+        </li>
+      </ul>
+    `}
+  </Story>
+  <Story name="disc">
+    {`
+      <ul class="u-list-disc">
+        <li>
+          u-list-disc
+        </li>
+        <li>
+          u-list-disc
+        </li>
+        <li>
+          u-list-disc
+        </li>
+      </ul>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+Customize the available list-style-type values by overriding the `$bitstyles-list-values` Sass map. Provide the name to be used for the class as the key, and the value for the property:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/list' with (
+  $values: (
+    'circle': circle,
+    'thumbs': '\1F44D',
+  )
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$bitstyles-list-breakpoints` variable:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/list' with (
+  $breakpoints: (
+    'm',
+  )
+);
+```

--- a/scss/bitstyles/utilities/row-start/row-start.stories.mdx
+++ b/scss/bitstyles/utilities/row-start/row-start.stories.mdx
@@ -13,7 +13,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
 <Canvas isColumn>
   <Story name="u-row-start-1">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-1">6-column grid, child 3, row-start-1</li>
@@ -25,7 +25,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-2">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2">6-column grid, child 3, row-start-2</li>
@@ -37,7 +37,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-3">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 3</li>
@@ -49,7 +49,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-4">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-4">6-column grid, child 3, row-start-4</li>
@@ -61,7 +61,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-5">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-5">6-column grid, child 3, row-start-5</li>
@@ -73,7 +73,7 @@ It’s common to use `.u-row-start-1` to force an element to be placed in the fi
   </Story>
   <Story name="u-row-start-6">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-6">6-column grid, child 3, row-start-6</li>
@@ -92,7 +92,7 @@ The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
 <Canvas isColumn>
   <Story name="u-row-start-2@s">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@s">6-column grid, child 3, row-start-1@s</li>
@@ -104,7 +104,7 @@ The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
   </Story>
   <Story name="u-row-start-2@m">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@m">6-column grid, child 3, row-start-1@m</li>
@@ -116,7 +116,7 @@ The `row-start` classes are available at `s`, `m`, and `xl` breakpoints by defau
   </Story>
   <Story name="u-row-start-2@xl">
     {`
-      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light a-list-reset">
+      <ul class="u-grid u-gap-l u-grid-cols-6 u-padding-m u-bg-gray-light u-list-none">
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 1</li>
         <li class="u-bg-background u-padding-m a-card">6-column grid, child 2</li>
         <li class="u-bg-brand-2 u-padding-m a-card u-row-start-2@xl">6-column grid, child 3, row-start-1@xl</li>

--- a/scss/bitstyles/utilities/self/self.stories.mdx
+++ b/scss/bitstyles/utilities/self/self.stories.mdx
@@ -17,7 +17,7 @@ Set `align-self` to align a flex child to the flex end:
 <Canvas>
   <Story name="self-end">
     {`
-      <ul class="a-list-reset u-flex u-items-start u-fg-white">
+      <ul class="u-list-none u-flex u-items-start u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="height: 10rem;">
           Elements of different height.
         </li>
@@ -42,7 +42,7 @@ The classes are available at the `m` breakpoint.
 <Canvas>
   <Story name="self-end@m">
     {`
-      <ul class="a-list-reset u-flex u-items-start u-fg-white">
+      <ul class="u-list-none u-flex u-items-start u-fg-white">
         <li class="u-margin-m u-padding-m u-bg-gray-light" style="height: 10rem;">
           Elements of different height.
         </li>

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -758,6 +758,11 @@ h6 {
 p {
   margin: 0 0 10rem;
 }
+ol,
+ul {
+  margin: 0;
+  padding: 0;
+}
 address {
   font-style: normal;
 }

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -758,11 +758,6 @@ h6 {
 p {
   margin: 0 0 10rem;
 }
-ol,
-ul {
-  margin: 0;
-  padding: 0;
-}
 address {
   font-style: normal;
 }

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -2067,6 +2067,9 @@ table {
 .bs-line-height-10 {
   line-height: 10;
 }
+.bs-list-none {
+  list-style-type: none;
+}
 .bs-margin-0 {
   margin: 0;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -803,11 +803,6 @@ body {
 p {
   margin: 0;
 }
-ol,
-ul {
-  margin: 0;
-  padding: 0;
-}
 address {
   font-style: normal;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2577,6 +2577,15 @@ table {
 .u-line-height-6 {
   line-height: 1.67;
 }
+.u-list-none {
+  list-style-type: none;
+}
+.u-list-disc {
+  list-style-type: disc;
+}
+.u-list-decimal {
+  list-style-type: decimal;
+}
 .u-margin-0 {
   margin: 0;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -803,6 +803,11 @@ body {
 p {
   margin: 0;
 }
+ol,
+ul {
+  margin: 0;
+  padding: 0;
+}
 address {
   font-style: normal;
 }

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -218,6 +218,9 @@ $bitstyles-justify-content-values: (
 $bitstyles-line-height-values: (
   '10': 10,
 );
+$bitstyles-list-values: (
+  'none': none,
+);
 $bitstyles-margin-breakpoints: ('xl', 's');
 $bitstyles-max-height-values: (
   '1em': 1em,

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -218,6 +218,9 @@ $bitstyles-justify-content-values: (
 $bitstyles-line-height-values: (
   '10': 10,
 );
+$bitstyles-list-values: (
+  'none': none,
+);
 $bitstyles-margin-breakpoints: ('xl', 's');
 $bitstyles-max-height-values: (
   '1em': 1em,
@@ -385,6 +388,7 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/utilities/items';
 @import '../../scss/bitstyles/utilities/justify';
 @import '../../scss/bitstyles/utilities/line-height';
+@import '../../scss/bitstyles/utilities/list';
 @import '../../scss/bitstyles/utilities/margin';
 @import '../../scss/bitstyles/utilities/max-height';
 @import '../../scss/bitstyles/utilities/max-width';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -159,6 +159,9 @@
   $items-values: ('start': start),
   $justify-content-values: ('start': start),
   $line-height-values: ('10': 10),
+  $list-values: (
+    'none': none,
+  ),
   $margin-breakpoints: ('xl', 's'),
   $max-height-values: ('1em': 1em),
   $max-width-values: ('1em': 1em),

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -159,9 +159,7 @@
   $items-values: ('start': start),
   $justify-content-values: ('start': start),
   $line-height-values: ('10': 10),
-  $list-values: (
-    'none': none,
-  ),
+  $list-values: ('none': none),
   $margin-breakpoints: ('xl', 's'),
   $max-height-values: ('1em': 1em),
   $max-width-values: ('1em': 1em),

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -369,6 +369,11 @@
     '10': 10,
   )
 );
+@use '../../scss/bitstyles/utilities/list' with (
+  $values: (
+    'none': none,
+  )
+);
 @use '../../scss/bitstyles/utilities/margin' with (
   $breakpoints: (
     'xl',


### PR DESCRIPTION
Fixes #702 

## Changes

- Adds a utility class to specify `list-style-type`
- Renames all uses of `a-list-reset` to `u-list-none`
- Adds base styles for lists that remove the default padding & margin

## 📸

<img width="1105" alt="Screenshot 2022-10-13 at 18 24 26" src="https://user-images.githubusercontent.com/2479422/195653048-03b742db-c6e1-41d0-8bce-14c766ff9984.png">

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
