### PR TITLE
Driveby - Fix CI node version.

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -7,6 +7,8 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: '18.16.1'
 
       - name: Lint 👀
         run: |

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -6,6 +6,7 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
 
       - name: Lint 👀
         run: |


### PR DESCRIPTION
New changes on the github actions workflow. We now need to specify the node version. [See](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#create-an-example-workflow)
