### PR TITLE
[#719] Add utility: text-decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 ## Unreleased
 
-### Added
-
-- Adds utility classes for specifying `justify-self` and `justify-items`
-
-### Changed
-
-- The variables for the `justify` utility class (which specifies `justify-content`) have been renamed to from `$values` to `$content-values`, and `$breakpoints` to `$content-breakpoints`. If you were overriding these variables, you’ll need to rename them.
-- The variables for the `utilities/flex` classes have been updated to match the pattern used by the `utilities/justify` classes. `$direction` becomes `$direction-values`, `$wrap` becomes `$wrap-values`, `$grow` becomes `$grow-values`, and `$shrink` becomes `$shrink-values`. The single `$breakpoints` variable has been broken out into individual variables for specifying breakpoints for each property: `$direction-breakpoints`, `$wrap-breakpoints`, `$grow-breakpoints`, and `$shrink-breakpoints`. If you were overriding any of these variables, you’ll need to rename them.
-
 ### Fixed
 
 - Radios and checkboxes no longer get distorted when placed in a flex layout, and the sibling content has a min-content width larger than the available space
@@ -22,6 +13,8 @@
 - Use `setup.$viewport-elements` to define which elements should be considered equal to the viewport in size. These elements’ heights will match the viewport (including any variable sizing on mobile browsers). Make sure to add a selector for any wrapper elements your framework may be wrapping around your app/content.
 - Adds a utility class for the `width` property. Defaults to providing `width: 100%` under the name `u-width-full`. This can be customized using `$bitstyles-width-values` and `$bitstyles-width-breakpoints`.
 - Adds utility classes to specify white-space property. Defaults to just `nowrap`, and is configurable with `$bitstyles-white-space-values`, and `$bitstyles-white-space-breakpoints`.
+- Adds a new set of utility classes for specifying the `text-decoration-line` property. Default configuration gives `underline` and `line-through` as values, and is not available at any breakpoints. This can be configured using `$values` and `$breakpoints`.
+- Adds utility classes for specifying `justify-self` and `justify-items`
 
 ### Changed
 
@@ -30,6 +23,8 @@
 - Order of line-heights in `settings/typography.$line-heights` is now in order of size. If you were using the utility classes based on these values, line-heights `1` and `2` have swapped places, as have `4` and `5`. If you were using those values with `line-height.get()`, you’ll need to change the value you request to match. If you were using the utility classes `u-line-height`, you’ll need to rename `u-line-height-1` to `u-line-height-2`, `u-line-height-2` to `u-line-height-1`, `u-line-height-4` to `u-line-height-5`, and `u-line-height-5` to `u-line-height-4`.
 - `settings/typography.$line-height-base` has been removed. Use `tools/line-height.get('5')` instead.
 - `<body>` is now given `height: stretch` instead of 100%. In all likelihood, this is what was intended by the previous declaration of `height: 100%`, so you shouldn’t need to change anything.
+- The variables for the `justify` utility class (which specifies `justify-content`) have been renamed to from `$values` to `$content-values`, and `$breakpoints` to `$content-breakpoints`. If you were overriding these variables, you’ll need to rename them.
+- The variables for the `utilities/flex` classes have been updated to match the pattern used by the `utilities/justify` classes. `$direction` becomes `$direction-values`, `$wrap` becomes `$wrap-values`, `$grow` becomes `$grow-values`, and `$shrink` becomes `$shrink-values`. The single `$breakpoints` variable has been broken out into individual variables for specifying breakpoints for each property: `$direction-breakpoints`, `$wrap-breakpoints`, `$grow-breakpoints`, and `$shrink-breakpoints`. If you were overriding any of these variables, you’ll need to rename them.
 
 ## [[5.0.0-alpha-1]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0) - 2022-09-12
 

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -126,6 +126,7 @@
 @forward 'bitstyles/utilities/self' as self-*;
 @forward 'bitstyles/utilities/sr-only' as sr-only-*;
 @forward 'bitstyles/utilities/text' as text-*;
+@forward 'bitstyles/utilities/text-decoration' as text-decoration*;
 @forward 'bitstyles/utilities/truncate' as truncate-*;
 @forward 'bitstyles/utilities/typography-responsive' as
   typography-responsive-utilities-*;

--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -126,7 +126,7 @@
 @forward 'bitstyles/utilities/self' as self-*;
 @forward 'bitstyles/utilities/sr-only' as sr-only-*;
 @forward 'bitstyles/utilities/text' as text-*;
-@forward 'bitstyles/utilities/text-decoration' as text-decoration*;
+@forward 'bitstyles/utilities/text-decoration' as text-decoration-*;
 @forward 'bitstyles/utilities/truncate' as truncate-*;
 @forward 'bitstyles/utilities/typography-responsive' as
   typography-responsive-utilities-*;

--- a/scss/bitstyles/utilities/text-decoration/_index.import.scss
+++ b/scss/bitstyles/utilities/text-decoration/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-text-decoration-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/text-decoration/_index.scss
+++ b/scss/bitstyles/utilities/text-decoration/_index.scss
@@ -1,0 +1,10 @@
+@forward './settings';
+@use './settings';
+@use '../../tools/properties';
+
+@include properties.output(
+  $property-name: 'text-decoration-line',
+  $classname-root: '',
+  $values: settings.$values,
+  $breakpoints: settings.$breakpoints
+);

--- a/scss/bitstyles/utilities/text-decoration/_settings.scss
+++ b/scss/bitstyles/utilities/text-decoration/_settings.scss
@@ -1,6 +1,5 @@
 $values: (
   'line-through': line-through,
   'underline': underline,
-  'none': none,
 ) !default;
 $breakpoints: () !default;

--- a/scss/bitstyles/utilities/text-decoration/_settings.scss
+++ b/scss/bitstyles/utilities/text-decoration/_settings.scss
@@ -1,0 +1,6 @@
+$values: (
+  'line-through': line-through,
+  'underline': underline,
+  'none': none,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/text-decoration/text-decoration.stories.mdx
+++ b/scss/bitstyles/utilities/text-decoration/text-decoration.stories.mdx
@@ -1,0 +1,42 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/text-decoration" />
+
+# Text-decoration
+
+Set text-decoration-line property on an element. Default values available are: `line-through` and `underline`. These classes are not available at any breakpoint by default. See the [customization](#customization) section for details on how to change the configuration.
+
+<Canvas isColumn>
+  <Story name="u-line-through">
+    {`
+      <p class="u-line-through">Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
+    `}
+  </Story>
+  <Story name="u-underline">
+    {`
+      <p class="u-underline">Pastry marzipan gummi bears lollipop pie pie carrot cake dessert.</p>
+    `}
+  </Story>
+</Canvas>
+
+## Customization
+
+The available text-align values can be customized by overriding the `$values` Sass variable:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/text-decoration' with (
+  $values: (
+    'overline': overline,
+  )
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$breakpoints` list, providing the names of the breakpoints from the global breakpoints list.
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/text-decoration' with (
+  $breakpoints: (
+    'm',
+  )
+);
+```

--- a/scss/bitstyles/utilities/text-decoration/text-decoration.stories.mdx
+++ b/scss/bitstyles/utilities/text-decoration/text-decoration.stories.mdx
@@ -4,7 +4,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 # Text-decoration
 
-Set text-decoration-line property on an element. Default values available are: `line-through` and `underline`. These classes are not available at any breakpoint by default. See the [customization](#customization) section for details on how to change the configuration.
+Set the `text-decoration-line` property on an element. With default configuration the available values are: `line-through` and `underline`, which are not available at any breakpoint. See the [customization](#customization) section for details on how to change the configuration.
 
 <Canvas isColumn>
   <Story name="u-line-through">

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -3734,6 +3734,9 @@ table {
 .bs-text-top {
   text-align: top;
 }
+.bs-text-decoration-none {
+  text-decoration-line: none;
+}
 .bs-truncate {
   max-width: 100%;
   overflow: hidden;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -4311,6 +4311,12 @@ table {
 .u-text-justify {
   text-align: justify;
 }
+.u-line-through {
+  text-decoration-line: line-through;
+}
+.u-underline {
+  text-decoration-line: underline;
+}
 .u-truncate {
   max-width: 100%;
   overflow: hidden;

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -246,6 +246,9 @@ $bitstyles-sr-only-breakpoints: ('xl');
 $bitstyles-text-values: (
   'top': top,
 );
+$bitstyles-text-decoration-values: (
+  'text-decoration-none': none,
+);
 $bitstyles-typography-responsive-utilities-values: (
   'm': (
     'h1': (

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -246,6 +246,9 @@ $bitstyles-sr-only-breakpoints: ('xl');
 $bitstyles-text-values: (
   'top': top,
 );
+$bitstyles-text-decoration-values: (
+  'text-decoration-none': none,
+);
 $bitstyles-typography-responsive-utilities-values: (
   'm': (
     'h1': (
@@ -396,6 +399,7 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/utilities/self';
 @import '../../scss/bitstyles/utilities/sr-only';
 @import '../../scss/bitstyles/utilities/text';
+@import '../../scss/bitstyles/utilities/text-decoration';
 @import '../../scss/bitstyles/utilities/truncate';
 @import '../../scss/bitstyles/utilities/typography-responsive';
 @import '../../scss/bitstyles/utilities/typography';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -174,9 +174,7 @@
   $self-values: ('start': start),
   $sr-only-breakpoints: ('xl'),
   $text-values: ('top': top),
-  $text-decoration-values: (
-    'text-decoration-none': none,
-  ),
+  $text-decoration-values: ('text-decoration-none': none),
   $typography-responsive-utilities-values: (
     'm': (
       'h1': (

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -174,6 +174,9 @@
   $self-values: ('start': start),
   $sr-only-breakpoints: ('xl'),
   $text-values: ('top': top),
+  $text-decoration-values: (
+    'text-decoration-none': none,
+  ),
   $typography-responsive-utilities-values: (
     'm': (
       'h1': (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -434,6 +434,11 @@
     'top': top,
   )
 );
+@use '../../scss/bitstyles/utilities/text-decoration' with (
+  $values: (
+    'text-decoration-none': none,
+  )
+);
 @use '../../scss/bitstyles/utilities/truncate';
 @use '../../scss/bitstyles/utilities/typography-responsive' as
   typography-responsive-utilities with (


### PR DESCRIPTION
Fixes #719 

## Changes

- Adds a text-decoration-line utility class

## 📸

<img width="1044" alt="Screenshot 2022-12-21 at 14 26 18" src="https://user-images.githubusercontent.com/2479422/208916142-382d955d-5990-4639-8fc5-96711bf533f6.png">

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
