### PR TITLE
Add justify-content: center to the default configuration for the justify utility class

### DIFF
--- a/scss/bitstyles/utilities/justify/_settings.scss
+++ b/scss/bitstyles/utilities/justify/_settings.scss
@@ -1,6 +1,7 @@
 /* justify-content */
 $content-values: (
   'between': space-between,
+  'center': center,
   'end': flex-end,
   'start': flex-start,
 ) !default;

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -27,7 +27,7 @@ The `u-justify-` classes set set `justify-content` to align flex children to the
       </ul>
     `}
   </Story>
-    <Story name="justify-center">
+  <Story name="justify-center">
     {`
       <ul class="u-list-none u-flex u-justify-center u-fg-white" style="min-height:10rem;">
         <li class="a-card u-margin-m u-bg-gray-dark">

--- a/scss/bitstyles/utilities/justify/justify.stories.mdx
+++ b/scss/bitstyles/utilities/justify/justify.stories.mdx
@@ -8,7 +8,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 Specify `justify-content` property on an element.
 
-Available with `between`, `start`, and `end` values by default, and at the `m` breakpoint. See [customization](#customization) below for details on how change the settings.
+Available with `between`, `start`, `center` and `end` values by default, and at the `m` breakpoint. See [customization](#customization) below for details on how change the settings.
 
 Flex and Grid share many alignment properties. These will have no effect on elements to which you haven’t given one of those classes (`.u-flex`, `.u-grid`).
 
@@ -23,6 +23,18 @@ The `u-justify-` classes set set `justify-content` to align flex children to the
         </li>
         <li class="a-card u-margin-m u-bg-gray-dark">
           Between
+        </li>
+      </ul>
+    `}
+  </Story>
+    <Story name="justify-center">
+    {`
+      <ul class="u-list-none u-flex u-justify-center u-fg-white" style="min-height:10rem;">
+        <li class="a-card u-margin-m u-bg-gray-dark">
+          Center
+        </li>
+        <li class="a-card u-margin-m u-bg-gray-dark">
+          Center
         </li>
       </ul>
     `}

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2716,6 +2716,9 @@ table {
 .u-justify-between {
   justify-content: space-between;
 }
+.u-justify-center {
+  justify-content: center;
+}
 .u-justify-end {
   justify-content: flex-end;
 }
@@ -2725,6 +2728,9 @@ table {
 @media screen and (min-width: 30em) {
   .u-justify-between\@m {
     justify-content: space-between;
+  }
+  .u-justify-center\@m {
+    justify-content: center;
   }
   .u-justify-end\@m {
     justify-content: flex-end;


### PR DESCRIPTION
This PR updates the default configuration for the `u-justify` utility class to include `justify-content: center`

#733 

### Screenshot
<img width="1224" alt="image" src="https://user-images.githubusercontent.com/61787049/212654289-6574a1e8-2fe1-4baf-90e3-4f794e2f9b69.png">


Delete if not applicable:

- [x] Storybook documentation has been updated