### PR TITLE
[#693] Export design tokens to JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Added
 
 - New helper function `custom-property.get()` for generating names of CSS custom properties that respect the namespace and layer-prefix configuration.
-- Most design tokens are now output as CSS Custom Properties in a `:root` block. All are prefixed with `bs` in the default configuration (customize that using `setup.$custom-property-namespace`), with names matching their Sass variable e.g. `--bs-color-brand-1-base`, `--bs-color-brand-1-light`, `--bs-size-xs`, `--bs-size-s`
+- Most design tokens are now output as CSS Custom Properties in a `:root` block. All are prefixed with `bs` in the default configuration (customize that using `setup.$custom-property-namespace`), with names matching their Sass variable e.g. `--bs-color-brand-1-base`, `--bs-color-brand-1-light`, `--bs-size-xs`, `--bs-size-s`.
+- Most design tokens are now available in JS environments by importing the relevant file from `exports/`. See the documentation for each set of design tokens for more details.
 
 ### Changed
 
@@ -18,7 +19,7 @@
 - Order of line-heights in `settings/typography.$line-heights` is now in order of size. If you were using the utility classes based on these values, line-heights `1` and `2` have swapped places, as have `4` and `5`. If you were using those values with `line-height.get()`, you’ll need to change the value you request to match. If you were using the utility classes `u-line-height`, you’ll need to rename `u-line-height-1` to `u-line-height-2`, `u-line-height-2` to `u-line-height-1`, `u-line-height-4` to `u-line-height-5`, and `u-line-height-5` to `u-line-height-4`.
 - `settings/typography.$line-height-base` has been removed. Use `tools/line-height.get('5')` instead.
 
-## [[5.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0) - 2022-09-12
+## [[5.0.0-alpha-1]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0-alpha) - 2022-09-12
 
 ### Added
 

--- a/scss/bitstyles/exports/_animation.scss
+++ b/scss/bitstyles/exports/_animation.scss
@@ -1,0 +1,9 @@
+@use '../settings/animation';
+
+/* stylelint-disable selector-pseudo-class-no-unknown */
+:export {
+  #{'easing'}: ease-in-out;
+  #{'duration'}: 0.075s;
+  #{'duration-long'}: 0.5s;
+}
+/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/scss/bitstyles/exports/_breakpoints.scss
+++ b/scss/bitstyles/exports/_breakpoints.scss
@@ -1,0 +1,9 @@
+@use '../settings/breakpoints';
+
+/* stylelint-disable selector-pseudo-class-no-unknown */
+:export {
+  @each $breakpoint-name, $breakpoint in breakpoints.$breakpoints {
+    #{$breakpoint-name}: #{$breakpoint};
+  }
+}
+/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/scss/bitstyles/exports/_color-palette.scss
+++ b/scss/bitstyles/exports/_color-palette.scss
@@ -2,9 +2,9 @@
 
 /* stylelint-disable selector-pseudo-class-no-unknown, max-nesting-depth */
 :export {
-  @each $name, $color-palette in color-palette.$palette {
+  @each $color-palette-name, $color-palette in color-palette.$palette {
     @each $color-name, $color-value in $color-palette {
-      #{$name}#{'.'}#{$color-name}: #{$color-value};
+      #{$color-palette-name}#{'.'}#{$color-name}: #{$color-value};
     }
   }
 }

--- a/scss/bitstyles/exports/_layout.scss
+++ b/scss/bitstyles/exports/_layout.scss
@@ -1,0 +1,9 @@
+@use '../settings/layout';
+
+/* stylelint-disable selector-pseudo-class-no-unknown */
+:export {
+  @each $size-name, $size in layout.$sizes {
+    #{$size-name}: #{$size};
+  }
+}
+/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/scss/bitstyles/exports/_shadows.scss
+++ b/scss/bitstyles/exports/_shadows.scss
@@ -1,0 +1,10 @@
+@use '../settings/shadows' as shadows-settings;
+@use '../tools/shadows';
+
+/* stylelint-disable selector-pseudo-class-no-unknown */
+:export {
+  @each $shadow-name, $shadow in shadows-settings.$shadows {
+    #{$shadow-name}: shadows.get($shadow-name, 'drop');
+  }
+}
+/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/scss/bitstyles/exports/_typography.scss
+++ b/scss/bitstyles/exports/_typography.scss
@@ -1,0 +1,13 @@
+@use '../settings/typography';
+
+/* stylelint-disable selector-pseudo-class-no-unknown */
+:export {
+  @each $font-size-name, $font-size in typography.$font-sizes {
+    #{'font-size.'}#{$font-size-name}: $font-size;
+  }
+
+  @each $line-height-name, $line-height in typography.$line-heights {
+    #{'line-height.'}#{$line-height-name}: $line-height;
+  }
+}
+/* stylelint-enable selector-pseudo-class-no-unknown */

--- a/scss/bitstyles/settings/animation.stories.mdx
+++ b/scss/bitstyles/settings/animation.stories.mdx
@@ -38,6 +38,18 @@ The animation design tokens are also available as CSS custom properties. In the 
 --bs-transition-easing: ease-in-out;
 ```
 
+## Using animation settings in JS
+
+The animation design tokens can be imported and used in JS:
+
+```js
+import animation from '../exports/_animation.scss';
+
+console.log(animation['easing']); // 'ease-in-out'
+console.log(animation['duration']); // '75ms'
+console.log(animation['duration-long']); // '0.5s'
+```
+
 ## Customization
 
 Override the values for these animation variables at the start of your Sass manifest file.

--- a/scss/bitstyles/settings/breakpoints.stories.mdx
+++ b/scss/bitstyles/settings/breakpoints.stories.mdx
@@ -84,6 +84,19 @@ The breakpoints are also available as CSS custom properties. In the default conf
 --bs-breakpoint-motion-ok: screen and (prefers-reduced-motion: no-preference);
 ```
 
+## Using breakpoint settings in JS
+
+The breakpoint design tokens can be imported and used in JS:
+
+```js
+import breakpoints from '../exports/_breakpoints.scss';
+
+console.log(breakpoints['s']); // 'screen and (max-width:29.9375em)'
+console.log(breakpoints['m']); // 'screen and (min-width:30em)'
+console.log(breakpoints['l']); // 'screen and (min-width:55em)'
+// …
+```
+
 ## Customization
 
 Override the values for the available breakpoints at the start of your Sass manifest file.

--- a/scss/bitstyles/settings/color-palette.stories.mdx
+++ b/scss/bitstyles/settings/color-palette.stories.mdx
@@ -59,6 +59,19 @@ The color palette is also available as CSS custom properties. In the default con
 
 Note that each color is also output as rgb tuples, to make using them in CSS color functions a little easier e.g. `rgba(var(--bs-color-brand-1-lighter), 0.5)`
 
+## Using color-palettes in JS
+
+The color design tokens can be imported and used in JS:
+
+```js
+import colorPalette from '../exports/_color-palette.scss';
+
+console.log(colorPalette['brand-1.lighter']); // '#f4f2ff'
+console.log(colorPalette['brand-1.light']); // '#c8bfff'
+console.log(colorPalette['brand-1.base']); // '#644dff'
+// …
+```
+
 ## How the system works
 
 The color system in Bitstyles is a three-tier design token system:

--- a/scss/bitstyles/settings/shadows.stories.mdx
+++ b/scss/bitstyles/settings/shadows.stories.mdx
@@ -89,6 +89,16 @@ The shadow definitions are also available as CSS custom properties. In the defau
   );
 ```
 
+## Using shadow design tokens in JS
+
+The shadow design tokens can be imported and used in JS:
+
+```js
+import shadows from '../exports/_shadows.scss';
+
+console.log(shadows['default']); // 'drop-shadow(rgba(200, 191, 255, 0.125) 0 0.5rem 0.5rem) drop-shadow(rgba(200, 191, 255, 0.125) 0 0.6666666667rem 0.6666666667rem) drop-shadow(rgba(200, 191, 255, 0.125) 0 1rem 1rem) drop-shadow(rgba(200, 191, 255, 0.125) 0 2rem 2rem)'
+```
+
 ### Using local shadows
 
 Not all shadows belong to the global shadows design tokens. Including all the shadows applied to buttons and input elements on hover/focus/active/disabled/etc. could swamp the global list. But you may want to use `shadow.generate()` to take advantage of the multi-layered shadows without having to hand-code them. You can do this using one of the two helper functions `shadow.to-box-shadow()` and `shadow.to-drop-shadow()`. These convert the list formatted-shadows provided by the generator into a format suitable for use in CSS `box-shadow` properties and CSS `filter` properties (using `drop-shadow`), respectively.

--- a/scss/bitstyles/settings/sizes.stories.mdx
+++ b/scss/bitstyles/settings/sizes.stories.mdx
@@ -72,6 +72,20 @@ The sizing scale is also available as CSS custom properties. In the default conf
 --bs-size-3xl: 6.4rem;
 ```
 
+## Using size design tokens in JS
+
+The size design tokens can be imported and used in JS:
+
+```js
+import sizes from '../exports/_sizes.scss';
+
+console.log(sizes['0']); // '0'
+console.log(sizes['2xl']); // '3.2rem'
+console.log(sizes['xl']); // '1.6rem'
+console.log(sizes['l']); // '1rem'
+// …
+```
+
 ## Customization
 
 ### Base size

--- a/scss/bitstyles/settings/typography.stories.mdx
+++ b/scss/bitstyles/settings/typography.stories.mdx
@@ -211,12 +211,27 @@ The font-size and line-height scales are also available as CSS custom properties
 --bs-font-size-6: 2rem;
 --bs-font-size-7: 3rem;
 --bs-font-size-8: 4.8rem;
---bs-line-height-1: 1.29;
---bs-line-height-2: 1.2;
+--bs-line-height-1: 1.21;
+--bs-line-height-2: 1.29;
 --bs-line-height-3: 1.33;
---bs-line-height-4: 1.5;
---bs-line-height-5: 1.43;
+--bs-line-height-4: 1.43;
+--bs-line-height-5: 1.5;
 --bs-line-height-6: 1.67;
+```
+
+## Using typography design tokens in JS
+
+The typography design tokens can be imported and used in JS:
+
+```js
+import typography from '../exports/_typography.scss';
+
+console.log(typography['font-size.1']); // '0.8rem'
+console.log(typography['font-size.2']); // '1rem'
+// …
+console.log(typography['line-height.1']); // '1.29rem'
+console.log(typography['line-height.2']); // '1.2rem'
+// …
 ```
 
 ## Webfonts


### PR DESCRIPTION
Fixes #693 

## Changes

- Adds export files for all the design tokens
- Adds documentation for using the design tokens in JS

## Example

```js
import breakpoints from '../exports/_breakpoints.scss';

console.log(breakpoints['s']); // 'screen and (max-width:29.9375em)'
console.log(breakpoints['m']); // 'screen and (min-width:30em)'
console.log(breakpoints['l']); // 'screen and (min-width:55em)'
// …
```

```js
import colorPalette from '../exports/_color-palette.scss';

console.log(colorPalette['brand-1.lighter']); // '#f4f2ff'
console.log(colorPalette['brand-1.light']); // '#c8bfff'
console.log(colorPalette['brand-1.base']); // '#644dff'
// …
```

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
