### PR TITLE
[#716] Add utility: grid-row

### DIFF
--- a/scss/bitstyles.scss
+++ b/scss/bitstyles.scss
@@ -107,6 +107,7 @@
 @forward 'bitstyles/utilities/font' as font-*;
 @forward 'bitstyles/utilities/gap' as gap-*;
 @forward 'bitstyles/utilities/grid-cols' as grid-cols-*;
+@forward 'bitstyles/utilities/grid-rows' as grid-rows-*;
 @forward 'bitstyles/utilities/height' as height-*;
 @forward 'bitstyles/utilities/inset' as inset-*;
 @forward 'bitstyles/utilities/items' as items-*;

--- a/scss/bitstyles/utilities/grid-rows/_index.import.scss
+++ b/scss/bitstyles/utilities/grid-rows/_index.import.scss
@@ -1,0 +1,2 @@
+@forward 'settings' as bitstyles-grid-rows-*;
+@forward 'index';

--- a/scss/bitstyles/utilities/grid-rows/_index.scss
+++ b/scss/bitstyles/utilities/grid-rows/_index.scss
@@ -1,0 +1,10 @@
+@forward 'settings';
+@use './settings';
+@use '../../tools/properties';
+
+@include properties.output(
+  $property-name: 'grid-template-rows',
+  $classname-root: 'grid-rows',
+  $values: settings.$values,
+  $breakpoints: settings.$breakpoints
+);

--- a/scss/bitstyles/utilities/grid-rows/_index.scss
+++ b/scss/bitstyles/utilities/grid-rows/_index.scss
@@ -3,7 +3,7 @@
 @use '../../tools/properties';
 
 @include properties.output(
-  $property-name: 'grid-template-rows',
+  $property-name: 'grid-auto-rows',
   $classname-root: 'grid-rows',
   $values: settings.$values,
   $breakpoints: settings.$breakpoints

--- a/scss/bitstyles/utilities/grid-rows/_settings.scss
+++ b/scss/bitstyles/utilities/grid-rows/_settings.scss
@@ -1,4 +1,4 @@
 $values: (
-  'max-content': max-content,
+  '1fr': 1fr,
 ) !default;
 $breakpoints: () !default;

--- a/scss/bitstyles/utilities/grid-rows/_settings.scss
+++ b/scss/bitstyles/utilities/grid-rows/_settings.scss
@@ -1,0 +1,4 @@
+$values: (
+  'max-content': max-content,
+) !default;
+$breakpoints: () !default;

--- a/scss/bitstyles/utilities/grid-rows/grid-rows.stories.mdx
+++ b/scss/bitstyles/utilities/grid-rows/grid-rows.stories.mdx
@@ -1,0 +1,53 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities/grid-rows" />
+
+# Grid rows
+
+Specify the layout of rows on a grid element.
+
+For when you need to specify specific row layouts for your grid. Default configuration provides only `1fr`, resulting in rows of equal heights even when the content is of unequal lengths (and even with single column layouts on small viewports). In practice that means your rows will all be the height of the tallest row.
+
+<Canvas isColumn>
+  <Story name="u-grid-rows-max-content">
+    {`
+      <div class="u-grid u-grid-cols-2@m u-grid-rows-1fr u-gap-l">
+        <p class="u-bg-gray-dark a-card">Cupcake ipsum dolor sit amet muffin gummi bears chocolate cake croissant. Cookie icing apple pie danish chocolate cake. Wafer tootsie roll bear claw chupa chups liquorice sweet jelly-o. Lollipop oat cake sesame snaps shortbread carrot cake chocolate bar marshmallow. Gummi bears jelly toffee cake biscuit wafer bonbon. Carrot cake tiramisu caramels cake danish. Halvah wafer cupcake bear claw candy canes lemon drops bonbon cotton candy gingerbread. Marzipan cake bear claw fruitcake dragée tiramisu carrot cake jujubes. Muffin pie oat cake chocolate jelly beans jelly beans.</p>
+        <p class="u-bg-gray-dark a-card">Cupcake ipsum dolor sit amet muffin gummi bears chocolate cake croissant. Cookie icing apple pie danish chocolate cake. Wafer tootsie roll bear claw chupa chups liquorice sweet jelly-o. Lollipop oat cake sesame snaps shortbread carrot cake chocolate bar marshmallow. Gummi bears jelly toffee cake biscuit wafer bonbon. Carrot cake tiramisu caramels cake danish. Halvah wafer cupcake bear claw candy canes lemon drops bonbon cotton candy gingerbread. Marzipan cake bear claw fruitcake dragée tiramisu carrot cake jujubes. Muffin pie oat cake chocolate jelly beans jelly beans. Cake cookie danish tiramisu halvah cake chocolate bar cake fruitcake.</p>
+        <p class="u-bg-gray-dark a-card">Cupcake ipsum dolor sit amet muffin gummi bears chocolate cake croissant. Cookie icing apple pie danish chocolate cake. Wafer tootsie roll bear claw chupa chups liquorice sweet jelly-o. Lollipop oat cake sesame snaps shortbread carrot cake chocolate bar marshmallow. Gummi bears jelly toffee cake biscuit wafer bonbon. Carrot cake tiramisu caramels cake danish. Halvah wafer cupcake bear claw candy canes lemon drops bonbon cotton candy gingerbread. Marzipan cake bear claw fruitcake dragée tiramisu carrot cake jujubes. Muffin pie oat cake chocolate jelly beans jelly beans.</p>
+        <p class="u-bg-gray-dark a-card">Cupcake ipsum dolor sit amet muffin gummi bears chocolate cake croissant. Cookie icing apple pie danish chocolate cake. Wafer tootsie roll bear claw chupa chups liquorice sweet jelly-o. Lollipop oat cake sesame snaps shortbread carrot cake chocolate bar marshmallow.</p>
+        <p class="u-bg-gray-dark a-card">Macaroon brownie chocolate tiramisu icing caramels fruitcake lollipop. Sesame snaps cookie croissant cheesecake danish pastry. Halvah sweet roll shortbread cheesecake sesame snaps wafer chocolate bar pudding pie.</p>
+        <p class="u-bg-gray-dark a-card">Macaroon brownie chocolate tiramisu icing caramels fruitcake lollipop. Sesame snaps cookie croissant cheesecake danish pastry. Halvah sweet roll shortbread cheesecake sesame snaps wafer chocolate bar pudding pie.</p>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
+### Responsive rows
+
+Row classes are not available at any breakpoints with the default configuration.
+
+## Customization
+
+The available grid row layouts can be customized by overriding the `$values` Sass map. Provide the name for the class as the key, and the value for the `grid-template-rows` property as the value:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/grid-rows' with (
+  $values: (
+    'auto': auto,
+    'stripes': repeat(4, 25vh);
+  )
+);
+```
+
+The breakpoints these classes are available at can be customized by overriding the `$breakpoints` variable:
+
+```scss
+@use '~bitstyles/scss/bitstyles/utilities/grid-rows' with (
+  $breakpoints: (
+    's',
+    'm',
+    'xl',
+  )
+);
+```

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1993,7 +1993,7 @@ table {
   }
 }
 .bs-grid-rows-auto {
-  grid-template-rows: auto;
+  grid-auto-rows: auto;
 }
 .bs-height-1em {
   height: 1em;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1992,6 +1992,9 @@ table {
     grid-template-columns: repeat(100, minmax(0, 1fr));
   }
 }
+.bs-grid-rows-auto {
+  grid-template-rows: auto;
+}
 .bs-height-1em {
   height: 1em;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2446,6 +2446,9 @@ table {
     grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 }
+.u-grid-rows-max-content {
+  grid-template-rows: max-content;
+}
 .u-height-100vh {
   height: 100vh;
 }

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2446,8 +2446,8 @@ table {
     grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 }
-.u-grid-rows-max-content {
-  grid-template-rows: max-content;
+.u-grid-rows-1fr {
+  grid-auto-rows: 1fr;
 }
 .u-height-100vh {
   height: 100vh;

--- a/test/scss/test-import-all.scss
+++ b/test/scss/test-import-all.scss
@@ -200,6 +200,9 @@ $bitstyles-gap-sizes: (
 $bitstyles-grid-cols-values: (
   '100': repeat(100, minmax(0, 1fr)),
 );
+$bitstyles-grid-rows-values: (
+  'auto': auto,
+);
 $bitstyles-height-values: (
   '1em': 1em,
 );

--- a/test/scss/test-import-each.scss
+++ b/test/scss/test-import-each.scss
@@ -200,6 +200,9 @@ $bitstyles-gap-sizes: (
 $bitstyles-grid-cols-values: (
   '100': repeat(100, minmax(0, 1fr)),
 );
+$bitstyles-grid-rows-values: (
+  'auto': auto,
+);
 $bitstyles-height-values: (
   '1em': 1em,
 );
@@ -371,6 +374,7 @@ $bitstyles-z-index-values: (
 @import '../../scss/bitstyles/utilities/font';
 @import '../../scss/bitstyles/utilities/gap';
 @import '../../scss/bitstyles/utilities/grid-cols';
+@import '../../scss/bitstyles/utilities/grid-rows';
 @import '../../scss/bitstyles/utilities/height';
 @import '../../scss/bitstyles/utilities/inset';
 @import '../../scss/bitstyles/utilities/items';

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -153,6 +153,7 @@
   $flex-grow: ('100': 100),
   $gap-sizes: ('100': 100rem),
   $grid-cols-values: ('100': repeat(100, minmax(0, 1fr))),
+  $grid-rows-values: ('auto': auto),
   $height-values: ('1em': 1em),
   $inset-values: ('100': 100rem),
   $items-values: ('start': start),

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -342,6 +342,11 @@
     '100': repeat(100, minmax(0, 1fr)),
   )
 );
+@use '../../scss/bitstyles/utilities/grid-rows' with (
+  $values: (
+    'auto': auto,
+  )
+);
 @use '../../scss/bitstyles/utilities/height' with (
   $values: (
     '1em': 1em,


### PR DESCRIPTION
Fixes #716 

## Changes

- Adds grid-rows utility class, with example

## 📸

|Small viewport| Large viewport|
|--|--|
|![utilities grid rows u grid rows max content](https://user-images.githubusercontent.com/2479422/209147076-bd302dcf-4e4c-48e4-8cb2-dd112c23bc9e.png)|![utilities grid rows u grid rows max content(1)](https://user-images.githubusercontent.com/2479422/209147120-7f858190-1a9d-4706-9a3f-44f2e88f2dab.png)|


## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
