### PR TITLE
[#764] Update skip-link

### DIFF
--- a/.storybook/helpers.js
+++ b/.storybook/helpers.js
@@ -15,7 +15,7 @@ export const generateLabel = (
   shapeVariant = [],
   colorVariant = [],
   disabled = false,
-  pressed = false,
+  pressed = false
 ) =>
   capitalizeFirstLetter(
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - `font-size.get($font-size-name)` to `design-token.get('font-size', $font-size-name)`
   - `shadows.get($shadow-name)` to `design-token.get('shadow', $shadow-name)`
   - `custom-property.get()` to `design-token.get()`
+- Updated design for `.a-skip-link`. If you were overriding the appearance before, the only difference you’ll notice is that the skip-link now has a focus indicator, and a hover state. There are extra Sass variables available for customizing the hover state — see the docs for details.
 
 ### Added
 

--- a/scss/bitstyles/atoms/skip-link/_index.scss
+++ b/scss/bitstyles/atoms/skip-link/_index.scss
@@ -20,6 +20,7 @@
     border: settings.$border;
     outline-width: 0;
     background: settings.$background;
+    box-shadow: settings.$shadow;
     color: settings.$color;
     text-decoration: settings.$text-decoration;
   }

--- a/scss/bitstyles/atoms/skip-link/_index.scss
+++ b/scss/bitstyles/atoms/skip-link/_index.scss
@@ -10,19 +10,23 @@
   left: 50%;
   padding: settings.$padding;
   transform: translateX(-50%);
-  font-weight: settings.$font-weight;
-  outline-offset: 0;
   border-radius: settings.$border-radius;
+  outline-offset: 0;
+  font-weight: settings.$font-weight;
 
   &,
   &:visited,
-  &:hover,
   &:focus {
     border: settings.$border;
     outline-width: 0;
     background: settings.$background;
     color: settings.$color;
     text-decoration: settings.$text-decoration;
+  }
+
+  &:hover {
+    background: settings.$background-hover;
+    color: settings.$color-hover;
   }
 
   &:focus {

--- a/scss/bitstyles/atoms/skip-link/_index.scss
+++ b/scss/bitstyles/atoms/skip-link/_index.scss
@@ -1,5 +1,6 @@
 @forward './settings';
 @use './settings';
+@use '../../design-tokens/focus';
 @use '../../tools/classname';
 
 #{classname.get($classname-items: 'skip-link', $layer: 'atom')} {
@@ -10,17 +11,26 @@
   padding: settings.$padding;
   transform: translateX(-50%);
   font-weight: settings.$font-weight;
+  outline-offset: 0;
+  border-radius: settings.$border-radius;
 
   &,
   &:visited,
   &:hover,
   &:focus {
     border: settings.$border;
+    outline-width: 0;
     background: settings.$background;
     color: settings.$color;
+    text-decoration: settings.$text-decoration;
   }
 
   &:focus {
-    top: 0;
+    top: settings.$spacing;
+  }
+
+  &:focus-visible {
+    outline: focus.$outline-color solid focus.$outline-width;
+    outline-offset: focus.$outline-offset;
   }
 }

--- a/scss/bitstyles/atoms/skip-link/_index.scss
+++ b/scss/bitstyles/atoms/skip-link/_index.scss
@@ -12,6 +12,7 @@
   transform: translateX(-50%);
   border-radius: settings.$border-radius;
   outline-offset: 0;
+  font-size: settings.$font-size;
   font-weight: settings.$font-weight;
 
   &,

--- a/scss/bitstyles/atoms/skip-link/_settings.scss
+++ b/scss/bitstyles/atoms/skip-link/_settings.scss
@@ -4,7 +4,8 @@
 // Base styles /////////////////////////////////////////
 
 $padding: var(design-token.get('size', 'm')) var(design-token.get('size', 'l2')) !default;
-$font-weight: var(design-token.get('font-weight', 'medium')) !default;
+$font-size: var(design-token.get('font-size', '4')) !default;
+$font-weight: var(design-token.get('font-weight', 'semibold')) !default;
 $z-index: var(design-token.get('z-index', 'top')) !default;
 $text-decoration: none !default;
 $spacing: var(design-token.get('size', 's4')) !default;
@@ -13,9 +14,9 @@ $spacing: var(design-token.get('size', 's4')) !default;
 // Base/focus Colors /////////////////////////////////////////
 
 $background: var(design-token.get('color', 'grayscale', 'white')) !default;
-$color: var(design-token.get('color', 'grayscale', 'black')) !default;
+$color: var(design-token.get('color', 'grayscale', 'dark-4')) !default;
 $border: var(design-token.get('size', 's6'))
-  var(design-token.get('color', 'grayscale', 'black')) solid !default;
+  var(design-token.get('color', 'grayscale', 'dark-4')) solid !default;
 $border-radius: var(design-token.get('size', 's4')) !default;
 $shadow: var(design-token.get('shadow', 'brand-2', 'box')) !default;
 

--- a/scss/bitstyles/atoms/skip-link/_settings.scss
+++ b/scss/bitstyles/atoms/skip-link/_settings.scss
@@ -17,6 +17,7 @@ $color: var(design-token.get('color', 'grayscale', 'black')) !default;
 $border: var(design-token.get('size', 's6'))
   var(design-token.get('color', 'grayscale', 'black')) solid !default;
 $border-radius: var(design-token.get('size', 's4')) !default;
+$shadow: var(design-token.get('shadow', 'brand-2', 'box')) !default;
 
 //
 // Hover Colors /////////////////////////////////////////

--- a/scss/bitstyles/atoms/skip-link/_settings.scss
+++ b/scss/bitstyles/atoms/skip-link/_settings.scss
@@ -3,14 +3,17 @@
 //
 // Base styles /////////////////////////////////////////
 
-$padding: var(design-token.get('size', 's1')) !default;
+$padding: var(design-token.get('size', 'l2')) !default;
 $font-weight: var(design-token.get('font-weight', 'medium')) !default;
 $z-index: var(design-token.get('z-index', 'top')) !default;
+$text-decoration: none !default;
+$spacing: var(design-token.get('size', 's4')) !default;
 
 //
 // Base/hover Colors /////////////////////////////////////////
 
 $background: var(design-token.get('color', 'grayscale', 'white')) !default;
-$color: var(design-token.get('color', 'grayscale', 'dark-1')) !default;
+$color: var(design-token.get('color', 'grayscale', 'black')) !default;
 $border: var(design-token.get('size', 's6'))
-  var(design-token.get('color', 'grayscale', 'dark-1')) solid !default;
+  var(design-token.get('color', 'grayscale', 'black')) solid !default;
+$border-radius: var(design-token.get('size', 's4')) !default;

--- a/scss/bitstyles/atoms/skip-link/_settings.scss
+++ b/scss/bitstyles/atoms/skip-link/_settings.scss
@@ -3,17 +3,25 @@
 //
 // Base styles /////////////////////////////////////////
 
-$padding: var(design-token.get('size', 'l2')) !default;
+$padding: var(design-token.get('size', 'm')) var(design-token.get('size', 'l2')) !default;
 $font-weight: var(design-token.get('font-weight', 'medium')) !default;
 $z-index: var(design-token.get('z-index', 'top')) !default;
 $text-decoration: none !default;
 $spacing: var(design-token.get('size', 's4')) !default;
 
 //
-// Base/hover Colors /////////////////////////////////////////
+// Base/focus Colors /////////////////////////////////////////
 
 $background: var(design-token.get('color', 'grayscale', 'white')) !default;
 $color: var(design-token.get('color', 'grayscale', 'black')) !default;
 $border: var(design-token.get('size', 's6'))
   var(design-token.get('color', 'grayscale', 'black')) solid !default;
 $border-radius: var(design-token.get('size', 's4')) !default;
+
+//
+// Hover Colors /////////////////////////////////////////
+
+$background-hover: var(
+  design-token.get('color', 'grayscale', 'black')
+) !default;
+$color-hover: var(design-token.get('color', 'grayscale', 'white')) !default;

--- a/scss/bitstyles/atoms/skip-link/skip-link.stories.js
+++ b/scss/bitstyles/atoms/skip-link/skip-link.stories.js
@@ -1,0 +1,30 @@
+import Link from '../../base/anchor/Link';
+
+export default {
+  title: 'Atoms/Skip link',
+  component: Link,
+};
+
+const Template = (args) => {
+  const fragment = new DocumentFragment();
+  const mainContent = document.createElement('div');
+  mainContent.setAttribute('id', 'main');
+  mainContent.innerHTML =
+    'Your main content here, after some other content that gets repeated on every page (navigation etc.)';
+  fragment.append(Link(args));
+  fragment.append(mainContent);
+  return fragment;
+};
+
+// ***** Default size, each shape & color ****************** //
+
+export const Base = Template.bind({});
+Base.args = {
+  children: 'Skip to content',
+  classname: ['a-skip-link'],
+  href: '#main',
+};
+Base.parameters = {
+  zeplinLink:
+    'https://app.zeplin.io/styleguide/63079b90d0bf4a646c46c227/components?coid=6363a297d8cc70b3d84eeee3',
+};

--- a/scss/bitstyles/atoms/skip-link/skip-link.stories.mdx
+++ b/scss/bitstyles/atoms/skip-link/skip-link.stories.mdx
@@ -34,6 +34,7 @@ The default colors are high contrast and clearly readable. If you change them, p
       design-token.get('color', 'grayscale', 'dark-1')
     )
     solid,
