### PR TITLE
Task/internal 26 create a badge with trailing label component 785

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Badge with Label, added an example showing a text label rendered next to a badge component, to the badge docs.
+
 ## [[6.0.0]](https://github.com/bitcrowd/bitstyles/releases/tag/v6.0.0) - 2023-06-08
 
 ### Changed

--- a/scss/bitstyles/atoms/badge/Badge.stories.js
+++ b/scss/bitstyles/atoms/badge/Badge.stories.js
@@ -269,3 +269,20 @@ PositiveButtonSmall.args = {
   onClick: dummyOnClick,
   sizeVariant: ['small'],
 };
+
+const TemplateBadgeWithLabel = (args) => {
+  const fragment = document.createElement('div');
+  const mainContent = document.createElement('span');
+  mainContent.setAttribute('id', 'main');
+  mainContent.classList.add('u-margin-m-left');
+  mainContent.innerHTML = 'Trailing label';
+  fragment.append(Badge(args));
+  fragment.append(mainContent);
+  return fragment;
+};
+
+export const BadgeWithLabel = TemplateBadgeWithLabel.bind({});
+BadgeWithLabel.args = {
+  theme: 'default',
+  sizeVariant: ['small'],
+};

--- a/scss/bitstyles/atoms/badge/Badge.stories.js
+++ b/scss/bitstyles/atoms/badge/Badge.stories.js
@@ -271,18 +271,21 @@ PositiveButtonSmall.args = {
 };
 
 const TemplateBadgeWithLabel = (args) => {
-  const fragment = document.createElement('div');
-  const mainContent = document.createElement('span');
-  mainContent.setAttribute('id', 'main');
-  mainContent.classList.add('u-margin-m-left');
-  mainContent.innerHTML = 'Trailing label';
-  fragment.append(Badge(args));
-  fragment.append(mainContent);
-  return fragment;
+  const wrapper = document.createElement('div');
+  const trailingLabel = document.createElement('span');
+  trailingLabel.classList.add('u-margin-m-left');
+  trailingLabel.innerHTML = 'Trailing label';
+  wrapper.append(Badge(args));
+  wrapper.append(trailingLabel);
+  return wrapper;
 };
 
 export const BadgeWithLabel = TemplateBadgeWithLabel.bind({});
 BadgeWithLabel.args = {
   theme: 'default',
   sizeVariant: ['small'],
+};
+BadgeWithLabel.parameters = {
+  zeplinLink:
+    'https://app.zeplin.io/styleguide/63079b90d0bf4a646c46c227/components?coid=640ef6a6805d9020e491d493',
 };

--- a/scss/bitstyles/atoms/skip-link/skip-link.stories.js
+++ b/scss/bitstyles/atoms/skip-link/skip-link.stories.js
@@ -6,7 +6,7 @@ export default {
 };
 
 const Template = (args) => {
-  const fragment = new DocumentFragment();
+  const fragment = document.createElement('div');
   const mainContent = document.createElement('div');
   mainContent.setAttribute('id', 'main');
   mainContent.innerHTML =

--- a/scss/bitstyles/atoms/skip-link/skip-link.stories.js
+++ b/scss/bitstyles/atoms/skip-link/skip-link.stories.js
@@ -6,14 +6,14 @@ export default {
 };
 
 const Template = (args) => {
-  const fragment = document.createElement('div');
+  const wrapper = document.createElement('div');
   const mainContent = document.createElement('div');
   mainContent.setAttribute('id', 'main');
   mainContent.innerHTML =
     'Your main content here, after some other content that gets repeated on every page (navigation etc.)';
-  fragment.append(Link(args));
-  fragment.append(mainContent);
-  return fragment;
+  wrapper.append(Link(args));
+  wrapper.append(mainContent);
+  return wrapper;
 };
 
 // ***** Default size, each shape & color ****************** //


### PR DESCRIPTION
## Changes

- Add a `badge` with label option to the badge atom on storybook
- Fix `skip-link` doc.

## 📸 Looks like


<img width="1121" alt="Screenshot 2023-07-20 at 14 54 20" src="https://github.com/bitcrowd/bitstyles/assets/17965508/62024e65-c8f7-40a9-9d11-89cf25b289b0">


### 👀 Visual changes

_Insert a detailed list explaining exactly how to QA your changes from a designer’s PoV_

- `git fetch`
- `git checkout <pr-branch-name>`
- `yarn`
- `yarn storybook`
- navigate to `Badge` - `Badge With Label`

Check:

- [x] The appearance matches the design in Zeplin
- [x] The Zeplin component is correctly linked in storybook
- [x] The documentation for this component is correct, understandable, and up-to-date.

### 👾 Code changes

Check:

- [x] The documentation for this component is correct, understandable, and up-to-date.
- [x] The component makes good use of CSS custom properties to simplify creating variants (or doesn’t have variants).
- [x] Everything that should be a variable, is.

## Preflight checks

_PR author to check, and delete if not applicable_

- [x] Storybook documentation has been updated
- [x] Your changes have been added to the `unreleased` section of [CHANGELOG.md](../CHANGELOG.md)
