### PR TITLE
[#721] No flex-shrink for radios & checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Radios and checkboxes no longer get distorted when placed in a flex layout, and the sibling content has a min-content width larger than the available space
+
 ## [[5.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0) - 2022-09-12
 
 ### Added

--- a/script/test
+++ b/script/test
@@ -22,11 +22,11 @@ npx prettier --write $TEMP_FOLDER/*.css
 
 printf "\nComparing generated CSS against expected CSS…\n"
 
-diff -u -w --from-file $FIXTURES_FOLDER/bitstyles.css $TEMP_FOLDER/bitstyles.css \
-  && diff -u -w --from-file $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-use-all.css \
-  && diff -u -w --from-file $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-import-each.css \
-  && diff -u -w --from-file $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-use-each.css \
-  && diff -u -w --from-file $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-import-all.css
+diff -u -w $FIXTURES_FOLDER/bitstyles.css $TEMP_FOLDER/bitstyles.css \
+  && diff -u -w $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-use-all.css \
+  && diff -u -w $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-import-each.css \
+  && diff -u -w $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-use-each.css \
+  && diff -u -w $FIXTURES_FOLDER/bitstyles-overrides.css $TEMP_FOLDER/test-import-all.css
 
 compare_result=$?
 

--- a/scss/bitstyles/base/input-checkbox/_index.scss
+++ b/scss/bitstyles/base/input-checkbox/_index.scss
@@ -6,6 +6,7 @@
 [type='checkbox'] {
   display: inline-block;
   position: relative;
+  flex-shrink: 0;
   width: 1em;
   height: 1em;
   margin-right: settings.$gap;

--- a/scss/bitstyles/base/input-radio/_index.scss
+++ b/scss/bitstyles/base/input-radio/_index.scss
@@ -5,6 +5,7 @@
 [type='radio'] {
   display: inline-block;
   position: relative;
+  flex-shrink: 0;
   width: 1em;
   height: 1em;
   margin-right: settings.$gap;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -268,6 +268,7 @@ img {
   appearance: none;
   cursor: pointer;
   display: inline-block;
+  flex-shrink: 0;
   font-size: 10rem;
   height: 1em;
   margin-right: 5rem;
@@ -330,6 +331,7 @@ img {
   appearance: none;
   cursor: pointer;
   display: inline-block;
+  flex-shrink: 0;
   font-size: 10rem;
   height: 1em;
   margin-right: 5rem;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -268,6 +268,7 @@ img {
   appearance: none;
   cursor: pointer;
   display: inline-block;
+  flex-shrink: 0;
   font-size: 0.8rem;
   height: 1em;
   margin-right: 0.4rem;
@@ -331,6 +332,7 @@ img {
   appearance: none;
   cursor: pointer;
   display: inline-block;
+  flex-shrink: 0;
   font-size: 0.8rem;
   height: 1em;
   margin-right: 0.4rem;


### PR DESCRIPTION
Fixes #721 

## Changes

When in a flex layout, if the sibling content’s min-content width (which is taken as the min-width of an element in a flex layout) is larger then the available space, the checkbox/radio would be crushed horizontally. That would happen when e.g. the text label next to the input has a long word, or if the available space is very narrow.

- Checkboxes and radios now have `flex-shrink: 0` to avoid distortion when placed in a flex layout

## 📸

|Before|After|
|--|--|
|<img width="98" alt="Screenshot 2022-12-12 at 15 09 06" src="https://user-images.githubusercontent.com/2479422/207069534-91cf98ce-387f-4af9-91cc-7a4806ed3023.png">|<img width="98" alt="Screenshot 2022-12-12 at 15 23 30" src="https://user-images.githubusercontent.com/2479422/207069578-4220a516-ae0c-4ce6-ae30-11b354260220.png">|

## Checks

Delete if not applicable:

- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