+  $shadow: var(design-token.get('shadow', 'brand-1', 'box')),
   $background-hover: var(design-token.get('color', 'grayscale', 'dark-1')),
   $color-hover: var(design-token.get('color', 'grayscale', 'white'))
 );

--- a/scss/bitstyles/atoms/skip-link/skip-link.stories.mdx
+++ b/scss/bitstyles/atoms/skip-link/skip-link.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 
-<Meta title="Atoms/Skip link" />
+<Meta title="Atoms/Skip link/Overview" />
 
 # Skip link
 
@@ -13,12 +13,7 @@ To see the link in the example here, you need to give the link focus, just like 
 If you try this example using a screenreader, move the screenreader focus to the skip link. The link text will be read out but the link itself may not become visible (that requires keyboard focus). You can follow the link in the normal way provided by your screenreader software; when you do so, the text in the main content area will be read out loud.
 
 <Canvas>
-  <Story inline={false} name="a-skip-link">
-    {`
-      <a href="#main" class="a-skip-link">Skip to content</a>
-      <div id="main">Your main content here, after some other content that gets repeated on every page (navigation etc.)</div>
-    `}
-  </Story>
+  <Story inline={false} id="atoms-skip-link--base" />
 </Canvas>
 
 ## Customization

--- a/scss/bitstyles/atoms/skip-link/skip-link.stories.mdx
+++ b/scss/bitstyles/atoms/skip-link/skip-link.stories.mdx
@@ -23,7 +23,7 @@ If you try this example using a screenreader, move the screenreader focus to the
 
 ## Customization
 
