### PR TITLE
[#735] Add aria-expanded to the button pressed state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Buttons now show their `pressed` state when they have `aria-expanded='true'`, so it’s usable with dropdowns, and other show/hide UI.
+
 ## [[5.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v5.0.0) - 2023-01-03
 
 ### Fixed

--- a/scss/bitstyles/atoms/button-colors/_index.scss
+++ b/scss/bitstyles/atoms/button-colors/_index.scss
@@ -65,6 +65,7 @@
     }
 
     @if map.has-key($variant-default-theme, 'pressed') {
+      &[aria-expanded='true'],
       &[aria-pressed='true'],
       &[aria-selected='true'],
       &[aria-current] {

--- a/scss/bitstyles/atoms/button-colors/button-colors.stories.mdx
+++ b/scss/bitstyles/atoms/button-colors/button-colors.stories.mdx
@@ -10,6 +10,18 @@ Buttons are available in several color-based variations:
 - **Secondary** Most other buttons on a screen should probably use this variant. It is a visibly interactive element but not heavily emphasised.
 - **Transparent** For buttons that really shouldn’t stand out, these present only a text label until interacted with.
 
+## Button states
+
+Buttons react to user interaction, and can be disabled, giving the following states:
+
+| State    | Description                                                                                                                                                                                                                                                                                                                                 |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| default  | The default appearance of the button variant, without any user interaction                                                                                                                                                                                                                                                                  |
+| hover    | The user has their cursor over the button (`:hover` psuedoclass)                                                                                                                                                                                                                                                                            |
+| active   | The user is currently clicking, tapping, or otherwise activating the button (`:active` psuedoclass)                                                                                                                                                                                                                                         |
+| pressed  | Covers several instances where the button can be in an “on” state. This is for toggle buttons, tab buttons, navigation or steps in a process where one is currently active, or for buttons that show/hide other content. Apply the relevant aria attribute to the button: `aria-selected`, `aria-expanded`, `aria-current`, `aria-pressed`. |
+| disabled | The button is not currently clickable, and will not perform an action                                                                                                                                                                                                                                                                       |
+
 <Canvas>
   <Story name="Primary">
     {`

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -950,6 +950,7 @@ table {
   color: var(--bscpn-at-button--secondary-active-color);
 }
 .bs-at-button--secondary[aria-current],
+.bs-at-button--secondary[aria-expanded='true'],
 .bs-at-button--secondary[aria-pressed='true'],
 .bs-at-button--secondary[aria-selected='true'] {
   background-color: var(--bscpn-at-button--secondary-pressed-background-color);
@@ -1114,6 +1115,7 @@ table {
   color: var(--bscpn-at-button--transparent-active-color);
 }
 .bs-at-button--transparent[aria-current],
+.bs-at-button--transparent[aria-expanded='true'],
 .bs-at-button--transparent[aria-pressed='true'],
 .bs-at-button--transparent[aria-selected='true'] {
   background-color: var(
@@ -1248,6 +1250,7 @@ table {
   color: var(--bscpn-at-button--tab-active-color);
 }
 .bs-at-button--tab[aria-current],
+.bs-at-button--tab[aria-expanded='true'],
 .bs-at-button--tab[aria-pressed='true'],
 .bs-at-button--tab[aria-selected='true'] {
   background-color: var(--bscpn-at-button--tab-pressed-background-color);

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -1002,6 +1002,7 @@ table {
   color: var(--bs-a-button-active-color);
 }
 .a-button[aria-current],
+.a-button[aria-expanded='true'],
 .a-button[aria-pressed='true'],
 .a-button[aria-selected='true'] {
   background-color: var(--bs-a-button-pressed-background-color);
@@ -1118,6 +1119,7 @@ table {
   color: var(--bs-a-button--secondary-active-color);
 }
 .a-button--secondary[aria-current],
+.a-button--secondary[aria-expanded='true'],
 .a-button--secondary[aria-pressed='true'],
 .a-button--secondary[aria-selected='true'] {
   background-color: var(--bs-a-button--secondary-pressed-background-color);
@@ -1254,6 +1256,7 @@ table {
   color: var(--bs-a-button--transparent-active-color);
 }
 .a-button--transparent[aria-current],
+.a-button--transparent[aria-expanded='true'],
 .a-button--transparent[aria-pressed='true'],
 .a-button--transparent[aria-selected='true'] {
   background-color: var(--bs-a-button--transparent-pressed-background-color);
@@ -1378,6 +1381,7 @@ table {
   color: var(--bs-a-button--tab-active-color);
 }
 .a-button--tab[aria-current],
+.a-button--tab[aria-expanded='true'],
 .a-button--tab[aria-pressed='true'],
 .a-button--tab[aria-selected='true'] {
   background-color: var(--bs-a-button--tab-pressed-background-color);


### PR DESCRIPTION
Fixes #735

## Changes

Buttons now show their `pressed` state when they have `aria-expanded='true'`, so it’s usable with dropdowns etc.

## Checks

Delete if not applicable:

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
