### PR TITLE
[#686] Html & body stretch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Added
 
 - New helper function `custom-property.get()` for generating names of CSS custom properties that respect the namespace and layer-prefix configuration.
-- Most design tokens are now output as CSS Custom Properties in a `:root` block. All are prefixed with `bs` in the default configuration (customize that using `setup.$custom-property-namespace`), with names matching their Sass variable e.g. `--bs-color-brand-1-base`, `--bs-color-brand-1-light`, `--bs-size-xs`, `--bs-size-s`
+- Most design tokens are now output as CSS Custom Properties in a `:root` block. All are prefixed with `bs` in the default configuration (customize that using `setup.$custom-property-namespace`), with names matching their Sass variable e.g. `--bs-color-brand-1-base`, `--bs-color-brand-1-light`, `--bs-size-xs`, `--bs-size-s`.
+- Use `setup.$viewport-elements` to define which elements should be considered equal to the viewport in size. These elements’ heights will match the viewport (including any variable sizing on mobile browsers). Make sure to add a selector for any wrapper elements your framework may be wrapping around your app/content.
 
 ### Changed
 
@@ -17,6 +18,7 @@
 - Names of CSS custom properties used for styling the icon buttons inside badge components have been renamed from `--button-fg`, `--button-bg`, `--button-fg-hover`, `--button-bg-hover` to `--bs-a-button-color`, `--bs-a-button-background-color`, `--bs-a-button-color-hover`, `--bs-a-button-background-color-hover` respectively. If you were using these variables in your own codebase, you’ll need to update the names.
 - Order of line-heights in `settings/typography.$line-heights` is now in order of size. If you were using the utility classes based on these values, line-heights `1` and `2` have swapped places, as have `4` and `5`. If you were using those values with `line-height.get()`, you’ll need to change the value you request to match. If you were using the utility classes `u-line-height`, you’ll need to rename `u-line-height-1` to `u-line-height-2`, `u-line-height-2` to `u-line-height-1`, `u-line-height-4` to `u-line-height-5`, and `u-line-height-5` to `u-line-height-4`.
 - `settings/typography.$line-height-base` has been removed. Use `tools/line-height.get('5')` instead.
+- `<body>` is now given `height: stretch` instead of 100%. In all likelihood, this is what was intended by the previous declaration of `height: 100%`, so you shouldn’t need to change anything.
 
 ## [[5.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0) - 2022-09-12
 

--- a/scss/bitstyles/generic/_box-sizing.scss
+++ b/scss/bitstyles/generic/_box-sizing.scss
@@ -1,19 +1,18 @@
-// Can be used to apply the border-box box model to all elements instead of the default content-box,
-// while still allowing components to change.
+@use '../settings/layout';
 
 /* stylelint-disable selector-max-type */
 html {
   box-sizing: border-box;
-  height: 100%;
-}
-
-body {
-  min-height: 100%;
 }
 
 *,
 *::before,
 *::after {
   box-sizing: inherit;
+}
+
+#{layout.$viewport-elements} {
+  height: 100%;
+  min-height: stretch;
 }
 /* stylelint-enable selector-max-type */

--- a/scss/bitstyles/settings/_layout.scss
+++ b/scss/bitstyles/settings/_layout.scss
@@ -15,4 +15,4 @@ $sizes: (
   '2xl': $size-base * 4,
   '3xl': $size-base * 8,
 ) !default;
-$viewport-elements: ('html', 'body', '#root') !default;
+$viewport-elements: ('html', 'body') !default;

--- a/scss/bitstyles/settings/_layout.scss
+++ b/scss/bitstyles/settings/_layout.scss
@@ -15,4 +15,4 @@ $sizes: (
   '2xl': $size-base * 4,
   '3xl': $size-base * 8,
 ) !default;
-$viewport-elements: ('html', 'body') !default;
+$viewport-elements: ('html', 'body', '#root') !default;