-The default colors are high contrast and clearly readable. If you change them, please check the contrast ratio between your foreground and background colors is high. This component is not intended to fit into a design, but to be highly visible and readable.
+The default colors are high contrast and clearly readable. If you change them, please check the contrast ratio between your foreground and background colors is high. This component is not intended to fit into a design, but to be highly visible and readable. Note that you can also configure the hover state.
 
 ```scss
 @use '~bitstyles/scss/bitstyles/atoms/skip-link' with (
@@ -33,6 +33,8 @@ The default colors are high contrast and clearly readable. If you change them, p
   $border: var(design-token.get('size', 's6')) var(
       design-token.get('color', 'grayscale', 'dark-1')
     )
-    solid
+    solid,
+  $background-hover: var(design-token.get('color', 'grayscale', 'dark-1')),
+  $color-hover: var(design-token.get('color', 'grayscale', 'white'))
 );
 ```

--- a/scss/bitstyles/base/anchor/Link.js
+++ b/scss/bitstyles/base/anchor/Link.js
@@ -5,6 +5,7 @@ export default ({
   ariaDisabled = false,
   element = 'a',
   href = '/some-url',
+  classname = [],
 }) => {
   const link = document.createElement(element);
   link.innerHTML = children || generateLabel(ariaDisabled);
@@ -13,6 +14,9 @@ export default ({
     link.type = 'button';
     link.classList.add('a-link');
   }
+  classname.forEach((cls) => {
+    link.classList.add(cls);
+  });
   if (ariaDisabled) link.setAttribute('aria-disabled', ariaDisabled);
   return link;
 };

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -1999,9 +1999,11 @@ table {
   text-decoration: underline;
 }
 .bs-at-skip-link {
+  border-radius: var(--bscpn-size-s4);
   font-weight: var(--bscpn-font-weight-medium);
   left: 50%;
-  padding: var(--bscpn-size-s1);
+  outline-offset: 0;
+  padding: var(--bscpn-size-m) var(--bscpn-size-l2);
   position: absolute;
   top: -100%;
   transform: translateX(-50%);
@@ -2009,14 +2011,24 @@ table {
 }
 .bs-at-skip-link,
 .bs-at-skip-link:focus,
-.bs-at-skip-link:hover,
 .bs-at-skip-link:visited {
   background: var(--bscpn-color-grayscale-white);
-  border: var(--bscpn-size-s6) var(--bscpn-color-grayscale-dark-1) solid;
+  border: var(--bscpn-size-s6) var(--bscpn-color-grayscale-black) solid;
   color: red;
+  outline-width: 0;
+  text-decoration: none;
+}
+.bs-at-skip-link:hover {
+  background: var(--bscpn-color-grayscale-black);
+  color: var(--bscpn-color-grayscale-white);
 }
 .bs-at-skip-link:focus {
-  top: 0;
+  top: var(--bscpn-size-s4);
+}
+.bs-at-skip-link:focus-visible {
+  outline: var(--bscpn-color-brand-2) solid
+    calc(var(--bscpn-size-s7) + var(--bscpn-size-s7) / 2);
+  outline-offset: var(--bscpn-size-s7);
 }
 .bs-at-topbar {
   left: 0;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -2003,7 +2003,8 @@ table {
 }
 .bs-at-skip-link {
   border-radius: var(--bscpn-size-s4);
-  font-weight: var(--bscpn-font-weight-medium);
+  font-size: var(--bscpn-font-size-4);
+  font-weight: var(--bscpn-font-weight-semibold);
   left: 50%;
   outline-offset: 0;
   padding: var(--bscpn-size-m) var(--bscpn-size-l2);
@@ -2016,7 +2017,7 @@ table {
 .bs-at-skip-link:focus,
 .bs-at-skip-link:visited {
   background: var(--bscpn-color-grayscale-white);
-  border: var(--bscpn-size-s6) var(--bscpn-color-grayscale-black) solid;
+  border: var(--bscpn-size-s6) var(--bscpn-color-grayscale-dark-4) solid;
   box-shadow: var(--bscpn-shadow-brand-2-box);
   color: red;
   outline-width: 0;

--- a/test/scss/fixtures/bitstyles-overrides.css
+++ b/test/scss/fixtures/bitstyles-overrides.css
@@ -99,6 +99,9 @@
   --bscpn-shadow-brand-1-drop: drop-shadow(red 0 2.5rem 5rem)
     drop-shadow(red 0 5rem 10rem);
   --bscpn-shadow-brand-1-box: 0 2.5rem 5rem red, 0 5rem 10rem red;
+  --bscpn-shadow-brand-2-drop: drop-shadow(#00f 0 2.5rem 5rem)
+    drop-shadow(#00f 0 5rem 10rem);
+  --bscpn-shadow-brand-2-box: 0 2.5rem 5rem #00f, 0 5rem 10rem #00f;
 }
 :root {
   --bscpn-font-size-1: 0.75rem;
@@ -2014,6 +2017,7 @@ table {
 .bs-at-skip-link:visited {
   background: var(--bscpn-color-grayscale-white);
   border: var(--bscpn-size-s6) var(--bscpn-color-grayscale-black) solid;
+  box-shadow: var(--bscpn-shadow-brand-2-box);
   color: red;
   outline-width: 0;
   text-decoration: none;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2430,9 +2430,11 @@ table {
   text-decoration: underline;
 }
 .a-skip-link {
+  border-radius: var(--bs-size-s4);
   font-weight: var(--bs-font-weight-medium);
   left: 50%;
-  padding: var(--bs-size-s1);
+  outline-offset: 0;
+  padding: var(--bs-size-m) var(--bs-size-l2);
   position: absolute;
   top: -100%;
   transform: translateX(-50%);
@@ -2440,14 +2442,24 @@ table {
 }
 .a-skip-link,
 .a-skip-link:focus,
-.a-skip-link:hover,
 .a-skip-link:visited {
   background: var(--bs-color-grayscale-white);
-  border: var(--bs-size-s6) var(--bs-color-grayscale-dark-1) solid;
-  color: var(--bs-color-grayscale-dark-1);
+  border: var(--bs-size-s6) var(--bs-color-grayscale-black) solid;
+  color: var(--bs-color-grayscale-black);
+  outline-width: 0;
+  text-decoration: none;
+}
+.a-skip-link:hover {
+  background: var(--bs-color-grayscale-black);
+  color: var(--bs-color-grayscale-white);
 }
 .a-skip-link:focus {
-  top: 0;
+  top: var(--bs-size-s4);
+}
+.a-skip-link:focus-visible {
+  outline: var(--bs-color-brand-2) solid
+    calc(var(--bs-size-s7) + var(--bs-size-s7) / 2);
+  outline-offset: var(--bs-size-s7);
 }
 .a-topbar {
   left: 0;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2445,6 +2445,7 @@ table {
 .a-skip-link:visited {
   background: var(--bs-color-grayscale-white);
   border: var(--bs-size-s6) var(--bs-color-grayscale-black) solid;
+  box-shadow: var(--bs-shadow-brand-2-box);
   color: var(--bs-color-grayscale-black);
   outline-width: 0;
   text-decoration: none;

--- a/test/scss/fixtures/bitstyles.css
+++ b/test/scss/fixtures/bitstyles.css
@@ -2431,7 +2431,8 @@ table {
 }
 .a-skip-link {
   border-radius: var(--bs-size-s4);
-  font-weight: var(--bs-font-weight-medium);
+  font-size: var(--bs-font-size-4);
+  font-weight: var(--bs-font-weight-semibold);
   left: 50%;
   outline-offset: 0;
   padding: var(--bs-size-m) var(--bs-size-l2);
@@ -2444,9 +2445,9 @@ table {
 .a-skip-link:focus,
 .a-skip-link:visited {
   background: var(--bs-color-grayscale-white);
-  border: var(--bs-size-s6) var(--bs-color-grayscale-black) solid;
+  border: var(--bs-size-s6) var(--bs-color-grayscale-dark-4) solid;
   box-shadow: var(--bs-shadow-brand-2-box);
-  color: var(--bs-color-grayscale-black);
+  color: var(--bs-color-grayscale-dark-4);
   outline-width: 0;
   text-decoration: none;
 }

--- a/test/scss/test-use-all.scss
+++ b/test/scss/test-use-all.scss
@@ -64,6 +64,10 @@
     'brand-1': (
       ('color': #f00, 'offset': 2.5rem, 'blur-radius': 5rem),
       ('color': #f00, 'offset': 5rem, 'blur-radius': 10rem),
+    ),
+    'brand-2': (
+      ('color': #00f, 'offset': 2.5rem, 'blur-radius': 5rem),
+      ('color': #00f, 'offset': 5rem, 'blur-radius': 10rem),
     )
   ),
   $themes-themes: (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -85,7 +85,7 @@
     'brand-2': (
       ('color': #00f, 'offset': 2.5rem, 'blur-radius': 5rem),
       ('color': #00f, 'offset': 5rem, 'blur-radius': 10rem),
-    )
+    ),
   )
 );
 @use '../../scss/bitstyles/design-tokens/typography' with (

--- a/test/scss/test-use-each.scss
+++ b/test/scss/test-use-each.scss
@@ -82,6 +82,10 @@
       ('color': #f00, 'offset': 2.5rem, 'blur-radius': 5rem),
       ('color': #f00, 'offset': 5rem, 'blur-radius': 10rem),
     ),
+    'brand-2': (
+      ('color': #00f, 'offset': 2.5rem, 'blur-radius': 5rem),
+      ('color': #00f, 'offset': 5rem, 'blur-radius': 10rem),
+    )
   )
 );
 @use '../../scss/bitstyles/design-tokens/typography' with (

--- a/test/scss/test-use-layers.scss
+++ b/test/scss/test-use-layers.scss
@@ -66,6 +66,10 @@
     'brand-1': (
       ('color': #f00, 'offset': 2.5rem, 'blur-radius': 5rem),
       ('color': #f00, 'offset': 5rem, 'blur-radius': 10rem),
+    ),
+    'brand-2': (
+      ('color': #00f, 'offset': 2.5rem, 'blur-radius': 5rem),
+      ('color': #00f, 'offset': 5rem, 'blur-radius': 10rem),
     )
   ),
   $typography-webfont-family-name: 'FakeFont',


### PR DESCRIPTION
Fixes #764 

## Changes

- New styles for the skip link
- Component now has a hover states, so that the component still indicates their affordance to those who mix use of keyboard and pointer

## 📸 Looks like

<img width="1293" alt="Screenshot 2023-05-22 at 13 42 25" src="https://github.com/bitcrowd/bitstyles/assets/2479422/e0383051-0bd8-4bb4-9108-3d88feb1472b">

## How to QA

### 👀 Visual changes

- `git fetch`
- `git checkout feature/764-update-skip-link`
- `yarn`
- `yarn storybook`
- navigate to atoms/skip-link component

Check:

- [ ] The appearance matches the design in Zeplin
- [ ] The Zeplin component is correctly linked in storybook
- [ ] The documentation for this component is correct, understandable, and up-to-date.

### 👾 Code changes

Check:

- [ ] The documentation for this component is correct, understandable, and up-to-date.
- [ ] The component makes good use of CSS custom properties to simplify creating variants (or doesn’t have variants).
- [ ] Everything that should be a variable, is.

## Preflight checks

- [x] Storybook documentation has been updated
- [x] Fixtures in [`test/scss/`](../test/scss/) have been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
