### PR TITLE
[#677] Line-height cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Radios and checkboxes no longer get distorted when placed in a flex layout, and the sibling content has a min-content width larger than the available space
 
+### Changed
+
+- Order of line-heights in `settings/typography.$line-heights` is now in order of size. If you were using the utility classes based on these values, line-heights `1` and `2` have swapped places, as have `4` and `5`.
+- `settings/typography.$line-height-base` has been removed. Use `tools/line-height.get('5')` instead.
+
 ## [[5.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0) - 2022-09-12
 
 ### Added

--- a/scss/bitstyles/base/forms/_index.scss
+++ b/scss/bitstyles/base/forms/_index.scss
@@ -1,6 +1,6 @@
 @forward 'settings';
 @use './settings';
-@use '../../settings/typography';
+@use '../../tools/line-height';
 @use '../../tools/size';
 
 /* stylelint-disable selector-max-type */
@@ -27,6 +27,6 @@ label {
 }
 
 [type='color'] {
-  height: calc(#{typography.$line-height-base * 1em} + #{size.get('s')});
+  height: calc(#{line-height.get('5') * 1em} + #{size.get('s')});
 }
 /* stylelint-enable selector-max-type */

--- a/scss/bitstyles/base/html/_index.scss
+++ b/scss/bitstyles/base/html/_index.scss
@@ -1,13 +1,14 @@
 @forward 'settings';
 @use './settings';
 @use '../../settings/typography';
+@use '../../tools/line-height';
 
 /* stylelint-disable selector-max-type */
 html {
   background: settings.$background-color;
   color: settings.$color;
   font-family: typography.$font-family-body;
-  line-height: typography.$line-height-base;
+  line-height: line-height.get('5');
   -webkit-text-size-adjust: 100%; // stylelint-disable-line property-no-vendor-prefix
 }
 /* stylelint-enable selector-max-type */

--- a/scss/bitstyles/settings/_typography-responsive.scss
+++ b/scss/bitstyles/settings/_typography-responsive.scss
@@ -6,11 +6,11 @@ $typographic-scale: (
   '#{setup.$no-media-query}': (
     'h1': (
       'font-size': font-size.get('6'),
-      'line-height': line-height.get('1'),
+      'line-height': line-height.get('2'),
     ),
     'h2': (
       'font-size': font-size.get('5'),
-      'line-height': line-height.get('2'),
+      'line-height': line-height.get('1'),
     ),
     'h3': (
       'font-size': font-size.get('4'),
@@ -18,11 +18,11 @@ $typographic-scale: (
     ),
     'h4': (
       'font-size': font-size.get('3'),
-      'line-height': line-height.get('4'),
+      'line-height': line-height.get('5'),
     ),
     'h5': (
       'font-size': font-size.get('2'),
-      'line-height': line-height.get('5'),
+      'line-height': line-height.get('4'),
     ),
     'h6': (
       'font-size': font-size.get('1'),
@@ -36,11 +36,11 @@ $typographic-scale: (
   'm': (
     'h1': (
       'font-size': font-size.get('8'),
-      'line-height': line-height.get('1'),
+      'line-height': line-height.get('2'),
     ),
     'h2': (
       'font-size': font-size.get('7'),
-      'line-height': line-height.get('2'),
+      'line-height': line-height.get('1'),
     ),
     'h3': (
       'font-size': font-size.get('6'),
@@ -48,11 +48,11 @@ $typographic-scale: (
     ),
     'h4': (
       'font-size': font-size.get('4'),
-      'line-height': line-height.get('4'),
+      'line-height': line-height.get('5'),
     ),
     'h5': (
       'font-size': font-size.get('2'),
-      'line-height': line-height.get('5'),
+      'line-height': line-height.get('4'),
     ),
     'h6': (
       'font-size': font-size.get('1'),
@@ -60,7 +60,7 @@ $typographic-scale: (
     ),
     'body': (
       'font-size': font-size.get('2'),
-      'line-height': line-height.get('4'),
+      'line-height': line-height.get('5'),
     ),
   ),
 ) !default;

--- a/scss/bitstyles/settings/_typography.scss
+++ b/scss/bitstyles/settings/_typography.scss
@@ -78,7 +78,6 @@ $font-family-body: list.join(
 //
 // Vertical rhythm /////////////////////////////////////////
 
-$line-height-base: 1.5 !default;
 $font-sizes: (
   '1': 0.8rem,
   '2': 1rem,
@@ -90,10 +89,10 @@ $font-sizes: (
   '8': 4.8rem,
 ) !default;
 $line-heights: (
-  '1': 1.29,
-  '2': 1.2,
+  '1': 1.2,
+  '2': 1.29,
   '3': 1.33,
-  '4': 1.5,
-  '5': 1.43,
+  '4': 1.43,
+  '5': 1.5,
   '6': 1.67,
 ) !default;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2391,19 +2391,19 @@ table {
   }
 }
 .u-line-height-1 {
-  line-height: 1.29;
+  line-height: 1.2;
 }
 .u-line-height-2 {
-  line-height: 1.2;
+  line-height: 1.29;
 }
 .u-line-height-3 {
   line-height: 1.33;
 }
 .u-line-height-4 {
-  line-height: 1.5;
+  line-height: 1.43;
 }
 .u-line-height-5 {
-  line-height: 1.43;
+  line-height: 1.5;
 }
 .u-line-height-6 {
   line-height: 1.67;


### PR DESCRIPTION
Fixes #677

## Changes

- `settings/typography/$line-heights` is now ordered by magnitude
- adjusted `settings/typography-responsive.$typographic-scale` to output the same styles as before
- removes `settings/typography.$line-height-base`

## Checks

Delete if not applicable:

- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