--- a/scss/bitstyles/settings/_layout.scss
+++ b/scss/bitstyles/settings/_layout.scss
@@ -15,3 +15,4 @@ $sizes: (
   '2xl': $size-base * 4,
   '3xl': $size-base * 8,
 ) !default;
+$viewport-elements: ('html', 'body', '#root') !default;

--- a/scss/bitstyles/settings/layout.stories.mdx
+++ b/scss/bitstyles/settings/layout.stories.mdx
@@ -1,0 +1,37 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Design Tokens/Layout" />
+
+# Layout
+
+Default configuration causes the height of your site or app to stretch to at least the height of the viewport, even if there’s not enough content to make it do so. This allows you to position a footer or other content at the bottom of the screen. On browsers such as iOS safari where the viewport changes height as the user interacts with the UI, this means the height of your content will adapt and ensures any content placed at the bottom of the screen will stay correctly in view.
+
+This height could also be applied using the [u-height-stretch](/docs/utilities-height--stretch) classname (that’s being used in the example here because the default configuration applies only to the `html` and `body` elements, and to the `#root` element as this storybook requires it). See [Customization](#customization) below for details on how to change that in your setup — selectors for any and all wrapper element(s) around your app or content will need to be added here.
+
+<Canvas>
+  <Story name="layout stretch" inline={false} height="80vh">
+    {`
+      <div class="u-flex u-flex-col u-height-stretch u-gap-s" style="height: 100%;">
+        <header class="u-padding-m u-bg-gray-light">Header</header>
+        <main class="u-flex-grow-1 u-padding-m u-bg-gray-light">Main</main>
+        <footer class="u-padding-m u-bg-gray-light">Footer</footer>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+If you use a clientside framework that inserts its content into a wrapper element inside the `<body>` element, this layout will break because the minimum height is not set on this wrapper element. For React apps, that’s commonly an element with `id="root"`, for Next.js it’s `id="__next"`. Other frameworks may use similar mechanisms. If your content is wrapped in multiple elements, be sure to add each to the list.
+
+Configure `layout.$viewport-elements` to include the selector for the wrapper element:
+
+```scss
+@use 'bitstyles/settings/layout' with (
+  $viewport-elements: (
+    'html',
+    'body',
+    '#__next',
+  )
+);
+```

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -127,15 +127,18 @@
 }
 html {
   box-sizing: border-box;
-  height: 100%;
-}
-body {
-  min-height: 100%;
 }
 *,
 :after,
 :before {
   box-sizing: inherit;
+}
+body,
+html {
+  height: 100%;
+  min-height: -webkit-fill-available;
+  min-height: -moz-available;
+  min-height: stretch;
 } /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 hr {
   box-sizing: content-box;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -133,6 +133,7 @@ html {
 :before {
   box-sizing: inherit;
 }
+#root,
 body,
 html {
   height: 100%;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -130,6 +130,7 @@ html {
 :before {
   box-sizing: inherit;
 }
+#root,
 body,
 html {
   height: 100%;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -124,15 +124,18 @@
 }
 html {
   box-sizing: border-box;
-  height: 100%;
-}
-body {
-  min-height: 100%;
 }
 *,
 :after,
 :before {
   box-sizing: inherit;
+}
+body,
+html {
+  height: 100%;
+  min-height: -webkit-fill-available;
+  min-height: -moz-available;
+  min-height: stretch;
 } /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 hr {
   box-sizing: content-box;


### PR DESCRIPTION
Fixes #686 

## Changes

- Updates the height of body to `stretch`, to ensure it respects the variable height of mobile browser viewports
- The list of elements that style is applied to is now configurable
- Adds docs with an example of the layout

<img width="1105" alt="Screenshot 2022-10-19 at 12 36 24" src="https://user-images.githubusercontent.com/2479422/196669526-856a7e16-50f9-43fd-8974-eb89fb731163.png">

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
